### PR TITLE
add: LIFO option to dedupe processor

### DIFF
--- a/config/test/deduplicate_lifo.yaml
+++ b/config/test/deduplicate_lifo.yaml
@@ -1,0 +1,38 @@
+pipeline:
+  processors:
+    - dedupe:
+        cache: local
+        key: ${! json("user_uuid") }:${! json("month") }
+        strategy: LIFO
+
+cache_resources:
+  - label: local
+    memory:
+      default_ttl: 1m
+
+tests:
+  - name: de-duplicate LIFO across batches 
+    input_batches:
+      -
+        - content: '{"json":"data-1","month":"2024-01-01","user_uuid":"id-1"}'
+        - content: '{"json":"data-1","month":"2024-01-01","user_uuid":"id-2"}'
+        - content: '{"json":"data-1","month":"2024-01-01","user_uuid":"id-3"}'
+        - content: '{"json":"data-1","month":"2024-01-01","user_uuid":"id-4"}'
+        - content: '{"json":"updated-data-1","month":"2024-01-01","user_uuid":"id-1"}'
+      -
+        - content: '{"json":"data-2","month":"2024-02-01","user_uuid":"id-1"}'
+        - content: '{"json":"data-2","month":"2024-02-01","user_uuid":"id-2"}'
+        - content: '{"json":"data-2","month":"2024-02-01","user_uuid":"id-3"}'
+        - content: '{"json":"data-2","month":"2024-02-01","user_uuid":"id-4"}'
+        - content: '{"json":"updated-data-2","month":"2024-02-01","user_uuid":"id-1"}'
+    output_batches:
+      -
+        - json_equals: {"user_uuid": "id-2", "month": "2024-01-01", "json": "data-1"}
+        - json_equals: {"user_uuid": "id-3", "month": "2024-01-01", "json": "data-1"}
+        - json_equals: {"user_uuid": "id-4", "month": "2024-01-01", "json": "data-1"}
+        - json_equals: {"user_uuid": "id-1", "month": "2024-01-01", "json": "updated-data-1"}
+      -
+        - json_equals: {"user_uuid": "id-2", "month": "2024-02-01", "json": "data-2"}
+        - json_equals: {"user_uuid": "id-3", "month": "2024-02-01", "json": "data-2"}
+        - json_equals: {"user_uuid": "id-4", "month": "2024-02-01", "json": "data-2"}
+        - json_equals: {"user_uuid": "id-1", "month": "2024-02-01", "json": "updated-data-2"}

--- a/internal/impl/pure/processor_dedupe.go
+++ b/internal/impl/pure/processor_dedupe.go
@@ -41,7 +41,7 @@ This processor enacts on individual messages only, in order to perform a dedupli
 
 Performing deduplication on a stream using a distributed cache voids any at-least-once guarantees that it previously had. This is because the cache will preserve message signatures even if the message fails to leave the Bento pipeline, which would cause message loss in the event of an outage at the output sink followed by a restart of the Bento instance (or a server crash, etc).
 
-This problem can be mitigated by using an in-memory cache and distributing messages to horizontally scaled Bento pipelines partitioned by the deduplication key. However, in situations where at-least-once delivery guarantees are important it is worth avoiding deduplication in favour of implement idempotent behaviour at the edge of your stream pipelines.`).
+This problem can be mitigated by using an in-memory cache and distributing messages to horizontally scaled Bento pipelines partitioned by the deduplication key. However, in situations where at-least-once delivery guarantees are important it is worth avoiding deduplication in favour of implementing idempotent behaviour at the edge of your stream pipelines.`).
 		Example(
 			"Deduplicate based on Kafka key",
 			"The following configuration demonstrates a pipeline that deduplicates messages based on the Kafka key.",

--- a/website/docs/components/processors/dedupe.md
+++ b/website/docs/components/processors/dedupe.md
@@ -17,14 +17,38 @@ import TabItem from '@theme/TabItem';
 
 Deduplicates messages by storing a key value in a cache using the `add` operator. If the key already exists within the cache it is dropped.
 
+
+<Tabs defaultValue="common" values={[
+  { label: 'Common', value: 'common', },
+  { label: 'Advanced', value: 'advanced', },
+]}>
+
+<TabItem value="common">
+
 ```yml
-# Config fields, showing default values
+# Common config fields, showing default values
 label: ""
 dedupe:
   cache: "" # No default (required)
   key: ${! meta("kafka_key") } # No default (required)
   drop_on_err: true
 ```
+
+</TabItem>
+<TabItem value="advanced">
+
+```yml
+# All config fields, showing default values
+label: ""
+dedupe:
+  cache: "" # No default (required)
+  key: ${! meta("kafka_key") } # No default (required)
+  drop_on_err: true
+  strategy: FIFO
+```
+
+</TabItem>
+</Tabs>
 
 Caches must be configured as resources, for more information check out the [cache documentation here](/docs/components/caches/about).
 
@@ -72,6 +96,20 @@ Whether messages should be dropped when the cache returns a general error such a
 
 Type: `bool`  
 Default: `true`  
+
+### `strategy`
+
+Controls how to handle duplicate values.
+
+
+Type: `string`  
+Default: `"FIFO"`  
+
+| Option | Summary |
+|---|---|
+| `FIFO` | Keeps the first value seen for each key. |
+| `LIFO` | Keeps the last value seen for each key. |
+
 
 ## Examples
 

--- a/website/docs/components/processors/dedupe.md
+++ b/website/docs/components/processors/dedupe.md
@@ -62,7 +62,7 @@ This processor enacts on individual messages only, in order to perform a dedupli
 
 Performing deduplication on a stream using a distributed cache voids any at-least-once guarantees that it previously had. This is because the cache will preserve message signatures even if the message fails to leave the Bento pipeline, which would cause message loss in the event of an outage at the output sink followed by a restart of the Bento instance (or a server crash, etc).
 
-This problem can be mitigated by using an in-memory cache and distributing messages to horizontally scaled Bento pipelines partitioned by the deduplication key. However, in situations where at-least-once delivery guarantees are important it is worth avoiding deduplication in favour of implement idempotent behaviour at the edge of your stream pipelines.
+This problem can be mitigated by using an in-memory cache and distributing messages to horizontally scaled Bento pipelines partitioned by the deduplication key. However, in situations where at-least-once delivery guarantees are important it is worth avoiding deduplication in favour of implementing idempotent behaviour at the edge of your stream pipelines.
 
 ## Fields
 


### PR DESCRIPTION
### Changes

- Adds the ability to de-duplicate values in FIFO or LIFO order (FIFO by default.). 
- Adds a `strategy` key where this value can be set.