### PR TITLE
Add new rate limiting functionality to rate-limit bytes

### DIFF
--- a/internal/component/ratelimit/message_rate_limit.go
+++ b/internal/component/ratelimit/message_rate_limit.go
@@ -1,0 +1,26 @@
+package ratelimit
+
+import (
+	"context"
+	"time"
+
+	"github.com/warpstreamlabs/bento/internal/message"
+)
+
+// MessageAwareRateLimiter extends RateLimiter with message-specific rate limiting
+type MessageAwareRateLimiter interface {
+	// Add a new message part to the rate limiter. Returns true if this part triggers
+	// the conditions of the rate-limiter.
+	Add(ctx context.Context, msg *message.Part) bool
+
+	// Access the rate limited resource. Returns a duration or an error if the
+	// rate limit check fails. The returned duration is either zero (meaning the
+	// resource may be accessed) or a reasonable length of time to wait before
+	// requesting again.
+	Access(ctx context.Context) (time.Duration, error)
+
+	// Close the component, blocks until either the underlying resources are
+	// cleaned up or the context is cancelled. Returns an error if the context
+	// is cancelled.
+	Close(ctx context.Context) error
+}

--- a/internal/component/ratelimit/message_rate_limit.go
+++ b/internal/component/ratelimit/message_rate_limit.go
@@ -8,10 +8,10 @@ import (
 )
 
 // MessageAwareRateLimiter extends RateLimiter with message-specific rate limiting
-type MessageAwareRateLimiter interface {
+type MessageAwareRateLimit interface {
 	// Add a new message part to the rate limiter. Returns true if this part triggers
 	// the conditions of the rate-limiter.
-	Add(ctx context.Context, msg *message.Part) bool
+	Add(ctx context.Context, parts ...*message.Part) bool
 
 	// Access the rate limited resource. Returns a duration or an error if the
 	// rate limit check fails. The returned duration is either zero (meaning the

--- a/internal/component/ratelimit/rate_limit_metrics.go
+++ b/internal/component/ratelimit/rate_limit_metrics.go
@@ -46,7 +46,7 @@ func (r *metricsRateLimit) Close(ctx context.Context) error {
 //------------------------------------------------------------------------------
 
 type metricsMessageAwareRateLimit struct {
-	r MessageAwareRateLimiter
+	r MessageAwareRateLimit
 
 	mChecked metrics.StatCounter
 	mLimited metrics.StatCounter
@@ -55,7 +55,7 @@ type metricsMessageAwareRateLimit struct {
 
 // MetricsForRateLimit wraps a ratelimit.V2 with a struct that implements
 // types.RateLimit.
-func MetricsForMessageAwareRateLimit(r MessageAwareRateLimiter, stats metrics.Type) MessageAwareRateLimiter {
+func MetricsForMessageAwareRateLimit(r MessageAwareRateLimit, stats metrics.Type) MessageAwareRateLimit {
 	return &metricsMessageAwareRateLimit{
 		r: r,
 
@@ -65,8 +65,8 @@ func MetricsForMessageAwareRateLimit(r MessageAwareRateLimiter, stats metrics.Ty
 	}
 }
 
-func (r *metricsMessageAwareRateLimit) Add(ctx context.Context, msg *message.Part) bool {
-	return r.r.Add(ctx, msg)
+func (r *metricsMessageAwareRateLimit) Add(ctx context.Context, parts ...*message.Part) bool {
+	return r.r.Add(ctx, parts...)
 }
 
 func (r *metricsMessageAwareRateLimit) Access(ctx context.Context) (time.Duration, error) {

--- a/internal/component/ratelimit/rate_limit_metrics.go
+++ b/internal/component/ratelimit/rate_limit_metrics.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/warpstreamlabs/bento/internal/component/metrics"
+	"github.com/warpstreamlabs/bento/internal/message"
 )
 
 type metricsRateLimit struct {
@@ -39,5 +40,46 @@ func (r *metricsRateLimit) Access(ctx context.Context) (time.Duration, error) {
 }
 
 func (r *metricsRateLimit) Close(ctx context.Context) error {
+	return r.r.Close(ctx)
+}
+
+//------------------------------------------------------------------------------
+
+type metricsMessageAwareRateLimit struct {
+	r MessageAwareRateLimiter
+
+	mChecked metrics.StatCounter
+	mLimited metrics.StatCounter
+	mErr     metrics.StatCounter
+}
+
+// MetricsForRateLimit wraps a ratelimit.V2 with a struct that implements
+// types.RateLimit.
+func MetricsForMessageAwareRateLimit(r MessageAwareRateLimiter, stats metrics.Type) MessageAwareRateLimiter {
+	return &metricsMessageAwareRateLimit{
+		r: r,
+
+		mChecked: stats.GetCounter("rate_limit_checked"),
+		mLimited: stats.GetCounter("rate_limit_triggered"),
+		mErr:     stats.GetCounter("rate_limit_error"),
+	}
+}
+
+func (r *metricsMessageAwareRateLimit) Add(ctx context.Context, msg *message.Part) bool {
+	return r.r.Add(ctx, msg)
+}
+
+func (r *metricsMessageAwareRateLimit) Access(ctx context.Context) (time.Duration, error) {
+	r.mChecked.Incr(1)
+	tout, err := r.r.Access(ctx)
+	if err != nil {
+		r.mErr.Incr(1)
+	} else if tout > 0 {
+		r.mLimited.Incr(1)
+	}
+	return tout, err
+}
+
+func (r *metricsMessageAwareRateLimit) Close(ctx context.Context) error {
 	return r.r.Close(ctx)
 }

--- a/internal/impl/pure/processor_rate_limit.go
+++ b/internal/impl/pure/processor_rate_limit.go
@@ -74,7 +74,13 @@ func (r *rateLimitProc) Process(ctx context.Context, msg *message.Part) ([]*mess
 		var waitFor time.Duration
 		var err error
 		if rerr := r.mgr.AccessRateLimit(ctx, r.rlName, func(rl ratelimit.V1) {
+			v2, ok := rl.(ratelimit.MessageAwareRateLimiter)
+			if ok {
+				v2.Add(ctx, msg)
+			}
+
 			waitFor, err = rl.Access(ctx)
+
 		}); rerr != nil {
 			err = rerr
 		}

--- a/internal/impl/pure/processor_rate_limit.go
+++ b/internal/impl/pure/processor_rate_limit.go
@@ -74,7 +74,7 @@ func (r *rateLimitProc) Process(ctx context.Context, msg *message.Part) ([]*mess
 		var waitFor time.Duration
 		var err error
 		if rerr := r.mgr.AccessRateLimit(ctx, r.rlName, func(rl ratelimit.V1) {
-			v2, ok := rl.(ratelimit.MessageAwareRateLimiter)
+			v2, ok := rl.(ratelimit.MessageAwareRateLimit)
 			if ok {
 				v2.Add(ctx, msg)
 			}

--- a/internal/impl/pure/rate_limit_local.go
+++ b/internal/impl/pure/rate_limit_local.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/warpstreamlabs/bento/internal/message"
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
@@ -14,8 +15,11 @@ func localRatelimitConfig() *service.ConfigSpec {
 		Stable().
 		Summary(`The local rate limit is a simple X every Y type rate limit that can be shared across any number of components within the pipeline but does not support distributed rate limits across multiple running instances of Bento.`).
 		Field(service.NewIntField("count").
-			Description("The maximum number of requests to allow for a given period of time.").
-			Default(1000)).
+			Description("The maximum number of requests to allow for a given period of time. If `0` disables count based rate-limiting.").
+			Default(1000).LintRule(`root = if this < 0 { [ "count cannot be less than zero" ] }`)).
+		Field(service.NewIntField("byte_size").
+			Description("The maximum number of bytes to allow for a given period of time. If `0` disables size based rate-limiting.").
+			Default(0).LintRule(`root = if this < 0 { [ "byte_size cannot be less than zero" ] }`)).
 		Field(service.NewDurationField("interval").
 			Description("The time window to limit requests by.").
 			Default("1s"))
@@ -39,53 +43,106 @@ func newLocalRatelimitFromConfig(conf *service.ParsedConfig) (*localRatelimit, e
 	if err != nil {
 		return nil, err
 	}
+	byteSize, err := conf.FieldInt("byte_size")
+	if err != nil {
+		return nil, err
+	}
 	interval, err := conf.FieldDuration("interval")
 	if err != nil {
 		return nil, err
 	}
-	return newLocalRatelimit(count, interval)
+	return newLocalRatelimit(count, byteSize, interval)
 }
 
 //------------------------------------------------------------------------------
 
 type localRatelimit struct {
-	mut         sync.Mutex
-	bucket      int
-	lastRefresh time.Time
+	mut           sync.Mutex // TODO: We should rather be using atomics as opposed to locking
+	bucket        int
+	byteBucket    int
+	exceededLimit bool
+	lastRefresh   time.Time
 
-	size   int
-	period time.Duration
+	size     int
+	byteSize int
+	period   time.Duration
 }
 
-func newLocalRatelimit(count int, interval time.Duration) (*localRatelimit, error) {
-	if count <= 0 {
-		return nil, errors.New("count must be larger than zero")
+func newLocalRatelimit(count, byteSize int, interval time.Duration) (*localRatelimit, error) {
+	if byteSize < 0 || count < 0 {
+		return nil, errors.New("neither byte size nor count can be negative")
 	}
+
+	if byteSize == 0 && count == 0 {
+		return nil, errors.New("either count or byte size must be larger than zero")
+	}
+
 	return &localRatelimit{
-		bucket:      count,
-		lastRefresh: time.Now(),
-		size:        count,
-		period:      interval,
+		bucket:        count,
+		byteBucket:    byteSize,
+		exceededLimit: false,
+		lastRefresh:   time.Now(),
+
+		size:     count,
+		byteSize: byteSize,
+		period:   interval,
 	}, nil
 }
 
 func (r *localRatelimit) Access(ctx context.Context) (time.Duration, error) {
 	r.mut.Lock()
-	r.bucket--
+	defer r.mut.Unlock()
 
-	if r.bucket < 0 {
-		r.bucket = 0
-		remaining := r.period - time.Since(r.lastRefresh)
-
-		if remaining > 0 {
-			r.mut.Unlock()
-			return remaining, nil
-		}
-		r.bucket = r.size - 1
-		r.lastRefresh = time.Now()
+	if !r.exceededLimit {
+		return 0, nil
 	}
-	r.mut.Unlock()
+
+	remaining := r.period - time.Since(r.lastRefresh)
+	if remaining > 0 {
+		return remaining, nil
+	}
+
+	// The interval has passed so reset
+	r.refresh()
 	return 0, nil
+}
+
+// Add increments the observation or message-bytes counter. Returns true if this
+// triggers the conditions of the rate-limiter.
+func (r *localRatelimit) Add(ctx context.Context, part *message.Part) bool {
+	r.mut.Lock()
+	defer r.mut.Unlock()
+
+	if time.Since(r.lastRefresh) >= r.period {
+		r.refresh()
+	}
+
+	if r.exceededLimit {
+		return true
+	}
+
+	// Rate limiting count is enabled
+	if r.size > 0 {
+		r.bucket--
+	}
+
+	// Rate limiting bytes is enabled
+	if r.byteSize > 0 && part != nil {
+		r.byteBucket -= len(part.AsBytes())
+	}
+
+	if r.bucket < 0 || r.byteBucket < 0 {
+		r.exceededLimit = true
+	}
+
+	return r.exceededLimit
+}
+
+func (r *localRatelimit) refresh() {
+	r.byteBucket = r.byteSize
+	r.bucket = r.size
+	r.lastRefresh = time.Now()
+	r.exceededLimit = false
 }
 
 func (r *localRatelimit) Close(ctx context.Context) error {

--- a/internal/impl/pure/rate_limit_local_test.go
+++ b/internal/impl/pure/rate_limit_local_test.go
@@ -8,10 +8,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/warpstreamlabs/bento/internal/message"
 )
 
 func TestLocalRateLimitConfErrors(t *testing.T) {
 	conf, err := localRatelimitConfig().ParseYAML(`count: -1`, nil)
+	require.NoError(t, err)
+
+	_, err = newLocalRatelimitFromConfig(conf)
+	require.Error(t, err)
+
+	conf, err = localRatelimitConfig().ParseYAML(`byte_size: -1`, nil)
+	require.NoError(t, err)
+
+	_, err = newLocalRatelimitFromConfig(conf)
+	require.Error(t, err)
+
+	// This will fail as byte_size is set to 0 by default and we cannot have count=0 and byte_size=0
+	conf, err = localRatelimitConfig().ParseYAML(`count: 0`, nil)
 	require.NoError(t, err)
 
 	_, err = newLocalRatelimitFromConfig(conf)
@@ -37,10 +51,47 @@ interval: 1s
 	ctx := context.Background()
 
 	for i := 0; i < 10; i++ {
+		exceeded := rl.Add(ctx, nil)
+		assert.False(t, exceeded)
+
 		period, _ := rl.Access(ctx)
 		assert.LessOrEqual(t, period, time.Duration(0))
 	}
 
+	assert.True(t, rl.Add(ctx, nil), "Expected rate limit to be reached")
+	if period, _ := rl.Access(ctx); period == 0 {
+		t.Error("Expected limit on final request")
+	} else if period > time.Second {
+		t.Errorf("Period beyond interval: %v", period)
+	}
+}
+
+func TestLocalRateLimitBytesBasic(t *testing.T) {
+	conf, err := localRatelimitConfig().ParseYAML(`
+byte_size: 100
+interval: 1s
+`, nil)
+	require.NoError(t, err)
+
+	rl, err := newLocalRatelimitFromConfig(conf)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	msgBytes := make([][]byte, 10)
+
+	for i := 0; i < len(msgBytes); i++ {
+		msgBytes[i] = make([]byte, 10)
+	}
+	batch := message.QuickBatch(msgBytes)
+
+	for _, msg := range batch {
+		assert.False(t, rl.Add(ctx, msg))
+		period, _ := rl.Access(ctx)
+		assert.LessOrEqual(t, period, time.Duration(0))
+	}
+
+	assert.True(t, rl.Add(ctx, batch[0]), "Expected rate limit to be reached")
 	if period, _ := rl.Access(ctx); period == 0 {
 		t.Error("Expected limit on final request")
 	} else if period > time.Second {
@@ -61,12 +112,14 @@ interval: 10ms
 	ctx := context.Background()
 
 	for i := 0; i < 10; i++ {
+		assert.False(t, rl.Add(ctx, nil))
 		period, _ := rl.Access(ctx)
 		if period > 0 {
 			t.Errorf("Period above zero: %v", period)
 		}
 	}
 
+	assert.True(t, rl.Add(ctx, nil))
 	if period, _ := rl.Access(ctx); period == 0 {
 		t.Error("Expected limit on final request")
 	} else if period > time.Second {
@@ -76,12 +129,119 @@ interval: 10ms
 	<-time.After(time.Millisecond * 15)
 
 	for i := 0; i < 10; i++ {
+		assert.False(t, rl.Add(ctx, nil))
 		period, _ := rl.Access(ctx)
 		if period != 0 {
 			t.Errorf("Rate limited on get %v", i)
 		}
 	}
 
+	assert.True(t, rl.Add(ctx, nil))
+	if period, _ := rl.Access(ctx); period == 0 {
+		t.Error("Expected limit on final request")
+	} else if period > time.Second {
+		t.Errorf("Period beyond interval: %v", period)
+	}
+}
+
+func TestLocalRateLimitRefreshBytes(t *testing.T) {
+	conf, err := localRatelimitConfig().ParseYAML(`
+byte_size: 100
+interval: 10ms
+`, nil)
+	require.NoError(t, err)
+
+	rl, err := newLocalRatelimitFromConfig(conf)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	msgBytes := make([][]byte, 10)
+
+	for i := 0; i < len(msgBytes); i++ {
+		msgBytes[i] = make([]byte, 10)
+	}
+	batch := message.QuickBatch(msgBytes)
+
+	for _, msg := range batch {
+		assert.False(t, rl.Add(ctx, msg))
+		period, _ := rl.Access(ctx)
+		assert.LessOrEqual(t, period, time.Duration(0))
+	}
+
+	assert.True(t, rl.Add(ctx, batch[0]), "Expected rate limit to be reached")
+	if period, _ := rl.Access(ctx); period == 0 {
+		t.Error("Expected limit on final request")
+	} else if period > time.Second {
+		t.Errorf("Period beyond interval: %v", period)
+	}
+
+	<-time.After(time.Millisecond * 15)
+
+	for i, msg := range batch {
+		assert.False(t, rl.Add(ctx, msg))
+		period, _ := rl.Access(ctx)
+		if period != 0 {
+			t.Errorf("Rate limited on get %v", i)
+		}
+	}
+
+	assert.True(t, rl.Add(ctx, batch[0]))
+	if period, _ := rl.Access(ctx); period == 0 {
+		t.Error("Expected limit on final request")
+	} else if period > time.Second {
+		t.Errorf("Period beyond interval: %v", period)
+	}
+}
+
+func TestLocalRateLimitRefreshBytesAndCount(t *testing.T) {
+	conf, err := localRatelimitConfig().ParseYAML(`
+byte_size: 100
+count: 15
+interval: 10ms
+`, nil)
+	require.NoError(t, err)
+
+	rl, err := newLocalRatelimitFromConfig(conf)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	msgWith10Bytes := message.NewPart(make([]byte, 10))
+	msgWith5Bytes := message.NewPart(make([]byte, 5))
+
+	for i := 0; i < 10; i++ {
+		assert.False(t, rl.Add(ctx, msgWith10Bytes))
+		period, _ := rl.Access(ctx)
+		assert.LessOrEqual(t, period, time.Duration(0))
+	}
+
+	assert.Equal(t, 5, rl.bucket)
+	assert.Equal(t, 0, rl.byteBucket)
+
+	// Rate limit on 11th request since byte_size is reached
+	assert.True(t, rl.Add(ctx, msgWith10Bytes), "Expected rate limit to be reached")
+	if period, _ := rl.Access(ctx); period == 0 {
+		t.Error("Expected limit on final request")
+	} else if period > time.Second {
+		t.Errorf("Period beyond interval: %v", period)
+	}
+
+	<-time.After(time.Millisecond * 15)
+
+	for i := 0; i < 15; i++ {
+		assert.False(t, rl.Add(ctx, msgWith5Bytes))
+		period, _ := rl.Access(ctx)
+		if period != 0 {
+			t.Errorf("Rate limited on get %v", i)
+		}
+	}
+
+	assert.Equal(t, 0, rl.bucket)
+	assert.Equal(t, 25, rl.byteBucket)
+
+	// rate limit on 16th request since count is reached
+	assert.True(t, rl.Add(ctx, msgWith5Bytes))
 	if period, _ := rl.Access(ctx); period == 0 {
 		t.Error("Expected limit on final request")
 	} else if period > time.Second {
@@ -125,6 +285,7 @@ interval: 1ns
 		go func() {
 			<-startChan
 			for j := 0; j < b.N; j++ {
+				rl.Add(ctx, nil)
 				period, _ := rl.Access(ctx)
 				if period > 0 {
 					time.Sleep(period)

--- a/internal/impl/pure/rate_limit_local_test.go
+++ b/internal/impl/pure/rate_limit_local_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/internal/message"
 )
 
@@ -58,7 +59,6 @@ interval: 1s
 		assert.LessOrEqual(t, period, time.Duration(0))
 	}
 
-	assert.True(t, rl.Add(ctx, nil), "Expected rate limit to be reached")
 	if period, _ := rl.Access(ctx); period == 0 {
 		t.Error("Expected limit on final request")
 	} else if period > time.Second {
@@ -119,7 +119,6 @@ interval: 10ms
 		}
 	}
 
-	assert.True(t, rl.Add(ctx, nil))
 	if period, _ := rl.Access(ctx); period == 0 {
 		t.Error("Expected limit on final request")
 	} else if period > time.Second {
@@ -136,7 +135,6 @@ interval: 10ms
 		}
 	}
 
-	assert.True(t, rl.Add(ctx, nil))
 	if period, _ := rl.Access(ctx); period == 0 {
 		t.Error("Expected limit on final request")
 	} else if period > time.Second {
@@ -241,7 +239,6 @@ interval: 10ms
 	assert.Equal(t, 25, rl.byteBucket)
 
 	// rate limit on 16th request since count is reached
-	assert.True(t, rl.Add(ctx, msgWith5Bytes))
 	if period, _ := rl.Access(ctx); period == 0 {
 		t.Error("Expected limit on final request")
 	} else if period > time.Second {

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -498,6 +498,11 @@ func (e *Environment) RegisterRateLimit(name string, spec *ConfigSpec, ctor Rate
 		if err != nil {
 			return nil, err
 		}
+		// Check if the implementation is message-aware
+		if msgAware, ok := r.(MessageAwareRateLimit); ok {
+			return newAirGapMessageAwareRateLimit(msgAware, nm.Metrics()), nil
+		}
+
 		return newAirGapRateLimit(r, nm.Metrics()), nil
 	}, componentSpec)
 }

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -498,9 +498,11 @@ func (e *Environment) RegisterRateLimit(name string, spec *ConfigSpec, ctor Rate
 		if err != nil {
 			return nil, err
 		}
-		// Check if the implementation is message-aware
-		if msgAware, ok := r.(MessageAwareRateLimit); ok {
-			return newAirGapMessageAwareRateLimit(msgAware, nm.Metrics()), nil
+		// TODO: This MessageAwareRateLimit shoud eventually replace V1
+		// Try to upgrade to message aware rate-limiter if possible.
+		if rl, ok := r.(ratelimit.MessageAwareRateLimit); ok {
+			agrl := newReverseAirGapMessageAwareRateLimit(rl)
+			return newAirGapMessageAwareRateLimit(agrl, nm.Metrics()), nil
 		}
 
 		return newAirGapRateLimit(r, nm.Metrics()), nil

--- a/public/service/rate_limit.go
+++ b/public/service/rate_limit.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/warpstreamlabs/bento/internal/component/metrics"
 	"github.com/warpstreamlabs/bento/internal/component/ratelimit"
+	"github.com/warpstreamlabs/bento/internal/message"
 )
 
 // RateLimit is an interface implemented by Bento rate limits.
@@ -19,10 +20,30 @@ type RateLimit interface {
 	Closer
 }
 
+// MessageAwareRateLimit is an interface implemented by Bento rate limits that require message awareness
+type MessageAwareRateLimit interface {
+	// Add a new *message.Part to the rate limited resource. Returns true when an
+	// additional message part triggers rate-limiting or if the resource is currently
+	// being rate-limited.
+	Add(ctx context.Context, msg *message.Part) bool
+
+	// Access the rate limited resource. Returns a duration or an error if the
+	// rate limit check fails. The returned duration is either zero (meaning the
+	// resource may be accessed) or a reasonable length of time to wait before
+	// requesting again.
+	Access(context.Context) (time.Duration, error)
+
+	Closer
+}
+
 //------------------------------------------------------------------------------
 
 func newAirGapRateLimit(c RateLimit, stats metrics.Type) ratelimit.V1 {
 	return ratelimit.MetricsForRateLimit(c, stats)
+}
+
+func newAirGapMessageAwareRateLimit(c MessageAwareRateLimit, stats metrics.Type) ratelimit.MessageAwareRateLimiter {
+	return ratelimit.MetricsForMessageAwareRateLimit(c, stats)
 }
 
 //------------------------------------------------------------------------------
@@ -41,5 +62,27 @@ func (a *reverseAirGapRateLimit) Access(ctx context.Context) (time.Duration, err
 }
 
 func (a *reverseAirGapRateLimit) Close(ctx context.Context) error {
+	return a.r.Close(ctx)
+}
+
+//------------------------------------------------------------------------------
+
+// Implements MessageAwareRateLimit around a types.MessageAwareRateLimiter.
+type reverseAirGapMessageAwareRateLimit struct {
+	r ratelimit.MessageAwareRateLimiter
+}
+
+func newReverseAirGapMessageAwareRateLimit(r ratelimit.MessageAwareRateLimiter) *reverseAirGapMessageAwareRateLimit {
+	return &reverseAirGapMessageAwareRateLimit{r}
+}
+func (a *reverseAirGapMessageAwareRateLimit) Add(ctx context.Context, msg *message.Part) bool {
+	return a.r.Add(ctx, msg)
+}
+
+func (a *reverseAirGapMessageAwareRateLimit) Access(ctx context.Context) (time.Duration, error) {
+	return a.r.Access(ctx)
+}
+
+func (a *reverseAirGapMessageAwareRateLimit) Close(ctx context.Context) error {
 	return a.r.Close(ctx)
 }

--- a/public/service/rate_limit.go
+++ b/public/service/rate_limit.go
@@ -25,7 +25,7 @@ type MessageAwareRateLimit interface {
 	// Add a new *message.Part to the rate limited resource. Returns true when an
 	// additional message part triggers rate-limiting or if the resource is currently
 	// being rate-limited.
-	Add(ctx context.Context, msg *message.Part) bool
+	Add(ctx context.Context, msg ...*Message) bool
 
 	// Access the rate limited resource. Returns a duration or an error if the
 	// rate limit check fails. The returned duration is either zero (meaning the
@@ -42,8 +42,32 @@ func newAirGapRateLimit(c RateLimit, stats metrics.Type) ratelimit.V1 {
 	return ratelimit.MetricsForRateLimit(c, stats)
 }
 
-func newAirGapMessageAwareRateLimit(c MessageAwareRateLimit, stats metrics.Type) ratelimit.MessageAwareRateLimiter {
-	return ratelimit.MetricsForMessageAwareRateLimit(c, stats)
+func newAirGapMessageAwareRateLimit(rl MessageAwareRateLimit, stats metrics.Type) ratelimit.MessageAwareRateLimit {
+	agrl := &airGapMessageAwareRateLimit{r: rl}
+	return ratelimit.MetricsForMessageAwareRateLimit(agrl, stats)
+}
+
+//------------------------------------------------------------------------------
+
+// Implements types.MessageAwareRateLimit.
+type airGapMessageAwareRateLimit struct {
+	r MessageAwareRateLimit
+}
+
+func (a *airGapMessageAwareRateLimit) Add(ctx context.Context, msgs ...*message.Part) bool {
+	imsgs := make([]*Message, len(msgs))
+	for i, msg := range msgs {
+		imsgs[i] = NewInternalMessage(msg)
+	}
+	return a.r.Add(ctx, imsgs...)
+}
+
+func (a *airGapMessageAwareRateLimit) Access(ctx context.Context) (time.Duration, error) {
+	return a.r.Access(ctx)
+}
+
+func (a *airGapMessageAwareRateLimit) Close(ctx context.Context) error {
+	return a.r.Close(ctx)
 }
 
 //------------------------------------------------------------------------------
@@ -69,14 +93,18 @@ func (a *reverseAirGapRateLimit) Close(ctx context.Context) error {
 
 // Implements MessageAwareRateLimit around a types.MessageAwareRateLimiter.
 type reverseAirGapMessageAwareRateLimit struct {
-	r ratelimit.MessageAwareRateLimiter
+	r ratelimit.MessageAwareRateLimit
 }
 
-func newReverseAirGapMessageAwareRateLimit(r ratelimit.MessageAwareRateLimiter) *reverseAirGapMessageAwareRateLimit {
+func newReverseAirGapMessageAwareRateLimit(r ratelimit.MessageAwareRateLimit) *reverseAirGapMessageAwareRateLimit {
 	return &reverseAirGapMessageAwareRateLimit{r}
 }
-func (a *reverseAirGapMessageAwareRateLimit) Add(ctx context.Context, msg *message.Part) bool {
-	return a.r.Add(ctx, msg)
+func (a *reverseAirGapMessageAwareRateLimit) Add(ctx context.Context, msgs ...*Message) bool {
+	parts := make([]*message.Part, len(msgs))
+	for i, msg := range msgs {
+		parts[i] = msg.part
+	}
+	return a.r.Add(ctx, parts...)
 }
 
 func (a *reverseAirGapMessageAwareRateLimit) Access(ctx context.Context) (time.Duration, error) {

--- a/public/service/resources.go
+++ b/public/service/resources.go
@@ -239,8 +239,9 @@ func (r *Resources) HasOutput(name string) bool {
 // can block if CRUD operations are being actively performed on the resource.
 func (r *Resources) AccessRateLimit(ctx context.Context, name string, fn func(r RateLimit)) error {
 	return r.mgr.AccessRateLimit(ctx, name, func(r ratelimit.V1) {
-		// Try to upgrade to MessageAwareRateLimiter if possible
-		if mar, ok := r.(MessageAwareRateLimit); ok {
+		// TODO: This MessageAwareRateLimit shoud eventually replace V1
+		// Try to upgrade to message aware rate-limiter if possible.
+		if mar, ok := r.(ratelimit.MessageAwareRateLimit); ok {
 			fn(newReverseAirGapMessageAwareRateLimit(mar))
 		} else {
 			fn(newReverseAirGapRateLimit(r))

--- a/public/service/resources.go
+++ b/public/service/resources.go
@@ -239,7 +239,12 @@ func (r *Resources) HasOutput(name string) bool {
 // can block if CRUD operations are being actively performed on the resource.
 func (r *Resources) AccessRateLimit(ctx context.Context, name string, fn func(r RateLimit)) error {
 	return r.mgr.AccessRateLimit(ctx, name, func(r ratelimit.V1) {
-		fn(newReverseAirGapRateLimit(r))
+		// Try to upgrade to MessageAwareRateLimiter if possible
+		if mar, ok := r.(MessageAwareRateLimit); ok {
+			fn(newReverseAirGapMessageAwareRateLimit(mar))
+		} else {
+			fn(newReverseAirGapRateLimit(r))
+		}
 	})
 }
 

--- a/website/docs/components/rate_limits/local.md
+++ b/website/docs/components/rate_limits/local.md
@@ -21,6 +21,7 @@ The local rate limit is a simple X every Y type rate limit that can be shared ac
 label: ""
 local:
   count: 1000
+  byte_size: 0
   interval: 1s
 ```
 
@@ -28,11 +29,19 @@ local:
 
 ### `count`
 
-The maximum number of requests to allow for a given period of time.
+The maximum number of requests to allow for a given period of time. If `0` disables count based rate-limiting.
 
 
 Type: `int`  
 Default: `1000`  
+
+### `byte_size`
+
+The maximum number of bytes to allow for a given period of time. If `0` disables size based rate-limiting.
+
+
+Type: `int`  
+Default: `0`  
 
 ### `interval`
 

--- a/website/docs/components/rate_limits/local.md
+++ b/website/docs/components/rate_limits/local.md
@@ -37,7 +37,7 @@ Default: `1000`
 
 ### `byte_size`
 
-The maximum number of bytes to allow for a given period of time. If `0` disables size based rate-limiting.
+The maximum number of bytes to allow for a given period of time. If `0` disables byte_size based rate-limiting.
 
 
 Type: `int`  


### PR DESCRIPTION
## Changes
- New `MessageAwareRateLimit` interface with an `Add()` method.
- `Add()` is passed a slice of internal messages or message-parts where the total bytes are summated
- `Access()` will increment the counter and block if the rate-limiting is reached
- Made some changes with airgapped* implementations since we need to allow `RateLimit` and `ratelimit.V1` to be backwards compatible since its in the public API
- The `local` rate limiter has these changes implemented whereas the `redis` one has not.