### PR TITLE
 kafka-franz: Add more configurable fields for kafka-franz performance tuning

### DIFF
--- a/internal/impl/couchbase/integration_test.go
+++ b/internal/impl/couchbase/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"
 )

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -176,8 +176,8 @@ type franzKafkaReader struct {
 	batchPolicy     service.BatchPolicy
 
 	metadataMaxAge         time.Duration
-	fetchMaxBytes          int
-	fetchMaxPartitionBytes int
+	fetchMaxBytes          int32
+	fetchMaxPartitionBytes int32
 	fetchMaxWait           time.Duration
 	preferringLagFn        kgo.PreferLagFn
 	balancers              []kgo.GroupBalancer
@@ -278,7 +278,7 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 	if err != nil {
 		return nil, err
 	}
-	f.fetchMaxBytes = int(fetchMaxBytes)
+	f.fetchMaxBytes = int32(fetchMaxBytes)
 
 	fetchMaxPartitionBytesStr, err := conf.FieldString("fetch_max_partition_bytes")
 	if err != nil {
@@ -289,7 +289,7 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 	if err != nil {
 		return nil, err
 	}
-	f.fetchMaxPartitionBytes = int(fetchMaxPartitionBytes)
+	f.fetchMaxPartitionBytes = int32(fetchMaxPartitionBytes)
 
 	if f.fetchMaxWait, err = conf.FieldDuration("fetch_max_wait"); err != nil {
 		return nil, err
@@ -722,8 +722,8 @@ func (f *franzKafkaReader) Connect(ctx context.Context) error {
 		kgo.Rack(f.rackID),
 
 		kgo.MetadataMaxAge(f.metadataMaxAge),
-		kgo.FetchMaxBytes(int32(f.fetchMaxBytes)),
-		kgo.FetchMaxPartitionBytes(int32(f.fetchMaxPartitionBytes)),
+		kgo.FetchMaxBytes(f.fetchMaxBytes),
+		kgo.FetchMaxPartitionBytes(f.fetchMaxPartitionBytes),
 		kgo.FetchMaxWait(f.fetchMaxWait),
 		kgo.ConsumePreferringLagFn(f.preferringLagFn),
 		kgo.Balancers(f.balancers...),

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -296,11 +296,10 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 	}
 
 	if conf.Contains("preferring_lag") {
-		var preferring_lag int
-		if preferring_lag, err = conf.FieldInt("preferring_lag"); err != nil {
+		if preferringLag, err := conf.FieldInt("preferring_lag"); err != nil {
 			return nil, err
-		} else if preferring_lag > 0 {
-			f.preferringLagFn = kgo.PreferLagAt(int64(preferring_lag))
+		} else if preferringLag > 0 {
+			f.preferringLagFn = kgo.PreferLagAt(int64(preferringLag))
 		}
 	}
 

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
 
@@ -89,6 +91,35 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Description("Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.").
 			Default(true).
 			Advanced()).
+		Field(service.NewStringListField("group_balancers").
+			Description("Balancers sets the group balancers to use for dividing topic partitions among group members. This option is equivalent to Kafka's `partition.assignment.strategies` option.").
+			Default([]string{"cooperative_sticky"}).
+			Advanced()).
+		Field(service.NewDurationField("metadata_max_age").
+			Description("This sets the maximum age for the client's cached metadata, to allow detection of new topics, partitions, etc.").
+			Default("5m").
+			Advanced()).
+		Field(service.NewStringField("fetch_max_bytes").
+			Description("This sets the maximum amount of bytes a broker will try to send during a fetch. Note that brokers may not obey this limit if it has records larger than this limit. Also note that this client sends a fetch to each broker concurrently, meaning the client will buffer up to `<brokers * max bytes>` worth of memory. Equivalent to Kafka's `fetch.max.bytes` option.").
+			Default("50MiB").
+			Advanced()).
+		Field(service.NewStringField("fetch_max_partition_bytes").
+			Description("Sets the maximum amount of bytes that will be consumed for a single partition in a fetch request. Note that if a single batch is larger than this number, that batch will still be returned so the client can make progress. Equivalent to Kafka's `max.partition.fetch.bytes` option.").
+			Default("1MiB").
+			Advanced()).
+		Field(service.NewDurationField("fetch_max_wait").
+			Description("This sets the maximum amount of time a broker will wait for a fetch response to hit the minimum number of required bytes before returning, overriding the default 5s.").
+			Default("5s").
+			Advanced()).
+		Field(service.NewIntField("preferring_lag").
+			Description(`
+This allows you to re-order partitions before they are fetched, given each partition's current lag.
+
+By default, the client rotates partitions fetched by one after every fetch request. Kafka answers fetch requests in the order that partitions are requested, filling the fetch response until` + "`fetch_max_bytes`" + ` and ` + "`fetch_max_partition_bytes`" + ` are hit. All partitions eventually rotate to the front, ensuring no partition is starved.
+
+With this option, you can return topic order and per-topic partition ordering. These orders will sort to the front (first by topic, then by partition). Any topic or partitions that you do not return are added to the end, preserving their original ordering.`).
+			Optional().
+			Advanced()).
 		Field(service.NewTLSToggledField("tls")).
 		Field(saslField()).
 		Field(service.NewBoolField("multi_header").Description("Decode headers into lists to allow handling of multiple values with the same key").Default(false).Advanced()).
@@ -143,6 +174,13 @@ type franzKafkaReader struct {
 	regexPattern    bool
 	multiHeader     bool
 	batchPolicy     service.BatchPolicy
+
+	metadataMaxAge         time.Duration
+	fetchMaxBytes          int
+	fetchMaxPartitionBytes int
+	fetchMaxWait           time.Duration
+	preferringLagFn        kgo.PreferLagFn
+	balancers              []kgo.GroupBalancer
 
 	batchChan atomic.Value
 	res       *service.Resources
@@ -225,6 +263,73 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 
 	if f.commitPeriod, err = conf.FieldDuration("commit_period"); err != nil {
 		return nil, err
+	}
+
+	if f.metadataMaxAge, err = conf.FieldDuration("metadata_max_age"); err != nil {
+		return nil, err
+	}
+
+	fetchMaxBytesStr, err := conf.FieldString("fetch_max_bytes")
+	if err != nil {
+		return nil, err
+	}
+
+	fetchMaxBytes, err := humanize.ParseBytes(fetchMaxBytesStr)
+	if err != nil {
+		return nil, err
+	}
+	f.fetchMaxBytes = int(fetchMaxBytes)
+
+	fetchMaxPartitionBytesStr, err := conf.FieldString("fetch_max_partition_bytes")
+	if err != nil {
+		return nil, err
+	}
+
+	fetchMaxPartitionBytes, err := humanize.ParseBytes(fetchMaxPartitionBytesStr)
+	if err != nil {
+		return nil, err
+	}
+	f.fetchMaxPartitionBytes = int(fetchMaxPartitionBytes)
+
+	if f.fetchMaxWait, err = conf.FieldDuration("fetch_max_wait"); err != nil {
+		return nil, err
+	}
+
+	if conf.Contains("preferring_lag") {
+		var preferring_lag int
+		if preferring_lag, err = conf.FieldInt("preferring_lag"); err != nil {
+			return nil, err
+		} else if preferring_lag > 0 {
+			f.preferringLagFn = kgo.PreferLagAt(int64(preferring_lag))
+		}
+	}
+
+	var balancers []string
+	if balancers, err = conf.FieldStringList("group_balancers"); err != nil {
+		return nil, err
+	}
+
+	if len(balancers) > 0 {
+		seen := make(map[string]struct{})
+		for _, b := range balancers {
+			if _, ok := seen[b]; ok {
+				res.Logger().Warnf("Skipping duplicate group_balancer field %s", b)
+				continue
+			}
+
+			switch b {
+			case "round_robin":
+				f.balancers = append(f.balancers, kgo.RoundRobinBalancer())
+			case "range":
+				f.balancers = append(f.balancers, kgo.RangeBalancer())
+			case "sticky":
+				f.balancers = append(f.balancers, kgo.StickyBalancer())
+			case "cooperative_sticky":
+				f.balancers = append(f.balancers, kgo.CooperativeStickyBalancer())
+			default:
+				return nil, fmt.Errorf("undefined group_balancer option: [%s]", b)
+			}
+		}
 	}
 
 	if f.batchPolicy, err = conf.FieldBatchPolicy("batching"); err != nil {
@@ -616,6 +721,13 @@ func (f *franzKafkaReader) Connect(ctx context.Context) error {
 		kgo.ConsumerGroup(f.consumerGroup),
 		kgo.ClientID(f.clientID),
 		kgo.Rack(f.rackID),
+
+		kgo.MetadataMaxAge(f.metadataMaxAge),
+		kgo.FetchMaxBytes(int32(f.fetchMaxBytes)),
+		kgo.FetchMaxPartitionBytes(int32(f.fetchMaxPartitionBytes)),
+		kgo.FetchMaxWait(f.fetchMaxWait),
+		kgo.ConsumePreferringLagFn(f.preferringLagFn),
+		kgo.Balancers(f.balancers...),
 	}
 
 	if f.consumerGroup != "" {

--- a/internal/impl/questdb/output.go
+++ b/internal/impl/questdb/output.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	qdb "github.com/questdb/go-questdb-client/v3"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/questdb/output_test.go
+++ b/internal/impl/questdb/output_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -60,6 +60,13 @@ input:
     auto_replay_nacks: true
     commit_period: 5s
     start_from_oldest: true
+    group_balancers:
+      - cooperative_sticky
+    metadata_max_age: 5m
+    fetch_max_bytes: 50MiB
+    fetch_max_partition_bytes: 1MiB
+    fetch_max_wait: 5s
+    preferring_lag: 0 # No default (optional)
     tls:
       enabled: false
       skip_cert_verify: false
@@ -220,6 +227,57 @@ Determines whether to consume from the oldest available offset, otherwise messag
 
 Type: `bool`  
 Default: `true`  
+
+### `group_balancers`
+
+Balancers sets the group balancers to use for dividing topic partitions among group members. This option is equivalent to Kafka's `partition.assignment.strategies` option.
+
+
+Type: `array`  
+Default: `["cooperative_sticky"]`  
+
+### `metadata_max_age`
+
+This sets the maximum age for the client's cached metadata, to allow detection of new topics, partitions, etc.
+
+
+Type: `string`  
+Default: `"5m"`  
+
+### `fetch_max_bytes`
+
+This sets the maximum amount of bytes a broker will try to send during a fetch. Note that brokers may not obey this limit if it has records larger than this limit. Also note that this client sends a fetch to each broker concurrently, meaning the client will buffer up to `<brokers * max bytes>` worth of memory. Equivalent to Kafka's `fetch.max.bytes` option.
+
+
+Type: `string`  
+Default: `"50MiB"`  
+
+### `fetch_max_partition_bytes`
+
+Sets the maximum amount of bytes that will be consumed for a single partition in a fetch request. Note that if a single batch is larger than this number, that batch will still be returned so the client can make progress. Equivalent to Kafka's `max.partition.fetch.bytes` option.
+
+
+Type: `string`  
+Default: `"1MiB"`  
+
+### `fetch_max_wait`
+
+This sets the maximum amount of time a broker will wait for a fetch response to hit the minimum number of required bytes before returning, overriding the default 5s.
+
+
+Type: `string`  
+Default: `"5s"`  
+
+### `preferring_lag`
+
+This allows you to re-order partitions before they are fetched, given each partition's current lag.
+
+By default, the client rotates partitions fetched by one after every fetch request. Kafka answers fetch requests in the order that partitions are requested, filling the fetch response until`fetch_max_bytes` and `fetch_max_partition_bytes` are hit. All partitions eventually rotate to the front, ensuring no partition is starved.
+
+With this option, you can return topic order and per-topic partition ordering. These orders will sort to the front (first by topic, then by partition). Any topic or partitions that you do not return are added to the end, preserving their original ordering.
+
+
+Type: `int`  
 
 ### `tls`
 

--- a/website/docs/components/outputs/kafka_franz.md
+++ b/website/docs/components/outputs/kafka_franz.md
@@ -62,6 +62,10 @@ output:
     topic: "" # No default (required)
     key: "" # No default (optional)
     partitioner: "" # No default (optional)
+    uniform_bytes_options:
+      bytes: 1MB
+      adaptive: false
+      keys: false
     partition: ${! metadata("partition") } # No default (optional)
     client_id: bento
     rack_id: ""
@@ -78,6 +82,8 @@ output:
       check: ""
       processors: [] # No default (optional)
     max_message_bytes: 1MB
+    max_buffered_records: 10000
+    metadata_max_age: 5m
     compression: "" # No default (optional)
     tls:
       enabled: false
@@ -149,7 +155,39 @@ Type: `string`
 | `manual` | Manually select a partition for each message, requires the field `partition` to be specified. |
 | `murmur2_hash` | Kafka's default hash algorithm that uses a 32-bit murmur2 hash of the key to compute which partition the record will be on. |
 | `round_robin` | Round-robin's messages through all available partitions. This algorithm has lower throughput and causes higher CPU load on brokers, but can be useful if you want to ensure an even distribution of records to partitions. |
+| `uniform_bytes` | Partitions based on byte size, with options for adaptive partitioning and key-based hashing in the `uniform_bytes_options` component. |
 
+
+### `uniform_bytes_options`
+
+Sets partitioner options when `partitioner` is of type `uniform_bytes`. These values will otherwise be ignored. Note, that future versions will likely see this approach reworked.
+
+
+Type: `object`  
+
+### `uniform_bytes_options.bytes`
+
+The number of bytes the partitioner will return the same partition for.
+
+
+Type: `string`  
+Default: `"1MB"`  
+
+### `uniform_bytes_options.adaptive`
+
+Sets a slight imbalance so that the partitioner can produce more to brokers that are less loaded.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `uniform_bytes_options.keys`
+
+If `true`, uses standard hashing based on record key for records with non-nil keys.
+
+
+Type: `bool`  
+Default: `false`  
 
 ### `partition`
 
@@ -363,6 +401,22 @@ max_message_bytes: 100MB
 
 max_message_bytes: 50mib
 ```
+
+### `max_buffered_records`
+
+Sets the max amount of records the client will buffer, blocking produces until records are finished if this limit is reached. This overrides the `franz-kafka` default of 10,000.
+
+
+Type: `int`  
+Default: `10000`  
+
+### `metadata_max_age`
+
+This sets the maximum age for the client's cached metadata, to allow detection of new topics, partitions, etc.
+
+
+Type: `string`  
+Default: `"5m"`  
 
 ### `compression`
 


### PR DESCRIPTION
Adds the following fields to `input.kafka_franz`:
- A list of `group_balancers` (default `cooperative_sticky`)
- `metadata_max_age` (default 5m)
- `fetch_max_bytes` (default 50MiB)
- `fetch_max_partition_bytes` (default 1MiB)
- `fetch_max_wait` (default 5s)
- `preferring_lag` (optional, no default)

Adds the following fields to `output.kafka_franz`:
- `partitioner` has a `uniform_bytes` enum
- `uniform_bytes_options` (default `{ "bytes" : "1MiB",  "adaptive" : false, "keys" : false }`)
  - Note: we do not yet allow specifying a `PartitionerHasher`. This approach should probably be reworked using bloblang with some lint rule.
- `max_buffered_records` (default 10K)
- `metadata_max_age` (default 5m)

A new integration test `TestIntegrationKafkaWarpstreamDefaults` has also been added with the performance tuning defaults found [here](https://docs.warpstream.com/warpstream/byoc/configure-kafka-client/tuning-for-performance#producer-configuration).
