### PR TITLE
Chore: Fix reference to example project and update Slack card

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,4 +51,4 @@ The APIs for adding new components (inputs, outputs, processors, caches, etc) ha
 
 The core components within Bento (inputs, processors, conditions and outputs) are all easily pluggable. If you are interested in adding new components please raise a ticket and we can discuss whether it's a good fit for the project.
 
-If not then it's still easy to build your own version of Bento with custom components. For guidance take a look at [this example repo](https://github.com/warpstreamlabs/bento-plugin-example).
+If not then it's still easy to build your own version of Bento with custom components. For guidance take a look at [this example repo](https://github.com/benthosdev/benthos-plugin-example).

--- a/website/src/pages/community.tsx
+++ b/website/src/pages/community.tsx
@@ -58,7 +58,7 @@ function Community() {
                   <i className={classnames(styles.icon, styles.slack)}></i>
                 </div>
                 <div className="card__body">
-                  <p>Join us on the &#35;bentho channel in the Gophers slack</p>
+                  <p>Join us on the &#35;bento channel in the WarpStream Labs Community slack</p>
                 </div>
                 <div className="card__footer">
                   <Link to="https://console.warpstream.com/socials/slack" className="button button--outline button--primary button--block">Open</Link>


### PR DESCRIPTION
Some small housekeeping for the repo:
- Point to original plugin example in `benthosdev` in lieu of a forked version in `warpstreamlabs` (Related to #21)
- Change copy of social card to correctly reference `#bento` channel in WarpStream's Community Slack server.