### PR TITLE
mongodb: Update docs to reflect input metadata and interpolation for collection field

### DIFF
--- a/internal/impl/mongodb/input.go
+++ b/internal/impl/mongodb/input.go
@@ -24,7 +24,22 @@ func mongoConfigSpec() *service.ConfigSpec {
 		Version("1.0.0").
 		Categories("Services").
 		Summary("Executes a query and creates a message for each document received.").
-		Description(`Once the documents from the query are exhausted, this input shuts down, allowing the pipeline to gracefully terminate (or the next input in a [sequence](/docs/components/inputs/sequence) to execute).`).
+		Description(`
+Once the documents from the query are exhausted, this input shuts down, allowing the pipeline to gracefully terminate (or the next input in a [sequence](/docs/components/inputs/sequence) to execute).
+
+### Metadata
+
+This input adds the following metadata fields to each message:
+
+` + "```text" + `
+- mongo_database
+- mongo_collection
+` + "```" + `
+
+You can access these metadata fields using
+[function interpolation](/docs/configuration/interpolation#bloblang-queries).
+
+`).
 		Fields(clientFields()...).
 		Field(service.NewStringField("collection").Description("The collection to select from.")).
 		Field(service.NewStringEnumField("operation", FindInputOperation, AggregateInputOperation).

--- a/internal/impl/mongodb/output.go
+++ b/internal/impl/mongodb/output.go
@@ -27,7 +27,7 @@ func outputSpec() *service.ConfigSpec {
 		Description(service.OutputPerformanceDocs(true, true)).
 		Fields(clientFields()...).
 		Fields(
-			service.NewStringField(moFieldCollection).
+			service.NewInterpolatedStringField(moFieldCollection).
 				Description("The name of the target collection."),
 			outputOperationDocs(OperationUpdateOne),
 			writeConcernDocs(),

--- a/internal/impl/mongodb/processor.go
+++ b/internal/impl/mongodb/processor.go
@@ -28,7 +28,7 @@ func ProcessorSpec() *service.ConfigSpec {
 		Description("").
 		Fields(clientFields()...).
 		Fields(
-			service.NewStringField(mpFieldCollection).
+			service.NewInterpolatedStringField(mpFieldCollection).
 				Description("The name of the target collection."),
 			processorOperationDocs(OperationInsertOne),
 			writeConcernDocs(),

--- a/website/docs/components/inputs/mongodb.md
+++ b/website/docs/components/inputs/mongodb.md
@@ -78,6 +78,20 @@ input:
 
 Once the documents from the query are exhausted, this input shuts down, allowing the pipeline to gracefully terminate (or the next input in a [sequence](/docs/components/inputs/sequence) to execute).
 
+### Metadata
+
+This input adds the following metadata fields to each message:
+
+```text
+- mongo_database
+- mongo_collection
+```
+
+You can access these metadata fields using
+[function interpolation](/docs/configuration/interpolation#bloblang-queries).
+
+
+
 ## Fields
 
 ### `url`

--- a/website/docs/components/outputs/mongodb.md
+++ b/website/docs/components/outputs/mongodb.md
@@ -142,6 +142,7 @@ Default: `""`
 ### `collection`
 
 The name of the target collection.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 
 Type: `string`  

--- a/website/docs/components/processors/mongodb.md
+++ b/website/docs/components/processors/mongodb.md
@@ -121,6 +121,7 @@ Default: `""`
 ### `collection`
 
 The name of the target collection.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 
 Type: `string`  


### PR DESCRIPTION
Update documentation for MongoDB docs with the following:
- Reflect string interpolation functionality for `collection` field of the `output` and `processor`.
- Mention metadata being added to each message on `input`
- From #99 