### PR TITLE
Fix typo in subprocess input documentation

### DIFF
--- a/internal/impl/io/input_subprocess.go
+++ b/internal/impl/io/input_subprocess.go
@@ -27,7 +27,7 @@ func subprocInputSpec() *service.ConfigSpec {
 		Categories("Utility").
 		Summary("Executes a command, runs it as a subprocess, and consumes messages from it over stdout.").
 		Description(`
-Messages are consumed according to a specified codec. The command is executed once and if it terminates the input also closes down gracefully. Alternatively, the field `+"`restart_on_close` can be set to `true`"+` in order to have Bento re-execute the command each time it stops.
+Messages are consumed according to a specified codec. The command is executed once and if it terminates the input also closes down gracefully. Alternatively, the field `+"`restart_on_exit` can be set to `true`"+` in order to have Bento re-execute the command each time it stops.
 
 The field `+"`max_buffer`"+` defines the maximum message size able to be read from the subprocess. This value should be set significantly above the real expected maximum message size.
 

--- a/website/docs/components/inputs/subprocess.md
+++ b/website/docs/components/inputs/subprocess.md
@@ -57,7 +57,7 @@ input:
 </TabItem>
 </Tabs>
 
-Messages are consumed according to a specified codec. The command is executed once and if it terminates the input also closes down gracefully. Alternatively, the field `restart_on_close` can be set to `true` in order to have Bento re-execute the command each time it stops.
+Messages are consumed according to a specified codec. The command is executed once and if it terminates the input also closes down gracefully. Alternatively, the field `restart_on_exit` can be set to `true` in order to have Bento re-execute the command each time it stops.
 
 The field `max_buffer` defines the maximum message size able to be read from the subprocess. This value should be set significantly above the real expected maximum message size.
 


### PR DESCRIPTION
I noticed a small typo in the `subprocess` input documentation. The configuration field is `restart_on_exit`, but documentation refers to `restart_on_close`.

I've just fixed the wording on the source component and then executed `make docs` to generate the updated documentation.

It's a super minor change, but I wanted it to get out of my head :)

Thank you!