### PR TITLE
Add kafka rate limit

### DIFF
--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -83,6 +83,7 @@ input:
       jitter: 0
       check: ""
       processors: [] # No default (optional)
+    rate_limit: ""
 ```
 
 </TabItem>
@@ -703,5 +704,13 @@ processors:
   - archive:
       format: json_array
 ```
+
+### `rate_limit`
+
+An optional [`rate_limit`](/docs/components/rate_limits/about) to throttle invocations by.
+
+
+Type: `string`  
+Default: `""`  
 
 


### PR DESCRIPTION
### Changes

- Add new rate limit field to Kafka input in order, which pauses polling when rate is exceeded.