### PR TITLE
sql: Add optional verification ping on database client initialisation

### DIFF
--- a/internal/impl/sql/cache_sql.go
+++ b/internal/impl/sql/cache_sql.go
@@ -161,7 +161,7 @@ func newSQLCacheFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (
 		return nil, err
 	}
 
-	if s.db, err = sqlOpenWithReworks(s.logger, s.driver, s.dsn); err != nil {
+	if s.db, err = sqlOpenWithReworks(context.Background(), s.logger, s.driver, s.dsn, connSettings.initVerifyConn); err != nil {
 		return nil, err
 	}
 	connSettings.apply(context.Background(), s.db, s.logger)

--- a/internal/impl/sql/input_sql_raw.go
+++ b/internal/impl/sql/input_sql_raw.go
@@ -132,7 +132,7 @@ func (s *sqlRawInput) Connect(ctx context.Context) (err error) {
 	}
 
 	var db *sql.DB
-	if db, err = sqlOpenWithReworks(s.logger, s.driver, s.dsn); err != nil {
+	if db, err = sqlOpenWithReworks(ctx, s.logger, s.driver, s.dsn, s.connSettings.initVerifyConn); err != nil {
 		return err
 	}
 	defer func() {

--- a/internal/impl/sql/input_sql_select.go
+++ b/internal/impl/sql/input_sql_select.go
@@ -184,7 +184,7 @@ func (s *sqlSelectInput) Connect(ctx context.Context) (err error) {
 	}
 
 	var db *sql.DB
-	if db, err = sqlOpenWithReworks(s.logger, s.driver, s.dsn); err != nil {
+	if db, err = sqlOpenWithReworks(ctx, s.logger, s.driver, s.dsn, s.connSettings.initVerifyConn); err != nil {
 		return
 	}
 	defer func() {

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -192,7 +192,7 @@ func (s *sqlInsertOutput) Connect(ctx context.Context) error {
 	}
 
 	var err error
-	if s.db, err = sqlOpenWithReworks(s.logger, s.driver, s.dsn); err != nil {
+	if s.db, err = sqlOpenWithReworks(ctx, s.logger, s.driver, s.dsn, s.connSettings.initVerifyConn); err != nil {
 		return err
 	}
 

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -166,7 +166,7 @@ func (s *sqlRawOutput) Connect(ctx context.Context) error {
 	}
 
 	var err error
-	if s.db, err = sqlOpenWithReworks(s.logger, s.driver, s.dsn); err != nil {
+	if s.db, err = sqlOpenWithReworks(ctx, s.logger, s.driver, s.dsn, s.connSettings.initVerifyConn); err != nil {
 		return err
 	}
 

--- a/internal/impl/sql/processor_sql_insert.go
+++ b/internal/impl/sql/processor_sql_insert.go
@@ -171,7 +171,7 @@ func NewSQLInsertProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 		return nil, err
 	}
 
-	if s.db, err = sqlOpenWithReworks(mgr.Logger(), driverStr, dsnStr); err != nil {
+	if s.db, err = sqlOpenWithReworks(context.Background(), mgr.Logger(), driverStr, dsnStr, connSettings.initVerifyConn); err != nil {
 		return nil, err
 	}
 

--- a/internal/impl/sql/processor_sql_raw.go
+++ b/internal/impl/sql/processor_sql_raw.go
@@ -167,7 +167,7 @@ func newSQLRawProcessor(
 	}
 
 	var err error
-	if s.db, err = sqlOpenWithReworks(logger, driverStr, dsnStr); err != nil {
+	if s.db, err = sqlOpenWithReworks(context.Background(), logger, driverStr, dsnStr, connSettings.initVerifyConn); err != nil {
 		return nil, err
 	}
 	connSettings.apply(context.Background(), s.db, s.logger)

--- a/internal/impl/sql/processor_sql_select.go
+++ b/internal/impl/sql/processor_sql_select.go
@@ -171,7 +171,7 @@ func NewSQLSelectProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 		return nil, err
 	}
 
-	if s.db, err = sqlOpenWithReworks(mgr.Logger(), driverStr, dsnStr); err != nil {
+	if s.db, err = sqlOpenWithReworks(context.Background(), mgr.Logger(), driverStr, dsnStr, connSettings.initVerifyConn); err != nil {
 		return nil, err
 	}
 	connSettings.apply(context.Background(), s.db, s.logger)

--- a/website/docs/components/caches/sql.md
+++ b/website/docs/components/caches/sql.md
@@ -63,6 +63,7 @@ sql:
       baz varchar(50),
       primary key (foo)
     ) WITHOUT ROWID;
+  init_verify_conn: false
   conn_max_idle_time: "" # No default (optional)
   conn_max_life_time: "" # No default (optional)
   conn_max_idle: 2
@@ -248,6 +249,15 @@ init_statement: |2
     primary key (foo)
   ) WITHOUT ROWID;
 ```
+
+### `init_verify_conn`
+
+Whether to verify the database connection on startup by performing a simple ping, by default this is disabled.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.2.0 or newer  
 
 ### `conn_max_idle_time`
 

--- a/website/docs/components/inputs/sql_raw.md
+++ b/website/docs/components/inputs/sql_raw.md
@@ -63,6 +63,7 @@ input:
         baz varchar(50),
         primary key (foo)
       ) WITHOUT ROWID;
+    init_verify_conn: false
     conn_max_idle_time: "" # No default (optional)
     conn_max_life_time: "" # No default (optional)
     conn_max_idle: 2
@@ -245,6 +246,15 @@ init_statement: |2
     primary key (foo)
   ) WITHOUT ROWID;
 ```
+
+### `init_verify_conn`
+
+Whether to verify the database connection on startup by performing a simple ping, by default this is disabled.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.2.0 or newer  
 
 ### `conn_max_idle_time`
 

--- a/website/docs/components/inputs/sql_select.md
+++ b/website/docs/components/inputs/sql_select.md
@@ -69,6 +69,7 @@ input:
         baz varchar(50),
         primary key (foo)
       ) WITHOUT ROWID;
+    init_verify_conn: false
     conn_max_idle_time: "" # No default (optional)
     conn_max_life_time: "" # No default (optional)
     conn_max_idle: 2
@@ -287,6 +288,15 @@ init_statement: |2
     primary key (foo)
   ) WITHOUT ROWID;
 ```
+
+### `init_verify_conn`
+
+Whether to verify the database connection on startup by performing a simple ping, by default this is disabled.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.2.0 or newer  
 
 ### `conn_max_idle_time`
 

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -69,6 +69,7 @@ output:
         baz varchar(50),
         primary key (foo)
       ) WITHOUT ROWID;
+    init_verify_conn: false
     conn_max_idle_time: "" # No default (optional)
     conn_max_life_time: "" # No default (optional)
     conn_max_idle: 2
@@ -282,6 +283,15 @@ init_statement: |2
     primary key (foo)
   ) WITHOUT ROWID;
 ```
+
+### `init_verify_conn`
+
+Whether to verify the database connection on startup by performing a simple ping, by default this is disabled.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.2.0 or newer  
 
 ### `conn_max_idle_time`
 

--- a/website/docs/components/outputs/sql_raw.md
+++ b/website/docs/components/outputs/sql_raw.md
@@ -66,6 +66,7 @@ output:
         baz varchar(50),
         primary key (foo)
       ) WITHOUT ROWID;
+    init_verify_conn: false
     conn_max_idle_time: "" # No default (optional)
     conn_max_life_time: "" # No default (optional)
     conn_max_idle: 2
@@ -262,6 +263,15 @@ init_statement: |2
     primary key (foo)
   ) WITHOUT ROWID;
 ```
+
+### `init_verify_conn`
+
+Whether to verify the database connection on startup by performing a simple ping, by default this is disabled.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.2.0 or newer  
 
 ### `conn_max_idle_time`
 

--- a/website/docs/components/processors/sql_insert.md
+++ b/website/docs/components/processors/sql_insert.md
@@ -60,6 +60,7 @@ sql_insert:
       baz varchar(50),
       primary key (foo)
     ) WITHOUT ROWID;
+  init_verify_conn: false
   conn_max_idle_time: "" # No default (optional)
   conn_max_life_time: "" # No default (optional)
   conn_max_idle: 2
@@ -262,6 +263,15 @@ init_statement: |2
     primary key (foo)
   ) WITHOUT ROWID;
 ```
+
+### `init_verify_conn`
+
+Whether to verify the database connection on startup by performing a simple ping, by default this is disabled.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.2.0 or newer  
 
 ### `conn_max_idle_time`
 

--- a/website/docs/components/processors/sql_raw.md
+++ b/website/docs/components/processors/sql_raw.md
@@ -59,6 +59,7 @@ sql_raw:
       baz varchar(50),
       primary key (foo)
     ) WITHOUT ROWID;
+  init_verify_conn: false
   conn_max_idle_time: "" # No default (optional)
   conn_max_life_time: "" # No default (optional)
   conn_max_idle: 2
@@ -268,6 +269,15 @@ init_statement: |2
     primary key (foo)
   ) WITHOUT ROWID;
 ```
+
+### `init_verify_conn`
+
+Whether to verify the database connection on startup by performing a simple ping, by default this is disabled.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.2.0 or newer  
 
 ### `conn_max_idle_time`
 

--- a/website/docs/components/processors/sql_select.md
+++ b/website/docs/components/processors/sql_select.md
@@ -62,6 +62,7 @@ sql_select:
       baz varchar(50),
       primary key (foo)
     ) WITHOUT ROWID;
+  init_verify_conn: false
   conn_max_idle_time: "" # No default (optional)
   conn_max_life_time: "" # No default (optional)
   conn_max_idle: 2
@@ -278,6 +279,15 @@ init_statement: |2
     primary key (foo)
   ) WITHOUT ROWID;
 ```
+
+### `init_verify_conn`
+
+Whether to verify the database connection on startup by performing a simple ping, by default this is disabled.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.2.0 or newer  
 
 ### `conn_max_idle_time`
 


### PR DESCRIPTION
### Summary

- Add a flag that, when true, pings a SQL database. If the ping fails the component is set to an error state.
- From #70 

### Changes

- Extended `sqlOpenWithReworks` to include a `shouldPing` boolean which will run a `db.PingContext` if true. 
- Small refactor of `sqlOpenWithReworks`, placing the `rework` functionality into a seperate `reworkDSN` function.
- Added new flag `init_verify_conn` to the SQL component's config and included this in the `connSettings` struct.
- Updated docs.