### PR TITLE
Docs: Remove references to original

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,4 +51,4 @@ The APIs for adding new components (inputs, outputs, processors, caches, etc) ha
 
 The core components within Bento (inputs, processors, conditions and outputs) are all easily pluggable. If you are interested in adding new components please raise a ticket and we can discuss whether it's a good fit for the project.
 
-If not then it's still easy to build your own version of Bento with custom components. For guidance take a look at [this example repo](https://github.com/benthosdev/benthos-plugin-example).
+If not then it's still easy to build your own version of Bento with custom components.

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -33,7 +33,7 @@ func NewConfig() Config {
 	return Config{
 		Address:        "0.0.0.0:4195",
 		Enabled:        true,
-		RootPath:       "/benthos",
+		RootPath:       "/bento",
 		DebugEndpoints: false,
 		CertFile:       "",
 		KeyFile:        "",

--- a/internal/api/docs.go
+++ b/internal/api/docs.go
@@ -17,7 +17,7 @@ func Spec() docs.FieldSpecs {
 		docs.FieldString(fieldAddress, "The address to bind to.").HasDefault("0.0.0.0:4195"),
 		docs.FieldString(
 			fieldRootPath, "Specifies a general prefix for all endpoints, this can help isolate the service endpoints when using a reverse proxy with other shared services. All endpoints will still be registered at the root as well as behind the prefix, e.g. with a root_path set to `/foo` the endpoint `/version` will be accessible from both `/version` and `/foo/version`.",
-		).HasDefault("/benthos"),
+		).HasDefault("/bento"),
 		docs.FieldBool(
 			fieldDebugEndpoints, "Whether to register a few extra endpoints that can be useful for debugging performance or behavioral problems.",
 		).HasDefault(false),
@@ -48,14 +48,14 @@ func DocsMarkdown() ([]byte, error) {
 http:
   address: 0.0.0.0:4195
   enabled: true
-  root_path: /benthos
+  root_path: /bento
   debug_endpoints: false
 `,
 		AdvancedConfig: `
 http:
   address: 0.0.0.0:4195
   enabled: true
-  root_path: /benthos
+  root_path: /bento
   debug_endpoints: false
   cert_file: ""
   key_file: ""

--- a/website/docs/components/http/about.md
+++ b/website/docs/components/http/about.md
@@ -31,7 +31,7 @@ import TabItem from '@theme/TabItem';
 http:
   address: 0.0.0.0:4195
   enabled: true
-  root_path: /benthos
+  root_path: /bento
   debug_endpoints: false
 ```
 
@@ -44,7 +44,7 @@ http:
 http:
   address: 0.0.0.0:4195
   enabled: true
-  root_path: /benthos
+  root_path: /bento
   debug_endpoints: false
   cert_file: ""
   key_file: ""
@@ -138,7 +138,7 @@ Specifies a general prefix for all endpoints, this can help isolate the service 
 
 
 Type: `string`  
-Default: `"/benthos"`  
+Default: `"/bento"`  
 
 ### `debug_endpoints`
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -23,18 +23,18 @@ bento create nats/protobuf/aws_sqs > ./config.yaml
 # Run
 bento -c ./config.yaml`
   },
-  {
-    label: 'Homebrew',
-    language: 'bash',
-    children: `# Install
-brew install benthos
+//   {
+//     label: 'Homebrew',
+//     language: 'bash',
+//     children: `# Install
+// brew install benthos
 
-# Make a config
-bento create nats/protobuf/aws_sqs > ./config.yaml
+// # Make a config
+// bento create nats/protobuf/aws_sqs > ./config.yaml
 
-# Run
-bento -c ./config.yaml`
-  },
+// # Run
+// bento -c ./config.yaml`
+//   },
   {
     label: 'Docker',
     language: 'bash',
@@ -47,20 +47,20 @@ docker run --rm ghcr.io/warpstreamlabs/bento create nats/protobuf/aws_sqs > ./co
 # Run
 docker run --rm -v $(pwd)/config.yaml:/bento.yaml ghcr.io/warpstreamlabs/bento`
   },
-  {
-    label: 'Asdf',
-    language: 'bash',
-    children: `# Install
-asdf plugin add benthos
-asdf install benthos latest
-asdf global benthos latest
+//   {
+//     label: 'Asdf',
+//     language: 'bash',
+//     children: `# Install
+// asdf plugin add benthos
+// asdf install benthos latest
+// asdf global benthos latest
 
-# Make a config
-bento create nats/protobuf/aws_sqs > ./config.yaml
+// # Make a config
+// bento create nats/protobuf/aws_sqs > ./config.yaml
 
-# Run
-bento -c ./config.yaml`
-  },
+// # Run
+// bento -c ./config.yaml`
+//   },
 ]
 
 const snippets = [


### PR DESCRIPTION
- Remove references to original project in docs.
- Comment out `asfd` and `brew` installation methods until further notice.