### PR TITLE
Remove unused poke function references from JS

### DIFF
--- a/website/src/plugins/analytics/client.js
+++ b/website/src/plugins/analytics/client.js
@@ -6,14 +6,12 @@ module.exports = (() => {
   const host = window.location.hostname;
   let path = window.location.pathname;
 
-  poke(host, path);
   return {
     onRouteUpdate({location}) {
       if ( path === location.pathname ) {
         return;
       }
       path = location.pathname;
-      poke(host, path);
     },
   };
 })();


### PR DESCRIPTION
## Changes
- Remove the super-duper important `poke` function from the website's JS.
- Not sure how the doc-site will ever function without you.
- Goodnight sweet prince.