### PR TITLE
Sync upstream changes into bento

### DIFF
--- a/CHANGELOG.old.md
+++ b/CHANGELOG.old.md
@@ -1,9 +1,14 @@
 Changelog
 =========
 
-This file contains all the changes made to this project before it was forked to the Bento repository.
-
 All notable changes to this project will be documented in this file.
+
+## 4.28.0 - TBD
+
+### Added
+
+- Go API: Variadic options added to the public `service.RunCLI` function for customising CLI behaviour.
+- Go API: New schema APIs added with linting, generation and marshalling capabilities.
 
 ## 4.27.0 - 2024-04-23
 
@@ -64,7 +69,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed a regression in v4.25.0 where [template based components](https://warpstreamlabs.github.io/bento/docs/configuration/templating) were not parsing correctly from configs.
+- Fixed a regression in v4.25.0 where [template based components](https://www.benthos.dev/docs/configuration/templating) were not parsing correctly from configs.
 
 ## 4.25.0 - 2024-03-01
 
@@ -72,7 +77,7 @@ All notable changes to this project will be documented in this file.
 
 - Field `address_cache` added to the `socket_server` input.
 - Field `read_header` added to the `amqp_1` input.
-- All inputs with a `codec` field now support a new field `scanner` to replace it. Scanners are more powerful as they are configured in a structured way similar to other component types rather than via a single string field, for more information [check out the scanners page](https://warpstreamlabs.github.io/bento/docs/components/scanners/about).
+- All inputs with a `codec` field now support a new field `scanner` to replace it. Scanners are more powerful as they are configured in a structured way similar to other component types rather than via a single string field, for more information [check out the scanners page](https://www.benthos.dev/docs/components/scanners/about).
 - New `diff` and `patch` Bloblang methods.
 - New `processors` processor.
 - Field `read_header` added to the `amqp_1` input.
@@ -267,7 +272,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Restore message ordering support to `gcp_pubsub` output. This issue was introduced in 4.16.0 as a result of [#1836](https://github.com/warpstreamlabs/bento/pull/1836).
+- Restore message ordering support to `gcp_pubsub` output. This issue was introduced in 4.16.0 as a result of [#1836](https://github.com/benthosdev/benthos/pull/1836).
 - Specifying structured metadata values (non-strings) in unit test definitions should no longer cause linting errors.
 
 ### Changed
@@ -284,7 +289,7 @@ All notable changes to this project will be documented in this file.
 - Field `nak_delay` added to the `nats` input.
 - New `splunk_hec` output.
 - Plugin API: New `NewMetadataExcludeFilterField` function and accompanying `FieldMetadataExcludeFilter` method added.
-- The `pulsar` input and output are now included in the main distribution of Bento again.
+- The `pulsar` input and output are now included in the main distribution of Benthos again.
 - The `gcp_pubsub` input now adds the metadata field `gcp_pubsub_delivery_attempt` to messages when dead lettering is enabled.
 - The `aws_s3` input now adds `s3_version_id` metadata to versioned messages.
 - All compress/decompress components (codecs, bloblang methods, processors) now support `pgzip`.
@@ -307,8 +312,8 @@ All notable changes to this project will be documented in this file.
 - The `kafka_franz` input now supports explicit partitions in the field `topics`.
 - The `kafka_franz` input now supports batching.
 - New `metadata` Bloblang function for batch-aware structured metadata queries.
-- Go API: Running the Bento CLI with a context set with a deadline now triggers graceful termination before the deadline is reached.
-- Go API: New `public/service/servicetest` package added for functions useful for testing custom Bento builds.
+- Go API: Running the Benthos CLI with a context set with a deadline now triggers graceful termination before the deadline is reached.
+- Go API: New `public/service/servicetest` package added for functions useful for testing custom Benthos builds.
 - New `lru` and `ttlru` in-memory caches.
 
 ### Fixed
@@ -322,7 +327,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - The `-e/--env-file` cli flag can now be specified multiple times.
-- New `studio pull` cli subcommand for running [Bento Studio](https://studio.benthos.dev) session deployments.
+- New `studio pull` cli subcommand for running [Benthos Studio](https://studio.benthos.dev) session deployments.
 - Metadata field `kafka_tombstone_message` added to the `kafka` and `kafka_franz` inputs.
 - Method `SetEnvVarLookupFunc` added to the stream builder API.
 - The `discord` input and output now use the official chat client API and no longer rely on poll-based HTTP requests, this should result in more efficient and less erroneous behaviour.
@@ -342,10 +347,10 @@ All notable changes to this project will be documented in this file.
 - Prevented a panic caused when using the `encrypt_aes` and `decrypt_aes` Bloblang methods with a mismatched key/iv lengths.
 - The `snowpipe` field of the `snowflake_put` output can now be omitted from the config without raising an error.
 - Batch-aware processors such as `mapping` and `mutation` should now report correct error metrics.
-- Running `bento blobl server` should no longer panic when a mapping with variable read/writes is executed in parallel.
+- Running `benthos blobl server` should no longer panic when a mapping with variable read/writes is executed in parallel.
 - Speculative fix for the `cloudwatch` metrics exporter rejecting metrics due to `minimum field size of 1, PutMetricDataInput.MetricData[0].Dimensions[0].Value`.
 - The `snowflake_put` output now prevents silent failures under certain conditions. Details [here](https://github.com/snowflakedb/gosnowflake/issues/701).
-- Reduced the amount of pre-compilation of Bloblang based linting rules for documentation fields, this should dramatically improve the start up time of Bento (~1s down to ~200ms).
+- Reduced the amount of pre-compilation of Bloblang based linting rules for documentation fields, this should dramatically improve the start up time of Benthos (~1s down to ~200ms).
 - Environment variable interpolations with an empty fallback (`${FOO:}`) are now valid.
 - Fixed an issue where the `mongodb` output wasn't using bulk send requests according to batching policies.
 - The `amqp_1` input now falls back to accessing `Message.Value` when the data is empty.
@@ -409,7 +414,7 @@ All notable changes to this project will be documented in this file.
 - Fixed an issue where messages caught in a retry loop from inputs that do not support nacks (`generate`, `kafka`, `file`, etc) could be retried in their post-mutation form from the `switch` output rather than the original copy of the message.
 - The `sqlite` buffer should no longer print `Failed to ack buffer message` logs during graceful termination.
 - The default value of the `conn_max_idle` field has been changed from 0 to 2 for all `sql_*` components in accordance
-to the [`database/sql` docs](https://pkg.go.dev/database/sql#DB.SetMaxIdleConns).
+  to the [`database/sql` docs](https://pkg.go.dev/database/sql#DB.SetMaxIdleConns).
 - The `parse_csv` bloblang method with `parse_header_row` set to `false` no longer produces rows that are of an `unknown` type.
 - Fixed a bug where the `oracle` driver for the `sql_*` components was returning timestamps which were getting marshalled into an empty JSON object instead of a string.
 - The `aws_sqs` input no longer backs off on subsequent empty requests when long polling is enabled.
@@ -433,7 +438,7 @@ to the [`database/sql` docs](https://pkg.go.dev/database/sql#DB.SetMaxIdleConns)
 - TLS client certs now support both PKCS#1 and PKCS#8 encrypted keys.
 - New `redis_script` processor.
 - New `wasm` processor.
-- Fields marked as secrets will no longer be printed with `bento echo` or debug HTTP endpoints.
+- Fields marked as secrets will no longer be printed with `benthos echo` or debug HTTP endpoints.
 - Add `no_indent` parameter to the `format_json` bloblang method.
 - New `format_xml` bloblang method.
 - New `batched` higher level input type.
@@ -682,7 +687,7 @@ to the [`database/sql` docs](https://pkg.go.dev/database/sql#DB.SetMaxIdleConns)
 
 ## 4.0.0 - 2022-04-20
 
-This is a major version release, for more information and guidance on how to migrate please refer to [https://warpstreamlabs.github.io/bento/docs/guides/migration/v4](https://warpstreamlabs.github.io/bento/docs/guides/migration/v4).
+This is a major version release, for more information and guidance on how to migrate please refer to [https://benthos.dev/docs/guides/migration/v4](https://www.benthos.dev/docs/guides/migration/v4).
 
 ### Added
 
@@ -704,12 +709,12 @@ This is a major version release, for more information and guidance on how to mig
 
 - The `sftp` output no longer opens files in both read and write mode.
 - The `aws_sqs` input with `reset_visibility` set to `false` will no longer reset timeouts on pending messages during gracefully shutdown.
-- The `schema_registry_decode` processor now handles AVRO logical types correctly. Details in [#1198](https://github.com/warpstreamlabs/bento/pull/1198) and [#1161](https://github.com/warpstreamlabs/bento/issues/1161) and also in https://github.com/linkedin/goavro/issues/242.
+- The `schema_registry_decode` processor now handles AVRO logical types correctly. Details in [#1198](https://github.com/benthosdev/benthos/pull/1198) and [#1161](https://github.com/benthosdev/benthos/issues/1161) and also in https://github.com/linkedin/goavro/issues/242.
 
 ### Changed
 
 - All components, features and configuration fields that were marked as deprecated have been removed.
-- The `pulsar` input and output are no longer included in the default Bento builds.
+- The `pulsar` input and output are no longer included in the default Benthos builds.
 - The field `pipeline.threads` field now defaults to `-1`, which automatically matches the host machine CPU count.
 - Old style interpolation functions (`${!json:foo,1}`) are removed in favour of the newer Bloblang syntax (`${! json("foo") }`).
 - The Bloblang functions `meta`, `root_meta`, `error` and `env` now return `null` when the target value does not exist.
@@ -721,8 +726,8 @@ This is a major version release, for more information and guidance on how to mig
 - Outputs that traditionally wrote empty newlines at the end of batches with >1 message when using the `lines` codec (`socket`, `stdout`, `file`, `sftp`) no longer do this by default.
 - The `switch` output field `retry_until_success` now defaults to `false`.
 - All AWS components now have a default `region` field that is empty, allowing environment variables or profile values to be used by default.
-- Serverless distributions of Bento (AWS lambda, etc) have had the default output config changed to reject messages when the processing fails, this should make it easier to handle errors from invocation.
-- The standard metrics emitted by Bento have been largely simplified and improved, for more information [check out the metrics page](https://warpstreamlabs.github.io/bento/docs/components/metrics/about).
+- Serverless distributions of Benthos (AWS lambda, etc) have had the default output config changed to reject messages when the processing fails, this should make it easier to handle errors from invocation.
+- The standard metrics emitted by Benthos have been largely simplified and improved, for more information [check out the metrics page](https://www.benthos.dev/docs/components/metrics/about).
 - The default metrics type is now `prometheus`.
 - The `http_server` metrics type has been renamed to `json_api`.
 - The `stdout` metrics type has been renamed to `logger`.
@@ -733,9 +738,9 @@ This is a major version release, for more information and guidance on how to mig
 - The `dedupe` processor now acts upon individual messages by default, and the `hash` field has been removed.
 - The `log` processor now executes for each individual message of a batch.
 - The `sleep` processor now executes for each individual message of a batch.
-- The `bento test` subcommand no longer walks when targetting a directory, instead use triple-dot syntax (`./dir/...`) or wildcard patterns.
-- Go API: Module name has changed to `github.com/warpstreamlabs/bento/v4`.
-- Go API: All packages within the `lib` directory have been removed in favour of the newer [APIs within `public`](https://pkg.go.dev/github.com/warpstreamlabs/bento/v4/public).
+- The `benthos test` subcommand no longer walks when targetting a directory, instead use triple-dot syntax (`./dir/...`) or wildcard patterns.
+- Go API: Module name has changed to `github.com/benthosdev/benthos/v4`.
+- Go API: All packages within the `lib` directory have been removed in favour of the newer [APIs within `public`](https://pkg.go.dev/github.com/benthosdev/benthos/v4/public).
 - Go API: Distributed tracing is now via the Open Telemetry client library.
 
 ## 3.65.0 - 2022-03-07
@@ -813,11 +818,11 @@ This is a major version release, for more information and guidance on how to mig
 - New Bloblang method `format_json`.
 - Field `collection` in `mongodb` processor and output now supports interpolation functions.
 - Field `output_raw` added to the `jq` processor.
-- The lambda distribution now supports a `BENTO_CONFIG_PATH` environment variable for specifying a custom config path.
+- The lambda distribution now supports a `BENTHOS_CONFIG_PATH` environment variable for specifying a custom config path.
 - Field `metadata` added to `http` and `http_client` components.
 - Field `ordering_key` added to the `gcp_pubsub` output.
 - A suite of new experimental `geoip_` methods have been added.
-- Added flag `--deprecated` to the `bento lint` subcommand for detecting deprecated fields.
+- Added flag `--deprecated` to the `benthos lint` subcommand for detecting deprecated fields.
 
 ### Changed
 
@@ -939,7 +944,7 @@ This is a major version release, for more information and guidance on how to mig
 
 ### Fixed
 
-- The `test` subcommand now expands resource glob patterns (`bento -r "./foo/*.yaml" test ./...`).
+- The `test` subcommand now expands resource glob patterns (`benthos -r "./foo/*.yaml" test ./...`).
 - The Bloblang equality operator now returns `false` when comparing non-null values with `null` rather than a mismatched types error.
 
 ## 3.55.0 - 2021-09-08
@@ -1068,9 +1073,9 @@ This is a major version release, for more information and guidance on how to mig
 - New experimental `discord` input and output.
 - The `http_server` input now adds a metadata field `http_server_verb`.
 - New Bloblang methods `parse_yaml` and `format_yaml`.
-- CLI flag `env-file` added to Bento for parsing dotenv files.
+- CLI flag `env-file` added to Benthos for parsing dotenv files.
 - New `mssql` SQL driver for the `sql` processor and output.
-- New POST endpoint `/resources/{type}/{id}` added to Bento streams mode for dynamically mutating resource configs.
+- New POST endpoint `/resources/{type}/{id}` added to Benthos streams mode for dynamically mutating resource configs.
 
 ### Changed
 
@@ -1145,10 +1150,10 @@ This is a major version release, for more information and guidance on how to mig
 ### Changed
 
 - The following beta components have been promoted to stable:
-  + `ristretto` cache
-  + `csv` and `generate` inputs
-  + `reject` output
-  + `branch`, `jq` and `workflow` processors
+    + `ristretto` cache
+    + `csv` and `generate` inputs
+    + `reject` output
+    + `branch`, `jq` and `workflow` processors
 
 ## 3.44.1 - 2021-04-15
 
@@ -1189,7 +1194,7 @@ This is a major version release, for more information and guidance on how to mig
 - New output level `metadata.exclude_prefixes` config field for restricting metadata values sent to the following outputs: `kafka`, `aws_s3`, `amqp_0_9`, `redis_streams`, `aws_sqs`, `gcp_pubsub`.
 - All NATS components now have `tls` support.
 - Bloblang now supports context capture in query lambdas.
-- New subcommand `bento blobl server` that hosts a Bloblang editor web application.
+- New subcommand `benthos blobl server` that hosts a Bloblang editor web application.
 - New (experimental) `mongodb` output, cache and processor.
 - New (experimental) `gcp_cloud_storage` input and output.
 - Field `batch_as_multipart` added to the `http_client` output.
@@ -1207,7 +1212,7 @@ This is a major version release, for more information and guidance on how to mig
 
 ### Changed
 
-- Go API: Component implementations now require explicit import from `./public/components/all` in order to be invokable. This should be done automatically at all plugin and custom build entry points. If, however, you notice that your builds have begun complaining that known components do not exist then you will need to explicitly import the package with `_ "github.com/warpstreamlabs/bento/v3/public/components/all"`, if this is the case then please report it as an issue so that it can be dealt with.
+- Go API: Component implementations now require explicit import from `./public/components/all` in order to be invokable. This should be done automatically at all plugin and custom build entry points. If, however, you notice that your builds have begun complaining that known components do not exist then you will need to explicitly import the package with `_ "github.com/Jeffail/benthos/v3/public/components/all"`, if this is the case then please report it as an issue so that it can be dealt with.
 
 ## 3.42.1 - 2021-03-26
 
@@ -1239,7 +1244,7 @@ This is a major version release, for more information and guidance on how to mig
 
 ### New
 
-- New `http` fields `cert_file` and `key_file`, which when specified enforce HTTPS for the general Bento server.
+- New `http` fields `cert_file` and `key_file`, which when specified enforce HTTPS for the general Benthos server.
 - Bloblang method `catch` now supports `deleted()` as an argument.
 
 ### Fixed
@@ -1252,7 +1257,7 @@ This is a major version release, for more information and guidance on how to mig
 ### New
 
 - Experimental `sharded_join` fields added to the `sequence` input.
-- Added a new API for writing Bloblang plugins in Go at [`./public/bloblang`](https://pkg.go.dev/github.com/warpstreamlabs/bento/v3/public/bloblang).
+- Added a new API for writing Bloblang plugins in Go at [`./public/bloblang`](https://pkg.go.dev/github.com/Jeffail/benthos/v3/public/bloblang).
 - Field `fields_mapping` added to the `log` processor.
 
 ### Fixed
@@ -1446,7 +1451,7 @@ This is a major version release, for more information and guidance on how to mig
 
   This change means that string coercion on large numbers (e.g. `root.foo = this.large_int.string()`) should now preserve the original form. However, if you are using plugins that interact with JSON message payloads you must ensure that your plugins are able to process the [`json.Number`](https://golang.org/pkg/encoding/json/#Number) type.
 
-  This change should otherwise not alter the behaviour of your configs, but if you notice odd side effects you can disable this feature by setting the environment variable `BENTO_USE_NUMBER` to `false` (`BENTO_USE_NUMBER=false bento -c ./config.yaml`). Please [raise an issue](https://github.com/warpstreamlabs/bento/issues/new) if this is the case so that it can be looked into.
+  This change should otherwise not alter the behaviour of your configs, but if you notice odd side effects you can disable this feature by setting the environment variable `BENTHOS_USE_NUMBER` to `false` (`BENTHOS_USE_NUMBER=false benthos -c ./config.yaml`). Please [raise an issue](https://github.com/Jeffail/benthos/issues/new) if this is the case so that it can be looked into.
 
 ## 3.31.0 - 2020-10-15
 
@@ -1761,8 +1766,8 @@ This is a major version release, for more information and guidance on how to mig
 
 ### Changed
 
-- Bento now runs in strict mode, but this can be disabled with `--chilled`.
-- The Bento CLI has been revamped, the old flags are still supported but are deprecated.
+- Benthos now runs in strict mode, but this can be disabled with `--chilled`.
+- The Benthos CLI has been revamped, the old flags are still supported but are deprecated.
 - The `http_server` input now accepts requests without a content-type header.
 
 ### Fixed
@@ -1830,36 +1835,36 @@ This is a major version release, for more information and guidance on how to mig
 ### Added
 
 - New field `max_in_flight` added to the following outputs:
-  + `amqp_0_9`
-  + `cache`
-  + `dynamodb`
-  + `elasticsearch`
-  + `gcp_pubsub`
-  + `hdfs`
-  + `http_client`
-  + `kafka`
-  + `kinesis`
-  + `kinesis_firehose`
-  + `mqtt`
-  + `nanomsg`
-  + `nats`
-  + `nats_stream`
-  + `nsq`
-  + `redis_hash`
-  + `redis_list`
-  + `redis_pubsub`
-  + `redis_streams`
-  + `s3`
-  + `sns`
-  + `sqs`
+    + `amqp_0_9`
+    + `cache`
+    + `dynamodb`
+    + `elasticsearch`
+    + `gcp_pubsub`
+    + `hdfs`
+    + `http_client`
+    + `kafka`
+    + `kinesis`
+    + `kinesis_firehose`
+    + `mqtt`
+    + `nanomsg`
+    + `nats`
+    + `nats_stream`
+    + `nsq`
+    + `redis_hash`
+    + `redis_list`
+    + `redis_pubsub`
+    + `redis_streams`
+    + `s3`
+    + `sns`
+    + `sqs`
 - Batching fields added to the following outputs:
-  + `dynamodb`
-  + `elasticsearch`
-  + `http_client`
-  + `kafka`
-  + `kinesis`
-  + `kinesis_firehose`
-  + `sqs`
+    + `dynamodb`
+    + `elasticsearch`
+    + `http_client`
+    + `kafka`
+    + `kinesis`
+    + `kinesis_firehose`
+    + `sqs`
 - More TRACE level logs added throughout the pipeline.
 - Operator `delete` added to `cache` processor.
 - Operator `explode` added to `json` processor.
@@ -1995,7 +2000,7 @@ This is a major version release, for more information and guidance on how to mig
 
 ## 3.0.0 - 2019-09-17
 
-This is a major version release, for more information and guidance on how to migrate please refer to [https://warpstreamlabs.github.io/bento/docs/guides/migration/v3](https://warpstreamlabs.github.io/bento/docs/guides/migration/v3).
+This is a major version release, for more information and guidance on how to migrate please refer to [https://benthos.dev/docs/guides/migration/v3](https://www.benthos.dev/docs/guides/migration/v3).
 
 ### Added
 
@@ -2005,26 +2010,26 @@ This is a major version release, for more information and guidance on how to mig
 
 ### Changed
 
-- Go modules are now fully supported, imports must now include the major version (e.g. `github.com/warpstreamlabs/bento/v3`).
+- Go modules are now fully supported, imports must now include the major version (e.g. `github.com/Jeffail/benthos/v3`).
 - Removed deprecated `mmap_file` buffer.
 - Removed deprecated (and undocumented) metrics paths.
 - Moved field `prefix` from root of `metrics` into relevant child components.
 - Names of `process_dag` stages must now match the regexp `[a-zA-Z0-9_-]+`.
 - Go API: buffer constructors now take a `types.Manager` argument in parity with other components.
 - JSON dot paths within the following components have been updated to allow array-based operations:
-  + `awk` processor
-  + `json` processor
-  + `process_field` processor
-  + `process_map` processor
-  + `check_field` condition
-  + `json_field` function interpolation
-  + `s3` input
-  + `dynamodb` output
+    + `awk` processor
+    + `json` processor
+    + `process_field` processor
+    + `process_map` processor
+    + `check_field` condition
+    + `json_field` function interpolation
+    + `s3` input
+    + `dynamodb` output
 
 ### Fixed
 
 - The `sqs` output no longer attempts to send invalid attributes with payloads from metadata.
-- During graceful shutdown Bento now scales the attempt to propagate acks for sent messages with the overall system shutdown period.
+- During graceful shutdown Benthos now scales the attempt to propagate acks for sent messages with the overall system shutdown period.
 
 ## 2.15.1 - 2019-09-10
 
@@ -2216,7 +2221,7 @@ This is a major version release, for more information and guidance on how to mig
 - Operator `enum` added to `text` condition.
 - Field `result_type` added to `process_field` processor for marshalling results into non-string types.
 - Go API: Plugin APIs now allow nil config constructors.
-- Registering plugins automatically adds plugin documentation flags to the main Bento service.
+- Registering plugins automatically adds plugin documentation flags to the main Benthos service.
 
 ## 2.7.0 - 2019-06-20
 
@@ -2325,7 +2330,7 @@ This is a major version release, for more information and guidance on how to mig
 
 ### Added
 
-- Core service logic has been moved into new package `service`, making it easier to maintain plugin builds that match upstream Bento.
+- Core service logic has been moved into new package `service`, making it easier to maintain plugin builds that match upstream Benthos.
 
 ## 2.1.1 - 2019-05-17
 
@@ -2349,11 +2354,11 @@ This is a major version release, for more information and guidance on how to mig
 
 ### Changed
 
-This is a major version released due to a series of minor breaking changes, you can read the [full migration guide here](https://warpstreamlabs.github.io/bento/docs/guides/migration/v2).
+This is a major version released due to a series of minor breaking changes, you can read the [full migration guide here](https://www.benthos.dev/docs/guides/migration/v2).
 
 #### Configuration
 
-- Bento now attempts to infer the `type` of config sections whenever the field is omitted, for more information please read this overview: [Concise Configuration](https://warpstreamlabs.github.io/bento/docs/configuration/about#concise-configuration).
+- Benthos now attempts to infer the `type` of config sections whenever the field is omitted, for more information please read this overview: [Concise Configuration](https://www.benthos.dev/docs/configuration/about#concise-configuration).
 - Field `unsubscribe_on_close` of the `nats_stream` input is now `false` by default.
 
 #### Service
@@ -2362,7 +2367,7 @@ This is a major version released due to a series of minor breaking changes, you 
 
 #### Go API
 
-- Package `github.com/warpstreamlabs/bento/lib/processor/condition` changed to `github.com/warpstreamlabs/bento/lib/condition`.
+- Package `github.com/Jeffail/benthos/lib/processor/condition` changed to `github.com/Jeffail/benthos/lib/condition`.
 - Interface `types.Cache` now has `types.Closable` embedded.
 - Interface `types.RateLimit` now has `types.Closable` embedded.
 - Add method `GetPlugin` to interface `types.Manager`.
@@ -2416,7 +2421,7 @@ This is a major version released due to a series of minor breaking changes, you 
 
 ### Fixed
 
-- Bento in streams mode no longer tries to load directory `/bento/streams` by default.
+- Benthos in streams mode no longer tries to load directory `/benthos/streams` by default.
 
 ## 1.19.0 - 2019-05-07
 
@@ -2441,7 +2446,7 @@ This is a major version released due to a series of minor breaking changes, you 
 
 ### Fixed
 
-- The `bento-lambda` distribution now correctly returns all message parts in synchronous execution.
+- The `benthos-lambda` distribution now correctly returns all message parts in synchronous execution.
 
 ### Changed
 
@@ -2470,7 +2475,7 @@ This is a major version released due to a series of minor breaking changes, you 
 
 ### Fixed
 
-- Removed potential `bento-lambda` panic on shut down.
+- Removed potential `benthos-lambda` panic on shut down.
 
 ## 1.14.2 - 2019-04-25
 
@@ -2496,7 +2501,7 @@ This is a major version released due to a series of minor breaking changes, you 
 
 ### Added
 
-- New `bento-lambda` distribution for running Bento as a lambda function.
+- New `benthos-lambda` distribution for running Benthos as a lambda function.
 
 ## 1.12.0 - 2019-04-21
 
@@ -2894,8 +2899,8 @@ This is a major version released due to a series of minor breaking changes, you 
 
 ### Added
 
-- Lint errors are logged (level INFO) during normal Bento operation.
-- New `--strict` command flag which causes Bento to abort when linting errors are found in a config file.
+- Lint errors are logged (level INFO) during normal Benthos operation.
+- New `--strict` command flag which causes Benthos to abort when linting errors are found in a config file.
 
 ## 0.38.4 - 2018-11-26
 
@@ -3315,7 +3320,7 @@ This is a major version released due to a series of minor breaking changes, you 
 ### Added
 
 - Ability to create batches via conditions on message payloads in the `batch` processor.
-- New `--examples` flag for generating specific examples from Bento.
+- New `--examples` flag for generating specific examples from Benthos.
 
 ## 0.19.0 - 2018-07-23
 
@@ -3513,8 +3518,8 @@ This is a major version released due to a series of minor breaking changes, you 
 - New `batch` processor for combining payloads up to a number of bytes.
 - New `conditional` processor, allows you to configure a chain of processors to only be run if the payload passes a `condition`.
 - New `--stream` mode features:
-  + POST verb for `/streams` path now supported.
-  + New `--streams-dir` flag for parsing a directory of stream configs.
+    + POST verb for `/streams` path now supported.
+    + New `--streams-dir` flag for parsing a directory of stream configs.
 
 ### Changed
 

--- a/CHANGELOG.old.md
+++ b/CHANGELOG.old.md
@@ -3,7 +3,7 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
-## 4.28.0 - TBD
+## 4.28.0 - 2024-05-29
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ VER_PATCH := $(shell echo $(VER_CUT) | cut -f3 -d.)
 VER_RC    := $(shell echo $(VER_PATCH) | cut -f2 -d-)
 DATE      := $(shell date +"%Y-%m-%dT%H:%M:%SZ")
 
-VER_FLAGS = -X github.com/warpstreamlabs/bento/internal/cli.Version=$(VERSION) \
-	-X github.com/warpstreamlabs/bento/internal/cli.DateBuilt=$(DATE)
+VER_FLAGS = -X main.Version=$(VERSION) -X main.DateBuilt=$(DATE)
 
 LD_FLAGS   ?= -w -s
 GO_FLAGS   ?=

--- a/cmd/bento/main.go
+++ b/cmd/bento/main.go
@@ -9,6 +9,22 @@ import (
 	_ "github.com/warpstreamlabs/bento/public/components/all"
 )
 
+var (
+	// Version version set at compile time.
+	Version string
+	// DateBuilt date built set at compile time.
+	DateBuilt string
+	// BinaryName binary name.
+	BinaryName string = "bento"
+)
+
 func main() {
-	service.RunCLI(context.Background())
+	service.RunCLI(
+		context.Background(),
+		service.CLIOptSetVersion(Version, DateBuilt),
+		service.CLIOptSetBinaryName(BinaryName),
+		service.CLIOptSetProductName("Bento"),
+		service.CLIOptSetDocumentationURL("https://warpstreamlabs.github.io/bento/docs"),
+		service.CLIOptSetShowRunCommand(true),
+	)
 }

--- a/internal/cli/blobl/cli.go
+++ b/internal/cli/blobl/cli.go
@@ -15,6 +15,7 @@ import (
 	"github.com/warpstreamlabs/bento/internal/bloblang/mapping"
 	"github.com/warpstreamlabs/bento/internal/bloblang/parser"
 	"github.com/warpstreamlabs/bento/internal/bloblang/query"
+	"github.com/warpstreamlabs/bento/internal/cli/common"
 	"github.com/warpstreamlabs/bento/internal/filepath/ifs"
 	"github.com/warpstreamlabs/bento/internal/message"
 	"github.com/warpstreamlabs/bento/internal/value"
@@ -23,18 +24,18 @@ import (
 var red = color.New(color.FgRed).SprintFunc()
 
 // CliCommand is a cli.Command definition for running a blobl mapping.
-func CliCommand() *cli.Command {
+func CliCommand(opts *common.CLIOpts) *cli.Command {
 	return &cli.Command{
 		Name:  "blobl",
-		Usage: "Execute a Bloblang mapping on documents consumed via stdin",
-		Description: `
+		Usage: opts.ExecTemplate("Execute a {{.ProductName}} mapping on documents consumed via stdin"),
+		Description: opts.ExecTemplate(`
 Provides a convenient tool for mapping JSON documents over the command line:
 
-  cat documents.jsonl | bento blobl 'foo.bar.map_each(this.uppercase())'
+  cat documents.jsonl | {{.BinaryName}} blobl 'foo.bar.map_each(this.uppercase())'
 
-  echo '{"foo":"bar"}' | bento blobl -f ./mapping.blobl
+  echo '{"foo":"bar"}' | {{.BinaryName}} blobl -f ./mapping.blobl
 
-Find out more about Bloblang at: https://warpstreamlabs.github.io/bento/docs/guides/bloblang/about`[1:],
+Find out more about Bloblang at: {{.DocumentationURL}}/guides/bloblang/about`)[1:],
 		Flags: []cli.Flag{
 			&cli.IntFlag{
 				Name:    "threads",

--- a/internal/cli/common/opts.go
+++ b/internal/cli/common/opts.go
@@ -1,6 +1,10 @@
 package common
 
 import (
+	"bytes"
+	"os"
+	"text/template"
+
 	"github.com/warpstreamlabs/bento/internal/bundle"
 	"github.com/warpstreamlabs/bento/internal/config"
 	"github.com/warpstreamlabs/bento/internal/docs"
@@ -10,17 +14,29 @@ import (
 type CLIStreamBootstrapFunc func()
 
 type CLIOpts struct {
-	Version              string
-	DateBuilt            string
+	Version   string
+	DateBuilt string
+
+	BinaryName       string
+	ProductName      string
+	DocumentationURL string
+
 	MainConfigSpecCtor   func() docs.FieldSpecs // TODO: This becomes a service.Environment
 	OnManagerInitialised func(mgr bundle.NewManagement, pConf *docs.ParsedConfig) error
 	OnLoggerInit         func(l log.Modular) (log.Modular, error)
 }
 
 func NewCLIOpts(version, dateBuilt string) *CLIOpts {
+	binaryName := ""
+	if len(os.Args) > 0 {
+		binaryName = os.Args[0]
+	}
 	return &CLIOpts{
 		Version:            version,
 		DateBuilt:          dateBuilt,
+		BinaryName:         binaryName,
+		ProductName:        "Bento",
+		DocumentationURL:   "https://warpstreamlabs.github.io/bento/docs",
 		MainConfigSpecCtor: config.Spec,
 		OnManagerInitialised: func(mgr bundle.NewManagement, pConf *docs.ParsedConfig) error {
 			return nil
@@ -29,4 +45,26 @@ func NewCLIOpts(version, dateBuilt string) *CLIOpts {
 			return l, nil
 		},
 	}
+}
+
+func (c *CLIOpts) ExecTemplate(str string) string {
+	t, err := template.New("cli").Parse(str)
+	if err != nil {
+		return str
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, struct {
+		BinaryName       string
+		ProductName      string
+		DocumentationURL string
+	}{
+		BinaryName:       c.BinaryName,
+		ProductName:      c.ProductName,
+		DocumentationURL: c.DocumentationURL,
+	}); err != nil {
+		return str
+	}
+
+	return buf.String()
 }

--- a/internal/cli/common/opts.go
+++ b/internal/cli/common/opts.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"os"
+	"path"
 	"text/template"
 
 	"github.com/warpstreamlabs/bento/internal/bundle"
@@ -32,7 +33,7 @@ type CLIOpts struct {
 func NewCLIOpts(version, dateBuilt string) *CLIOpts {
 	binaryName := ""
 	if len(os.Args) > 0 {
-		binaryName = os.Args[0]
+		binaryName = path.Base(os.Args[0])
 	}
 	return &CLIOpts{
 		Version:          version,

--- a/internal/cli/common/opts.go
+++ b/internal/cli/common/opts.go
@@ -21,6 +21,9 @@ type CLIOpts struct {
 	ProductName      string
 	DocumentationURL string
 
+	ShowRunCommand    bool
+	ConfigSearchPaths []string
+
 	MainConfigSpecCtor   func() docs.FieldSpecs // TODO: This becomes a service.Environment
 	OnManagerInitialised func(mgr bundle.NewManagement, pConf *docs.ParsedConfig) error
 	OnLoggerInit         func(l log.Modular) (log.Modular, error)
@@ -32,11 +35,17 @@ func NewCLIOpts(version, dateBuilt string) *CLIOpts {
 		binaryName = os.Args[0]
 	}
 	return &CLIOpts{
-		Version:            version,
-		DateBuilt:          dateBuilt,
-		BinaryName:         binaryName,
-		ProductName:        "Bento",
-		DocumentationURL:   "https://warpstreamlabs.github.io/bento/docs",
+		Version:          version,
+		DateBuilt:        dateBuilt,
+		BinaryName:       binaryName,
+		ProductName:      "Bento",
+		DocumentationURL: "https://warpstreamlabs.github.io/bento/docs",
+		ShowRunCommand:   false,
+		ConfigSearchPaths: []string{
+			"/bento.yaml",
+			"/etc/bento/config.yaml",
+			"/etc/bento.yaml",
+		},
 		MainConfigSpecCtor: config.Spec,
 		OnManagerInitialised: func(mgr bundle.NewManagement, pConf *docs.ParsedConfig) error {
 			return nil

--- a/internal/cli/common/reader.go
+++ b/internal/cli/common/reader.go
@@ -14,11 +14,7 @@ func ReadConfig(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) (mainPath st
 	path := c.String("config")
 	if path == "" {
 		// Iterate default config paths
-		for _, dpath := range []string{
-			"/bento.yaml",
-			"/etc/bento/config.yaml",
-			"/etc/bento.yaml",
-		} {
+		for _, dpath := range cliOpts.ConfigSearchPaths {
 			if _, err := ifs.OS().Stat(dpath); err == nil {
 				inferred = true
 				path = dpath

--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -56,7 +56,7 @@ func RunService(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) int {
 		}
 	}
 	if strict && len(lints) > 0 {
-		logger.Error("Shutting down due to linter errors, to prevent shutdown run Bento with --chilled")
+		logger.Error(cliOpts.ExecTemplate("Shutting down due to linter errors, to prevent shutdown run {{.ProductName}} with --chilled"))
 		return 1
 	}
 
@@ -78,9 +78,9 @@ func RunService(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) int {
 	watching := c.Bool("watcher")
 	if streamsMode {
 		enableStreamsAPI := !c.Bool("no-api")
-		stoppableStream = initStreamsMode(strict, watching, enableStreamsAPI, confReader, stoppableManager.Manager())
+		stoppableStream = initStreamsMode(cliOpts, strict, watching, enableStreamsAPI, confReader, stoppableManager.Manager())
 	} else {
-		stoppableStream, dataStreamClosedChan = initNormalMode(conf, strict, watching, confReader, stoppableManager.Manager())
+		stoppableStream, dataStreamClosedChan = initNormalMode(cliOpts, conf, strict, watching, confReader, stoppableManager.Manager())
 	}
 
 	return RunManagerUntilStopped(c, conf, stoppableManager, stoppableStream, dataStreamClosedChan)
@@ -111,6 +111,7 @@ func DelayShutdown(ctx context.Context, duration time.Duration) error {
 }
 
 func initStreamsMode(
+	opts *CLIOpts,
 	strict, watching, enableAPI bool,
 	confReader *config.Reader,
 	mgr *manager.Type,
@@ -133,7 +134,7 @@ func initStreamsMode(
 		}
 	}
 	if strict && len(lints) > 0 {
-		logger.Error("Shutting down due to stream linter errors, to prevent shutdown run Bento with --chilled")
+		logger.Error(opts.ExecTemplate("Shutting down due to stream linter errors, to prevent shutdown run {{.ProductName}} with --chilled"))
 		os.Exit(1)
 	}
 
@@ -143,7 +144,7 @@ func initStreamsMode(
 			os.Exit(1)
 		}
 	}
-	logger.Info("Launching bento in streams mode, use CTRL+C to close")
+	logger.Info(opts.ExecTemplate("Launching {{.ProductName}} in streams mode, use CTRL+C to close"))
 
 	if err := confReader.SubscribeStreamChanges(func(id string, newStreamConf *stream.Config) error {
 		ctx, done := context.WithTimeout(context.Background(), time.Second*30)
@@ -175,6 +176,7 @@ func initStreamsMode(
 }
 
 func initNormalMode(
+	opts *CLIOpts,
 	conf config.Type,
 	strict, watching bool,
 	confReader *config.Reader,
@@ -202,7 +204,7 @@ func initNormalMode(
 
 	stoppableStream := NewSwappableStopper(initStream)
 
-	logger.Info("Launching a bento instance, use CTRL+C to close")
+	logger.Info(opts.ExecTemplate("Launching a {{.ProductName}} instance, use CTRL+C to close"))
 
 	if err := confReader.SubscribeConfigChanges(func(newStreamConf *config.Type) error {
 		ctx, done := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -111,23 +111,23 @@ func addExpression(conf map[string]any, expression string) error {
 func createCliCommand(cliOpts *common.CLIOpts) *cli.Command {
 	return &cli.Command{
 		Name:  "create",
-		Usage: "Create a new Bento config",
-		Description: `
-Prints a new Bento config to stdout containing specified components
+		Usage: cliOpts.ExecTemplate("Create a new {{.ProductName}} config"),
+		Description: cliOpts.ExecTemplate(`
+Prints a new {{.ProductName}} config to stdout containing specified components
 according to an expression. The expression must take the form of three
 comma-separated lists of inputs, processors and outputs, divided by
 forward slashes:
 
-  bento create stdin/bloblang,awk/nats
-  bento create file,http_server/protobuf/http_client
+  {{.BinaryName}} create stdin/bloblang,awk/nats
+  {{.BinaryName}} create file,http_server/protobuf/http_client
 
-If the expression is omitted a default config is created.`[1:],
+If the expression is omitted a default config is created.`)[1:],
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "small",
 				Aliases: []string{"s"},
 				Value:   false,
-				Usage:   "Print only the main components of a Bento config (input, pipeline, output) and omit all fields marked as advanced.",
+				Usage:   cliOpts.ExecTemplate("Print only the main components of a {{.ProductName}} config (input, pipeline, output) and omit all fields marked as advanced."),
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -138,17 +138,17 @@ func lintMDSnippets(path string, spec docs.FieldSpecs, lConf docs.LintConfig) (p
 func lintCliCommand(cliOpts *common.CLIOpts) *cli.Command {
 	return &cli.Command{
 		Name:  "lint",
-		Usage: "Parse Bento configs and report any linting errors",
-		Description: `
+		Usage: cliOpts.ExecTemplate("Parse {{.ProductName}} configs and report any linting errors"),
+		Description: cliOpts.ExecTemplate(`
 Exits with a status code 1 if any linting errors are detected:
 
-  bento -c target.yaml lint
-  bento lint ./configs/*.yaml
-  bento lint ./foo.yaml ./bar.yaml
-  bento lint ./configs/...
+  {{.BinaryName}} -c target.yaml lint
+  {{.BinaryName}} lint ./configs/*.yaml
+  {{.BinaryName}} lint ./foo.yaml ./bar.yaml
+  {{.BinaryName}} lint ./configs/...
 
-If a path ends with '...' then Bento will walk the target and lint any
-files with the .yaml or .yml extension.`[1:],
+If a path ends with '...' then {{.ProductName}} will walk the target and lint any
+files with the .yaml or .yml extension.`)[1:],
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "deprecated",

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -18,14 +18,14 @@ import (
 func listCliCommand(opts *common.CLIOpts) *cli.Command {
 	return &cli.Command{
 		Name:  "list",
-		Usage: "List all Bento component types",
-		Description: `
+		Usage: opts.ExecTemplate("List all {{.ProductName}} component types"),
+		Description: opts.ExecTemplate(`
 If any component types are explicitly listed then only types of those
 components will be shown.
 
-  bento list
-  bento list --format json inputs output
-  bento list rate-limits buffers`[1:],
+  {{.BinaryName}} list
+  {{.BinaryName}} list --format json inputs output
+  {{.BinaryName}} list rate-limits buffers`)[1:],
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "format",

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -72,7 +72,7 @@ func traverseHelp(cmd *cli.Command, pieces []string) []pluginHelp {
 	pieces = append(pieces, cmd.Name)
 	var args []string
 	for _, a := range cmd.Flags {
-		args = append(args, a.Names()[0])
+		args = append(args, "--"+a.Names()[0])
 	}
 	help := []pluginHelp{{
 		Path:  strings.Join(pieces, "_"),

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"runtime/debug"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
@@ -58,6 +60,32 @@ func init() {
 
 //------------------------------------------------------------------------------
 
+type pluginHelp struct {
+	Path  string   `json:"path,omitempty"`
+	Short string   `json:"short,omitempty"`
+	Long  string   `json:"long,omitempty"`
+	Args  []string `json:"args,omitempty"`
+}
+
+// In support of --help-autocomplete.
+func traverseHelp(cmd *cli.Command, pieces []string) []pluginHelp {
+	pieces = append(pieces, cmd.Name)
+	var args []string
+	for _, a := range cmd.Flags {
+		args = append(args, a.Names()[0])
+	}
+	help := []pluginHelp{{
+		Path:  strings.Join(pieces, "_"),
+		Short: cmd.Usage,
+		Long:  cmd.Description,
+		Args:  args,
+	}}
+	for _, cmd := range cmd.Subcommands {
+		help = append(help, traverseHelp(cmd, pieces)...)
+	}
+	return help
+}
+
 // App returns the full CLI app definition, this is useful for writing unit
 // tests around the CLI.
 func App(opts *common.CLIOpts) *cli.App {
@@ -98,7 +126,7 @@ func App(opts *common.CLIOpts) *cli.App {
 		&cli.StringSliceFlag{
 			Name:    "templates",
 			Aliases: []string{"t"},
-			Usage:   "EXPERIMENTAL: import Bento templates, supports glob patterns (requires quotes)",
+			Usage:   opts.ExecTemplate("EXPERIMENTAL: import {{.ProductName}} templates, supports glob patterns (requires quotes)"),
 		},
 		&cli.BoolFlag{
 			Name:  "chilled",
@@ -111,18 +139,24 @@ func App(opts *common.CLIOpts) *cli.App {
 			Value:   false,
 			Usage:   "EXPERIMENTAL: watch config files for changes and automatically apply them",
 		},
+		&cli.BoolFlag{
+			Name:   "help-autocomplete",
+			Value:  false,
+			Usage:  "print json serialised cli argument definitions to assist with autocomplete",
+			Hidden: true,
+		},
 	}
 
 	app := &cli.App{
-		Name:  "Bento",
-		Usage: "A stream processor for mundane tasks - https://warpstreamlabs.github.io/bento",
-		Description: `
-Either run Bento as a stream processor or choose a command:
+		Name:  opts.BinaryName,
+		Usage: opts.ExecTemplate("A stream processor for mundane tasks - {{.DocumentationURL}}"),
+		Description: opts.ExecTemplate(`
+Either run {{.ProductName}} as a stream processor or choose a command:
 
-  bento list inputs
-  bento create kafka//file > ./config.yaml
-  bento -c ./config.yaml
-  bento -r "./production/*.yaml" -c ./config.yaml`[1:],
+  {{.BinaryName}} list inputs
+  {{.BinaryName}} create kafka//file > ./config.yaml
+  {{.BinaryName}} -c ./config.yaml
+  {{.BinaryName}} -r "./production/*.yaml" -c ./config.yaml`)[1:],
 		Flags: flags,
 		Before: func(c *cli.Context) error {
 			dotEnvPaths, err := filepath.Globs(ifs.OS(), c.StringSlice("env-file"))
@@ -163,7 +197,7 @@ Either run Bento as a stream processor or choose a command:
 				for _, lint := range lints {
 					fmt.Fprintln(os.Stderr, lint)
 				}
-				fmt.Println("Shutting down due to linter errors, to prevent shutdown run Bento with --chilled")
+				fmt.Println(opts.ExecTemplate("Shutting down due to linter errors, to prevent shutdown run {{.ProductName}} with --chilled"))
 				os.Exit(1)
 			}
 			return nil
@@ -171,6 +205,10 @@ Either run Bento as a stream processor or choose a command:
 		Action: func(c *cli.Context) error {
 			if c.Bool("version") {
 				fmt.Printf("Version: %v\nDate: %v\n", opts.Version, opts.DateBuilt)
+				os.Exit(0)
+			}
+			if c.Bool("help-autocomplete") {
+				_ = json.NewEncoder(os.Stdout).Encode(traverseHelp(c.Command, nil))
 				os.Exit(0)
 			}
 			if c.Args().Len() > 0 {
@@ -188,12 +226,12 @@ Either run Bento as a stream processor or choose a command:
 			{
 				Name:  "echo",
 				Usage: "Parse a config file and echo back a normalised version",
-				Description: `
+				Description: opts.ExecTemplate(`
 This simple command is useful for sanity checking a config if it isn't
 behaving as expected, as it shows you a normalised version after environment
 variables have been resolved:
 
-  bento -c ./config.yaml echo | less`[1:],
+  {{.BinaryName}} -c ./config.yaml echo | less`)[1:],
 				Action: func(c *cli.Context) error {
 					_, _, confReader := common.ReadConfig(c, opts, false)
 					_, pConf, _, err := confReader.Read()
@@ -224,23 +262,23 @@ variables have been resolved:
 			lintCliCommand(opts),
 			{
 				Name:  "streams",
-				Usage: "Run Bento in streams mode",
-				Description: `
-Run Bento in streams mode, where multiple pipelines can be executed in a
+				Usage: opts.ExecTemplate("Run {{.ProductName}} in streams mode"),
+				Description: opts.ExecTemplate(`
+Run {{.ProductName}} in streams mode, where multiple pipelines can be executed in a
 single process and can be created, updated and removed via REST HTTP
 endpoints.
 
-  bento streams
-  bento -c ./root_config.yaml streams
-  bento streams ./path/to/stream/configs ./and/some/more
-  bento -c ./root_config.yaml streams ./streams/*.yaml
+  {{.BinaryName}} streams
+  {{.BinaryName}} -c ./root_config.yaml streams
+  {{.BinaryName}} streams ./path/to/stream/configs ./and/some/more
+  {{.BinaryName}} -c ./root_config.yaml streams ./streams/*.yaml
 
 In streams mode the stream fields of a root target config (input, buffer,
 pipeline, output) will be ignored. Other fields will be shared across all
 loaded streams (resources, metrics, etc).
 
 For more information check out the docs at:
-https://warpstreamlabs.github.io/bento/docs/guides/streams_mode/about`[1:],
+{{.DocumentationURL}}/guides/streams_mode/about`)[1:],
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
 						Name:  "no-api",
@@ -261,8 +299,8 @@ https://warpstreamlabs.github.io/bento/docs/guides/streams_mode/about`[1:],
 			listCliCommand(opts),
 			createCliCommand(opts),
 			test.CliCommand(opts),
-			clitemplate.CliCommand(),
-			blobl.CliCommand(),
+			clitemplate.CliCommand(opts),
+			blobl.CliCommand(opts),
 			studio.CliCommand(opts),
 		},
 	}

--- a/internal/cli/template/cli.go
+++ b/internal/cli/template/cli.go
@@ -2,25 +2,27 @@ package template
 
 import (
 	"github.com/urfave/cli/v2"
+
+	"github.com/warpstreamlabs/bento/internal/cli/common"
 )
 
 // CliCommand is a cli.Command definition for interacting with templates.
-func CliCommand() *cli.Command {
+func CliCommand(opts *common.CLIOpts) *cli.Command {
 	return &cli.Command{
 		Name:  "template",
-		Usage: "Interact and generate Bento templates",
-		Description: `
+		Usage: opts.ExecTemplate("Interact and generate {{.ProductName}} templates"),
+		Description: opts.ExecTemplate(`
 EXPERIMENTAL: This subcommand, and templates in general, are experimental and
 therefore are subject to change outside of major version releases.
 
-Allows linting and generating Bento templates.
+Allows linting and generating {{.ProductName}} templates.
 
-  bento template lint ./path/to/templates/...
+  {{.BinaryName}} template lint ./path/to/templates/...
 
 For more information check out the docs at:
-https://warpstreamlabs.github.io/bento/docs/configuration/templating`[1:],
+{{.DocumentationURL}}/configuration/templating`)[1:],
 		Subcommands: []*cli.Command{
-			lintCliCommand(),
+			lintCliCommand(opts),
 		},
 	}
 }

--- a/internal/cli/template/lint.go
+++ b/internal/cli/template/lint.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 
+	"github.com/warpstreamlabs/bento/internal/cli/common"
 	"github.com/warpstreamlabs/bento/internal/docs"
 	ifilepath "github.com/warpstreamlabs/bento/internal/filepath"
 	"github.com/warpstreamlabs/bento/internal/filepath/ifs"
@@ -59,20 +60,20 @@ func lintFile(path string) (pathLints []pathLint) {
 	return
 }
 
-func lintCliCommand() *cli.Command {
+func lintCliCommand(opts *common.CLIOpts) *cli.Command {
 	return &cli.Command{
 		Name:  "lint",
-		Usage: "Parse Bento templates and report any linting errors",
-		Description: `
+		Usage: opts.ExecTemplate("Parse {{.ProductName}} templates and report any linting errors"),
+		Description: opts.ExecTemplate(`
 Exits with a status code 1 if any linting errors are detected:
 
-  bento template lint
-  bento template lint ./templates/*.yaml
-  bento template lint ./foo.yaml ./bar.yaml
-  bento template lint ./templates/...
+  {{.BinaryName}} template lint
+  {{.BinaryName}} template lint ./templates/*.yaml
+  {{.BinaryName}} template lint ./foo.yaml ./bar.yaml
+  {{.BinaryName}} template lint ./templates/...
 
-If a path ends with '...' then Bento will walk the target and lint any
-files with the .yaml or .yml extension.`[1:],
+If a path ends with '...' then {{.ProductName}} will walk the target and lint any
+files with the .yaml or .yml extension.`)[1:],
 		Action: func(c *cli.Context) error {
 			targets, err := ifilepath.GlobsAndSuperPaths(ifs.OS(), c.Args().Slice(), "yaml", "yml")
 			if err != nil {

--- a/internal/cli/test/cli.go
+++ b/internal/cli/test/cli.go
@@ -16,17 +16,17 @@ import (
 func CliCommand(cliOpts *common.CLIOpts) *cli.Command {
 	return &cli.Command{
 		Name:  "test",
-		Usage: "Execute Bento unit tests",
-		Description: `
-Execute any number of Bento unit test definitions. If one or more tests
+		Usage: cliOpts.ExecTemplate("Execute {{.ProductName}} unit tests"),
+		Description: cliOpts.ExecTemplate(`
+Execute any number of {{.ProductName}} unit test definitions. If one or more tests
 fail the process will report the errors and exit with a status code 1.
 
-  bento test ./path/to/configs/...
-  bento test ./foo_configs/*.yaml ./bar_configs/*.yaml
-  bento test ./foo.yaml
+  {{.BinaryName}} test ./path/to/configs/...
+  {{.BinaryName}} test ./foo_configs/*.yaml ./bar_configs/*.yaml
+  {{.BinaryName}} test ./foo.yaml
 
 For more information check out the docs at:
-https://warpstreamlabs.github.io/bento/docs/configuration/unit_testing`[1:],
+{{.DocumentationURL}}/configuration/unit_testing`)[1:],
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "log",

--- a/internal/docs/json_schema.go
+++ b/internal/docs/json_schema.go
@@ -1,5 +1,20 @@
 package docs
 
+func jSchemaIsRequired(f *FieldSpec) bool {
+	if f.IsOptional || f.Default != nil {
+		return false
+	}
+	if len(f.Children) == 0 {
+		return true
+	}
+	for _, f := range f.Children {
+		if jSchemaIsRequired(&f) {
+			return true
+		}
+	}
+	return false
+}
+
 // JSONSchema serializes a field spec into a JSON schema structure.
 func (f FieldSpec) JSONSchema() any {
 	spec := map[string]any{}
@@ -36,7 +51,7 @@ func (f FieldSpec) JSONSchema() any {
 			spec["properties"] = f.Children.JSONSchema()
 			var required []string
 			for _, child := range f.Children {
-				if !child.IsOptional && child.Default == nil {
+				if jSchemaIsRequired(&child) {
 					required = append(required, child.Name)
 				}
 			}

--- a/public/service/service.go
+++ b/public/service/service.go
@@ -63,6 +63,21 @@ func CLIOptSetVersion(version, dateBuilt string) CLIOptFunc {
 	}
 }
 
+// CLIOptSetProductName overrides the default product name in CLI help docs.
+func CLIOptSetProductName(n string) CLIOptFunc {
+	return func(c *CLIOptBuilder) {
+		c.opts.ProductName = n
+	}
+}
+
+// CLIOptSetDocumentationURL overrides the default documentation URL in CLI help
+// docs.
+func CLIOptSetDocumentationURL(n string) CLIOptFunc {
+	return func(c *CLIOptBuilder) {
+		c.opts.DocumentationURL = n
+	}
+}
+
 // CLIOptOnLoggerInit sets a closure to be called when the service-wide logger
 // is initialised. A modified version can be returned, allowing you to mutate
 // the fields and settings that it has.

--- a/public/service/service.go
+++ b/public/service/service.go
@@ -63,6 +63,13 @@ func CLIOptSetVersion(version, dateBuilt string) CLIOptFunc {
 	}
 }
 
+// CLIOptSetBinaryName overrides the default binary name in CLI help docs.
+func CLIOptSetBinaryName(n string) CLIOptFunc {
+	return func(c *CLIOptBuilder) {
+		c.opts.BinaryName = n
+	}
+}
+
 // CLIOptSetProductName overrides the default product name in CLI help docs.
 func CLIOptSetProductName(n string) CLIOptFunc {
 	return func(c *CLIOptBuilder) {

--- a/public/service/service.go
+++ b/public/service/service.go
@@ -78,6 +78,23 @@ func CLIOptSetDocumentationURL(n string) CLIOptFunc {
 	}
 }
 
+// CLIOptSetShowRunCommand determines whether a `run` subcommand should appear
+// in CLI help and autocomplete.
+func CLIOptSetShowRunCommand(show bool) CLIOptFunc {
+	return func(c *CLIOptBuilder) {
+		c.opts.ShowRunCommand = show
+	}
+}
+
+// CLIOptSetDefaultConfigPaths overrides the default paths used for detecting
+// and loading config files when one was not provided explicitly with the
+// --config flag.
+func CLIOptSetDefaultConfigPaths(paths ...string) CLIOptFunc {
+	return func(c *CLIOptBuilder) {
+		c.opts.ConfigSearchPaths = paths
+	}
+}
+
 // CLIOptOnLoggerInit sets a closure to be called when the service-wide logger
 // is initialised. A modified version can be returned, allowing you to mutate
 // the fields and settings that it has.


### PR DESCRIPTION
Pulling in upstream changes. 

Changes:
- Add richer CLI customisation options
- ~Move `strip_html` to `internal/impl` and update docs (which generated weirdly and with an `unknown` param)~
- Include upstream `CHANGELOG` information into `CHANGELOG.old.md`