### PR TITLE
add: Jitter duration field to batching policy

### DIFF
--- a/internal/batch/policy/batchconfig/config.go
+++ b/internal/batch/policy/batchconfig/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Count      int                `json:"count" yaml:"count"`
 	Check      string             `json:"check" yaml:"check"`
 	Period     string             `json:"period" yaml:"period"`
+	Jitter     float64            `json:"jitter" yaml:"jitter"`
 	Processors []processor.Config `json:"processors" yaml:"processors"`
 }
 
@@ -18,6 +19,7 @@ func NewConfig() Config {
 	return Config{
 		ByteSize:   0,
 		Count:      0,
+		Jitter:     0,
 		Check:      "",
 		Period:     "",
 		Processors: []processor.Config{},

--- a/internal/batch/policy/docs.go
+++ b/internal/batch/policy/docs.go
@@ -24,6 +24,11 @@ Allows you to configure a [batching policy](/docs/configuration/batching).`,
 				"period": "1m",
 				"check":  `this.contains("END BATCH")`,
 			},
+			map[string]any{
+				"count":  10,
+				"period": "10s",
+				"jitter": "500ms",
+			},
 		},
 		Children: docs.FieldSpecs{
 			docs.FieldInt(
@@ -39,6 +44,10 @@ Allows you to configure a [batching policy](/docs/configuration/batching).`,
 				"A period in which an incomplete batch should be flushed regardless of its size.",
 				"1s", "1m", "500ms",
 			).HasDefault(""),
+			docs.FieldFloat("jitter",
+				"A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.",
+				"0.01", "0.1", "1",
+			).HasDefault(0).LinterBlobl(`root = if this < 0 { "Cannot set a negative jitter factor" }`),
 			docs.FieldBloblang(
 				"check",
 				"A [Bloblang query](/docs/guides/bloblang/about/) that should return a boolean value indicating whether a message should end a batch.",

--- a/internal/batch/policy/policy.go
+++ b/internal/batch/policy/policy.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"golang.org/x/exp/rand"
+
 	"github.com/warpstreamlabs/bento/internal/batch/policy/batchconfig"
 	"github.com/warpstreamlabs/bento/internal/bloblang/mapping"
 	"github.com/warpstreamlabs/bento/internal/bundle"
@@ -14,7 +16,6 @@ import (
 	iprocessor "github.com/warpstreamlabs/bento/internal/component/processor"
 	"github.com/warpstreamlabs/bento/internal/log"
 	"github.com/warpstreamlabs/bento/internal/message"
-	"golang.org/x/exp/rand"
 )
 
 // Batcher implements a batching policy by buffering messages until, based on a
@@ -63,7 +64,7 @@ func New(conf batchconfig.Config, mgr bundle.NewManagement) (*Batcher, error) {
 	}
 
 	if conf.Jitter < 0 {
-		return nil, fmt.Errorf("jitter factor cannot be negative")
+		return nil, errors.New("jitter factor cannot be negative")
 	}
 
 	var procs []iprocessor.V1

--- a/internal/batch/policy/policy_test.go
+++ b/internal/batch/policy/policy_test.go
@@ -2,6 +2,7 @@ package policy_test
 
 import (
 	"context"
+	"math/rand"
 	"reflect"
 	"testing"
 	"time"
@@ -124,6 +125,49 @@ func TestPolicyPeriod(t *testing.T) {
 
 	if v := pol.UntilNext(); v >= (time.Millisecond*300) || v < (time.Millisecond*100) {
 		t.Errorf("Wrong period: %v", v)
+	}
+}
+
+func TestPolicyPeriodJitter(t *testing.T) {
+	conf := batchconfig.NewConfig()
+	conf.Period = "100ms"
+	conf.Jitter = 0.5
+
+	pol, err := policy.New(conf, mock.NewManager())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tCtx, done := context.WithTimeout(context.Background(), time.Second*30)
+	t.Cleanup(func() {
+		require.NoError(t, pol.Close(tCtx))
+		done()
+	})
+
+	// Set RNG seed to ensure deterministic test runs
+	rand.Seed(1)
+	for i := 0; i < 10; i++ {
+
+		if pol.Add(message.NewPart(nil)) {
+			t.Error("Unexpected batch ready")
+		}
+
+		if v := pol.UntilNext(); v >= (time.Millisecond*150) || v < (time.Millisecond*100) {
+			t.Errorf("Wrong period: %v", v)
+		}
+
+		<-time.After(time.Millisecond * 150)
+		if v := pol.UntilNext(); v >= (time.Millisecond * 100) {
+			t.Errorf("Wrong period: %v", v)
+		}
+
+		if v := pol.Flush(tCtx); v == nil {
+			t.Error("Nil msgs from flush")
+		}
+
+		if v := pol.UntilNext(); v >= (time.Millisecond*150) || v < (time.Millisecond*100) {
+			t.Errorf("Wrong period: %v", v)
+		}
 	}
 }
 

--- a/internal/batch/policy/policy_test.go
+++ b/internal/batch/policy/policy_test.go
@@ -145,6 +145,7 @@ func TestPolicyPeriodJitter(t *testing.T) {
 	})
 
 	// Set RNG seed to ensure deterministic test runs
+	//nolint:staticcheck
 	rand.Seed(1)
 	for i := 0; i < 10; i++ {
 

--- a/public/service/config_batch_policy.go
+++ b/public/service/config_batch_policy.go
@@ -20,7 +20,7 @@ type BatchPolicy struct {
 	Count    int
 	Check    string
 	Period   string
-
+	Jitter   float64
 	// Only available when using NewBatchPolicyField.
 	procs []processor.Config
 }
@@ -31,6 +31,7 @@ func (b BatchPolicy) toInternal() batchconfig.Config {
 	batchConf.Count = b.Count
 	batchConf.Check = b.Check
 	batchConf.Period = b.Period
+	batchConf.Jitter = b.Jitter
 	batchConf.Processors = b.procs
 	return batchConf
 }
@@ -154,6 +155,9 @@ func (p *ParsedConfig) FieldBatchPolicy(path ...string) (conf BatchPolicy, err e
 		return
 	}
 	if conf.Period, err = p.FieldString(append(path, "period")...); err != nil {
+		return
+	}
+	if conf.Jitter, err = p.FieldFloat(append(path, "jitter")...); err != nil {
 		return
 	}
 	conf.procs, err = p.fieldProcessorListConfigs(append(path, "processors")...)

--- a/website/docs/components/buffers/memory.md
+++ b/website/docs/components/buffers/memory.md
@@ -35,6 +35,7 @@ buffer:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -51,6 +52,7 @@ buffer:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -127,6 +129,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batch_policy.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batch_policy.check`

--- a/website/docs/components/inputs/aws_kinesis.md
+++ b/website/docs/components/inputs/aws_kinesis.md
@@ -44,6 +44,7 @@ input:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -82,6 +83,7 @@ input:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -325,6 +327,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -359,6 +366,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/inputs/batched.md
+++ b/website/docs/components/inputs/batched.md
@@ -37,6 +37,7 @@ input:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -53,6 +54,7 @@ input:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -94,6 +96,11 @@ policy:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+policy:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `policy.count`
@@ -128,6 +135,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `policy.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `policy.check`

--- a/website/docs/components/inputs/broker.md
+++ b/website/docs/components/inputs/broker.md
@@ -35,6 +35,7 @@ input:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -52,6 +53,7 @@ input:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -139,6 +141,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -173,6 +180,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -82,6 +82,7 @@ input:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -566,6 +567,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -600,6 +606,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -80,6 +80,7 @@ input:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -607,6 +608,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -641,6 +647,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/aws_dynamodb.md
+++ b/website/docs/components/outputs/aws_dynamodb.md
@@ -40,6 +40,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -61,6 +62,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     region: ""
@@ -215,6 +217,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -249,6 +256,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/aws_kinesis.md
+++ b/website/docs/components/outputs/aws_kinesis.md
@@ -39,6 +39,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -58,6 +59,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     region: ""
@@ -156,6 +158,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -190,6 +197,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/aws_kinesis_firehose.md
+++ b/website/docs/components/outputs/aws_kinesis_firehose.md
@@ -38,6 +38,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -55,6 +56,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     region: ""
@@ -128,6 +130,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -162,6 +169,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/aws_s3.md
+++ b/website/docs/components/outputs/aws_s3.md
@@ -43,6 +43,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -75,6 +76,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     region: ""
@@ -343,6 +345,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -377,6 +384,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/aws_sqs.md
+++ b/website/docs/components/outputs/aws_sqs.md
@@ -43,6 +43,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -65,6 +66,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     region: ""
@@ -180,6 +182,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -214,6 +221,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/azure_cosmosdb.md
+++ b/website/docs/components/outputs/azure_cosmosdb.md
@@ -47,6 +47,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
     max_in_flight: 64
 ```
@@ -74,6 +75,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     max_in_flight: 64
@@ -389,6 +391,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -423,6 +430,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/azure_queue_storage.md
+++ b/website/docs/components/outputs/azure_queue_storage.md
@@ -45,6 +45,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -67,6 +68,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -176,6 +178,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -210,6 +217,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/azure_table_storage.md
+++ b/website/docs/components/outputs/azure_table_storage.md
@@ -48,6 +48,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -74,6 +75,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -272,6 +274,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -306,6 +313,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/broker.md
+++ b/website/docs/components/outputs/broker.md
@@ -36,6 +36,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -54,6 +55,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -128,6 +130,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -162,6 +169,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/cassandra.md
+++ b/website/docs/components/outputs/cassandra.md
@@ -41,6 +41,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -79,6 +80,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -451,6 +453,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -485,6 +492,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/elasticsearch.md
+++ b/website/docs/components/outputs/elasticsearch.md
@@ -39,6 +39,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -81,6 +82,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     aws:
@@ -450,6 +452,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -484,6 +491,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/gcp_bigquery.md
+++ b/website/docs/components/outputs/gcp_bigquery.md
@@ -48,6 +48,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -81,6 +82,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -303,6 +305,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -337,6 +344,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/gcp_bigquery_write_api.md
+++ b/website/docs/components/outputs/gcp_bigquery_write_api.md
@@ -59,6 +59,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     max_in_flight: 64
@@ -165,6 +166,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -199,6 +205,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/gcp_cloud_storage.md
+++ b/website/docs/components/outputs/gcp_cloud_storage.md
@@ -45,6 +45,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -68,6 +69,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -244,6 +246,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -278,6 +285,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/gcp_pubsub.md
+++ b/website/docs/components/outputs/gcp_pubsub.md
@@ -43,6 +43,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -73,6 +74,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -264,6 +266,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -298,6 +305,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/hdfs.md
+++ b/website/docs/components/outputs/hdfs.md
@@ -39,6 +39,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -59,6 +60,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -143,6 +145,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -177,6 +184,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -40,6 +40,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -108,6 +109,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     multipart: []
@@ -743,6 +745,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -777,6 +784,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -44,6 +44,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -96,6 +97,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     max_retries: 0
@@ -601,6 +603,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -635,6 +642,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/kafka_franz.md
+++ b/website/docs/components/outputs/kafka_franz.md
@@ -47,6 +47,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -79,6 +80,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     max_message_bytes: 1MB
@@ -313,6 +315,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -347,6 +354,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/mongodb.md
+++ b/website/docs/components/outputs/mongodb.md
@@ -54,6 +54,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -84,6 +85,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -275,6 +277,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -309,6 +316,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/opensearch.md
+++ b/website/docs/components/outputs/opensearch.md
@@ -39,6 +39,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -72,6 +73,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     aws:
@@ -394,6 +396,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -428,6 +435,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/pusher.md
+++ b/website/docs/components/outputs/pusher.md
@@ -39,6 +39,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
     channel: my_channel # No default (required)
     event: "" # No default (required)
@@ -62,6 +63,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     channel: my_channel # No default (required)
@@ -102,6 +104,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -136,6 +143,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/questdb.md
+++ b/website/docs/components/outputs/questdb.md
@@ -38,6 +38,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
     address: localhost:9000 # No default (required)
     username: "" # No default (optional)
@@ -66,6 +67,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     tls:
@@ -138,6 +140,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -172,6 +179,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/redis_list.md
+++ b/website/docs/components/outputs/redis_list.md
@@ -37,6 +37,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -64,6 +65,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     command: rpush
@@ -323,6 +325,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -357,6 +364,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/redis_pubsub.md
+++ b/website/docs/components/outputs/redis_pubsub.md
@@ -37,6 +37,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -64,6 +65,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -310,6 +312,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -344,6 +351,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/redis_streams.md
+++ b/website/docs/components/outputs/redis_streams.md
@@ -41,6 +41,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -72,6 +73,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -351,6 +353,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -385,6 +392,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/snowflake_put.md
+++ b/website/docs/components/outputs/snowflake_put.md
@@ -57,6 +57,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
     max_in_flight: 1
 ```
@@ -93,6 +94,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
     max_in_flight: 1
@@ -664,6 +666,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -698,6 +705,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/sql.md
+++ b/website/docs/components/outputs/sql.md
@@ -44,6 +44,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -64,6 +65,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -164,6 +166,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -198,6 +205,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -42,6 +42,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -89,6 +90,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -447,6 +449,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -481,6 +488,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`

--- a/website/docs/components/outputs/sql_raw.md
+++ b/website/docs/components/outputs/sql_raw.md
@@ -41,6 +41,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
 ```
 
@@ -86,6 +87,7 @@ output:
       count: 0
       byte_size: 0
       period: ""
+      jitter: 0
       check: ""
       processors: [] # No default (optional)
 ```
@@ -428,6 +430,11 @@ batching:
   check: this.contains("END BATCH")
   count: 0
   period: 1m
+
+batching:
+  count: 10
+  jitter: 500ms
+  period: 10s
 ```
 
 ### `batching.count`
@@ -462,6 +469,24 @@ period: 1s
 period: 1m
 
 period: 500ms
+```
+
+### `batching.jitter`
+
+A factor, proportional to `period`, that adds random delay between batch intervals to prevent synchronized flushes. For example, 0.1 adds up to 10% random delay.
+
+
+Type: `float`  
+Default: `0`  
+
+```yml
+# Examples
+
+jitter: "0.01"
+
+jitter: "0.1"
+
+jitter: "1"
 ```
 
 ### `batching.check`


### PR DESCRIPTION
## Changes
This PR introduces a new field to Bento's `batching` policy that allows for jittered flushes of new batches. The actual jittered delay is calculated as a random duration between `0-jitter*period`.

A lot of docs are updated as a result of this which have been added in a seperate commit.

