### PR TITLE
Update CHANGELOG for v1.0.2 and v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 1.1.0 - 2024-07-012
+
+### Added
+
+- Bento mascot as a `favicon.ico` to docusaurus site and back into the `README`.
+- New cookbook for Kafka topic mirroring.
+- New local testing guide for `bento-lambda`.
+
+### Changed
+
+- Removed more references to upstream in documentation.
+
+### Upstream Changes Synced
+
+- [v4.30.0 - 2024-05-29](./CHANGELOG.old.md#4.30.0-2024-06-13)    
+- [v4.29.0 - 2024-05-29](./CHANGELOG.old.md#4.29.0-2024-06-10)    
+- [v4.28.0 - 2024-05-29](./CHANGELOG.old.md#4.28.0-2024-05-29)    
+
+## 1.0.2 - 2024-06-07
+
+### Changed
+
+- Updated repository documentation.
+
+### Fixed
+
+- Removed referenced to upstream `v4` in favour of Bento `v1`.
+- Fixed flag in Docker `streams_mode` resource.
+
 ## 1.0.1 - 2024-06-03
 
 ### Changed


### PR DESCRIPTION
Updating CHANGELOG with `v1.0.2`  and incoming `v1.1.0` information. 