### PR TITLE
add unsafe_dynamic_query to gcp_bigquery_select

### DIFF
--- a/internal/impl/gcp/bigquery.go
+++ b/internal/impl/gcp/bigquery.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/squirrel"
 	"go.uber.org/multierr"
 
+	"github.com/warpstreamlabs/bento/public/bloblang"
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
@@ -64,11 +65,14 @@ func (client *wrappedBQClient) Close() error {
 }
 
 type bqQueryParts struct {
-	table   string
-	columns []string
-	where   string
-	prefix  string
-	suffix  string
+	table          string
+	tableDyn       *service.InterpolatedString
+	columns        []string
+	columnsMapping *bloblang.Executor
+	where          string
+	whereDyn       *service.InterpolatedString
+	prefix         string
+	suffix         string
 }
 
 type bqQueryBuilderOptions struct {

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -164,7 +164,7 @@ An example to show the use of the unsafe_dynamic_query field:`,
 pipeline:
   processors:
     - gcp_bigquery_select:
-        project: ${GGP_PROJECT}
+        project: ${GCP_PROJECT}
         table: ${! this.table } # test.people
         columns_mapping: root = this.columns #["name", "age", "city"]
         where:  ${! "city IN ("+this.args.join(",").re_replace_all("\\b\\w+\\b","?")+")" } # city IN (?,?,?)

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -141,7 +141,7 @@ func newBigQuerySelectProcessorConfig() *service.ConfigSpec {
 			Description("An optional suffix to append to the select query.").
 			Optional()).
 		Field(service.NewBoolField("unsafe_dynamic_query").
-			Description("Whether to enable [interpolation functions](/docs/configuration/interpolation/#bloblang-queries) in the columns & where fields. Great care should be made to ensure your queries are defended against injection attacks.").
+			Description("Whether to enable [interpolation functions](/docs/configuration/interpolation/#bloblang-queries) in the columns_mapping, table & where fields. When `unsafe_dynamic_query` is set to true, you should provide a bloblang mapping via the `columns_mapping` config field, and not `columns`. Great care should be made to ensure your queries are defended against injection attacks.").
 			Advanced().
 			Default(false).
 			Version("1.5.0").

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -92,16 +92,16 @@ func bigQuerySelectProcessorConfigFromParsed(inConf *service.ParsedConfig) (conf
 	}
 
 	// check config fields are being used appropriately
-	if !inConf.Contains("columns_mapping") && conf.unsafeDyn {
+	if conf.queryParts.columnsMapping == nil && conf.unsafeDyn {
 		err = errors.New("invalid gcp_bigquery_select config: unsafe_dynamic_query set to true but no columns_mapping provided")
+		return
+	}
+	if inConf.Contains("columns_mapping") && !conf.unsafeDyn {
+		err = errors.New("invalid gcp_bigquery_select config: unsafe_dynamic_query set to false but columns_mapping provided")
 		return
 	}
 	if conf.queryParts.columnsMapping != nil && len(conf.queryParts.columns) != 0 {
 		err = errors.New("invalid gcp_bigquery_select config: cannot set both columns_mapping and columns field")
-		return
-	}
-	if len(conf.queryParts.columns) != 0 && conf.unsafeDyn {
-		err = errors.New("invalide gcp_bigquery_select config: unsafe_dynamic_query set to true but columns field provided")
 		return
 	}
 

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -160,7 +160,7 @@ pipeline:
 			`
 An example to show the use of the unsafe_dynamic_query field:`,
 			`
-# {"table": "test.people", "where": "city IN (?,?,?)", "columns": ["name", "age", "city"], "args": ["London", "Paris", "Dublin"]}
+# {"table": "test.people", "columns": ["name", "age", "city"], "args": ["London", "Paris", "Dublin"]}
 pipeline:
   processors:
     - gcp_bigquery_select:

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -36,6 +36,20 @@ func bigQuerySelectProcessorConfigFromParsed(inConf *service.ParsedConfig) (conf
 		return
 	}
 
+	// check config fields are being used appropriately:
+	if !inConf.Contains("columns_mapping") && conf.unsafeDyn {
+		err = errors.New("invalid gcp_bigquery_select config: unsafe_dynamic_query set to true but no columns_mapping provided")
+		return
+	}
+	if inConf.Contains("columns_mapping") && inConf.Contains("columns") {
+		err = errors.New("invalid gcp_bigquery_select config: cannot set both columns_mapping and columns field")
+		return
+	}
+	if inConf.Contains("columns") && conf.unsafeDyn {
+		err = errors.New("invalide gcp_bigquery_select config: unsafe_dynamic_query set to true but columns field provided")
+		return
+	}
+
 	if inConf.Contains("args_mapping") {
 		if conf.argsMapping, err = inConf.FieldBloblang("args_mapping"); err != nil {
 			return

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -20,6 +20,7 @@ type bigQuerySelectProcessorConfig struct {
 	queryParts  *bqQueryParts
 	jobLabels   map[string]string
 	argsMapping *bloblang.Executor
+	unsafeDyn   bool
 }
 
 func bigQuerySelectProcessorConfigFromParsed(inConf *service.ParsedConfig) (conf bigQuerySelectProcessorConfig, err error) {
@@ -27,6 +28,11 @@ func bigQuerySelectProcessorConfigFromParsed(inConf *service.ParsedConfig) (conf
 	conf.queryParts = &queryParts
 
 	if conf.project, err = inConf.FieldString("project"); err != nil {
+		return
+	}
+
+	conf.unsafeDyn, err = inConf.FieldBool("unsafe_dynamic_query")
+	if err != nil {
 		return
 	}
 
@@ -40,16 +46,33 @@ func bigQuerySelectProcessorConfigFromParsed(inConf *service.ParsedConfig) (conf
 		return
 	}
 
-	if queryParts.table, err = inConf.FieldString("table"); err != nil {
-		return
+	if conf.unsafeDyn {
+		if queryParts.tableDyn, err = inConf.FieldInterpolatedString("table"); err != nil {
+			return
+		}
+		if inConf.Contains("where") {
+			if queryParts.whereDyn, err = inConf.FieldInterpolatedString("where"); err != nil {
+				return
+			}
+		}
+		if inConf.Contains("columns_mapping") {
+			if conf.queryParts.columnsMapping, err = inConf.FieldBloblang("columns_mapping"); err != nil {
+				return
+			}
+		}
+	} else {
+		if queryParts.table, err = inConf.FieldString("table"); err != nil {
+			return
+		}
+		if inConf.Contains("where") {
+			if queryParts.where, err = inConf.FieldString("where"); err != nil {
+				return
+			}
+		}
 	}
 
-	if queryParts.columns, err = inConf.FieldStringList("columns"); err != nil {
-		return
-	}
-
-	if inConf.Contains("where") {
-		if queryParts.where, err = inConf.FieldString("where"); err != nil {
+	if inConf.Contains("columns") {
+		if queryParts.columns, err = inConf.FieldStringList("columns"); err != nil {
 			return
 		}
 	}
@@ -77,8 +100,13 @@ func newBigQuerySelectProcessorConfig() *service.ConfigSpec {
 		Categories("Integration").
 		Summary("Executes a `SELECT` query against BigQuery and replaces messages with the rows returned.").
 		Field(service.NewStringField("project").Description("GCP project where the query job will execute.")).
-		Field(service.NewStringField("table").Description("Fully-qualified BigQuery table name to query.").Example("bigquery-public-data.samples.shakespeare")).
-		Field(service.NewStringListField("columns").Description("A list of columns to query.")).
+		Field(service.NewInterpolatedStringField("table").Description("Fully-qualified BigQuery table name to query.").Example("bigquery-public-data.samples.shakespeare")).
+		Field(service.NewStringListField("columns").
+			Description("A list of columns to query.").
+			Optional()).
+		Field(service.NewBloblangField("columns_mapping").
+			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of column names to query.").
+			Optional()).
 		Field(service.NewStringField("where").
 			Description("An optional where clause to add. Placeholder arguments are populated with the `args_mapping` field. Placeholders should always be question marks (`?`).").
 			Example("type = ? and created_at > ?").
@@ -95,6 +123,12 @@ func newBigQuerySelectProcessorConfig() *service.ConfigSpec {
 			Optional()).
 		Field(service.NewStringField("suffix").
 			Description("An optional suffix to append to the select query.").
+			Optional()).
+		Field(service.NewBoolField("unsafe_dynamic_query").
+			Description("Whether to enable [interpolation functions](/docs/configuration/interpolation/#bloblang-queries) in the columns & where fields. Great care should be made to ensure your queries are defended against injection attacks.").
+			Advanced().
+			Default(false).
+			Version("1.5.0").
 			Optional()).
 		Example("Word count",
 			`
@@ -118,6 +152,22 @@ pipeline:
               args_mapping: root = [ this.term ]
         result_map: |
           root.count = this.get("0.total_count")
+`,
+		).
+		Example("Unsafe Dynamic Query",
+			`
+An example to show the use of the unsafe_dynamic_query field:`,
+			`
+# {"table": "test.people", "where": "city IN (?,?,?)", "columns": ["name", "age", "city"], "args": ["London", "Paris", "Dublin"]}
+pipeline:
+  processors:
+    - gcp_bigquery_select:
+        project: ${GGP_PROJECT}
+        table: ${! this.table } # test.people
+        columns_mapping: root = this.columns #["name", "age", "city"]
+        where:  ${! "city IN ("+this.args.join(",").re_replace_all("\\b\\w+\\b","?")+")" } # city IN (?,?,?)
+        args_mapping: root = this.args # ["London", "Paris", "Dublin"]
+        unsafe_dynamic_query: true
 `,
 		)
 }
@@ -165,20 +215,63 @@ func newBigQuerySelectProcessor(inConf *service.ParsedConfig, options *bigQueryP
 
 func (proc *bigQuerySelectProcessor) ProcessBatch(ctx context.Context, batch service.MessageBatch) ([]service.MessageBatch, error) {
 	argsMapping := proc.config.argsMapping
+	columnsMapping := proc.config.queryParts.columnsMapping
 
 	outBatch := make(service.MessageBatch, 0, len(batch))
 
-	var executor *service.MessageBatchBloblangExecutor
+	var argsMappingExecutor *service.MessageBatchBloblangExecutor
 	if argsMapping != nil {
-		executor = batch.BloblangExecutor(argsMapping)
+		argsMappingExecutor = batch.BloblangExecutor(argsMapping)
+	}
+
+	var columnsMappingExecutor *service.MessageBatchBloblangExecutor
+	if argsMapping != nil {
+		columnsMappingExecutor = batch.BloblangExecutor(columnsMapping)
 	}
 
 	for i, msg := range batch {
 		outBatch = append(outBatch, msg)
 
+		if proc.config.unsafeDyn {
+			var err error
+			proc.config.queryParts.table, err = proc.config.queryParts.tableDyn.TryString(msg)
+			if err != nil {
+				msg.SetError(fmt.Errorf("failed to resolve table mapping: %w", err))
+				continue
+			}
+			proc.config.queryParts.where, err = proc.config.queryParts.whereDyn.TryString(msg)
+			if err != nil {
+				msg.SetError(fmt.Errorf("failed to resolve where mapping: %w", err))
+				continue
+			}
+
+			resMsg, err := columnsMappingExecutor.Query(i)
+			if err != nil {
+				msg.SetError(fmt.Errorf("failed to resolve columns mapping: %w", err))
+				continue
+			}
+
+			icols, err := resMsg.AsStructured()
+			if err != nil {
+				msg.SetError(fmt.Errorf("mapping returned non-structured result: %w", err))
+				continue
+			}
+			cols, ok := icols.([]any)
+			if !ok {
+				msg.SetError(fmt.Errorf("col mapping returned non-array result: %T", icols))
+				continue
+			}
+
+			proc.config.queryParts.columns, err = toStringSlice(cols)
+			if err != nil {
+				msg.SetError(fmt.Errorf("%w", err))
+				continue
+			}
+		}
+
 		var args []any
 		if argsMapping != nil {
-			resMsg, err := executor.Query(i)
+			resMsg, err := argsMappingExecutor.Query(i)
 			if err != nil {
 				msg.SetError(fmt.Errorf("failed to resolve args mapping: %w", err))
 				continue
@@ -186,13 +279,13 @@ func (proc *bigQuerySelectProcessor) ProcessBatch(ctx context.Context, batch ser
 
 			iargs, err := resMsg.AsStructured()
 			if err != nil {
-				msg.SetError(fmt.Errorf("mapping returned non-structured result: %w", err))
+				msg.SetError(fmt.Errorf("args mapping returned non-structured result: %w", err))
 				continue
 			}
 
 			var ok bool
 			if args, ok = iargs.([]any); !ok {
-				msg.SetError(fmt.Errorf("mapping returned non-array result: %T", iargs))
+				msg.SetError(fmt.Errorf("args mapping returned non-array result: %T", iargs))
 				continue
 			}
 		}
@@ -260,4 +353,15 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func toStringSlice(in []any) (out []string, err error) {
+	if in == nil {
+		return nil, errors.New("column mapping returned nil")
+	}
+	out = make([]string, len(in))
+	for i, v := range in {
+		out[i] = fmt.Sprint(v)
+	}
+	return out, nil
 }

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -106,7 +106,9 @@ func newBigQuerySelectProcessorConfig() *service.ConfigSpec {
 			Optional()).
 		Field(service.NewBloblangField("columns_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of column names to query.").
-			Optional()).
+			Optional().
+			Version("1.5.0").
+			Advanced()).
 		Field(service.NewStringField("where").
 			Description("An optional where clause to add. Placeholder arguments are populated with the `args_mapping` field. Placeholders should always be question marks (`?`).").
 			Example("type = ? and created_at > ?").

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -266,7 +266,7 @@ func (proc *bigQuerySelectProcessor) ProcessBatch(ctx context.Context, batch ser
 
 			proc.config.queryParts.columns, err = toStringSlice(cols)
 			if err != nil {
-				msg.SetError(fmt.Errorf("%w", err))
+				msg.SetError(err)
 				continue
 			}
 		}

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -227,7 +227,7 @@ func (proc *bigQuerySelectProcessor) ProcessBatch(ctx context.Context, batch ser
 	}
 
 	var columnsMappingExecutor *service.MessageBatchBloblangExecutor
-	if argsMapping != nil {
+	if columnsMapping != nil {
 		columnsMappingExecutor = batch.BloblangExecutor(columnsMapping)
 	}
 

--- a/internal/impl/gcp/processor_bigquery_select_test.go
+++ b/internal/impl/gcp/processor_bigquery_select_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
@@ -28,72 +29,119 @@ args_mapping: |
   root = [ this.term ]
 `
 
+var testBQProcessorDynamicYAML = `
+project: job-project
+table: ${! this.table }
+columns_mapping: root = this.columns
+where: ${! this.where }
+unsafe_dynamic_query: true
+suffix: |
+  GROUP BY word
+  ORDER BY total_count DESC
+  LIMIT 10
+args_mapping: |
+  root = [ this.term ]
+`
+
 func TestGCPBigQuerySelectProcessor(t *testing.T) {
-	spec := newBigQuerySelectProcessorConfig()
-
-	parsed, err := spec.ParseYAML(testBQProcessorYAML, nil)
-	require.NoError(t, err)
-
-	proc, err := newBigQuerySelectProcessor(parsed, &bigQueryProcessorOptions{
-		clientOptions: []option.ClientOption{option.WithoutAuthentication()},
-	})
-	require.NoError(t, err)
-
-	mockClient := &mockBQClient{}
-	proc.client = mockClient
-
-	expected := []map[string]any{
-		{"total_count": 25568, "word": "the"},
-		{"total_count": 19649, "word": "and"},
+	testCases := []struct {
+		name            string
+		yamlConfig      string
+		inputMessages   []string
+		expectedResults []map[string]any
+		expectedQueries []string
+	}{
+		{
+			name:       "Static Config Test",
+			yamlConfig: testBQProcessorYAML,
+			inputMessages: []string{
+				`{"term": "test1"}`,
+				`{"term": "test2"}`,
+			},
+			expectedResults: []map[string]any{
+				{"total_count": 25568, "word": "the"},
+				{"total_count": 19649, "word": "and"},
+			},
+			expectedQueries: []string{"test1", "test2"},
+		},
+		{
+			name:       "Dynamic Config Test",
+			yamlConfig: testBQProcessorDynamicYAML,
+			inputMessages: []string{
+				`{"term": "test1", "table": "bigquery-public-data.samples.shakespeare", "columns": ["word", "sum(word_count) as total_count"], "where": "length(word) >= ?"}`,
+				`{"term": "test2", "table": "bigquery-public-data.samples.shakespeare", "columns": ["word", "sum(word_count) as total_count"], "where": "length(word) >= ?"}`,
+			},
+			expectedResults: []map[string]any{
+				{"total_count": 25568, "word": "the"},
+				{"total_count": 19649, "word": "and"},
+			},
+			expectedQueries: []string{"test1", "test2"},
+		},
 	}
+	for _, tc := range testCases {
+		spec := newBigQuerySelectProcessorConfig()
 
-	expectedMsg, err := json.Marshal(expected)
-	require.NoError(t, err)
-
-	var rows []string
-	for _, v := range expected {
-		row, err := json.Marshal(v)
+		parsed, err := spec.ParseYAML(tc.yamlConfig, nil)
 		require.NoError(t, err)
 
-		rows = append(rows, string(row))
+		proc, err := newBigQuerySelectProcessor(parsed, &bigQueryProcessorOptions{
+			clientOptions: []option.ClientOption{option.WithoutAuthentication()},
+		})
+		require.NoError(t, err)
+
+		mockClient := &mockBQClient{}
+		proc.client = mockClient
+
+		expected := tc.expectedResults
+
+		expectedMsg, err := json.Marshal(expected)
+		require.NoError(t, err)
+
+		var rows []string
+		for _, v := range expected {
+			row, err := json.Marshal(v)
+			require.NoError(t, err)
+
+			rows = append(rows, string(row))
+		}
+
+		iter := &mockBQIterator{
+			rows: rows,
+		}
+
+		mockClient.On("RunQuery", mock.Anything, mock.Anything).Return(iter, nil)
+
+		inbatch := service.MessageBatch{
+			service.NewMessage([]byte(tc.inputMessages[0])),
+			service.NewMessage([]byte(tc.inputMessages[1])),
+		}
+
+		batches, err := proc.ProcessBatch(context.Background(), inbatch)
+		require.NoError(t, err)
+		require.Len(t, batches, 1)
+
+		// Assert that we generated the right parameters for each BQ query
+		mockClient.AssertNumberOfCalls(t, "RunQuery", 2)
+		call1 := mockClient.Calls[0]
+		args1 := call1.Arguments[1].(*bqQueryBuilderOptions).args
+		require.ElementsMatch(t, args1, []string{tc.expectedQueries[0]})
+		call2 := mockClient.Calls[1]
+		args2 := call2.Arguments[1].(*bqQueryBuilderOptions).args
+		require.ElementsMatch(t, args2, []string{tc.expectedQueries[1]})
+
+		outbatch := batches[0]
+		require.Len(t, outbatch, 2)
+
+		msg1, err := outbatch[0].AsBytes()
+		require.NoError(t, err)
+		require.JSONEq(t, string(expectedMsg), string(msg1))
+
+		msg2, err := outbatch[0].AsBytes()
+		require.NoError(t, err)
+		require.JSONEq(t, string(expectedMsg), string(msg2))
+
+		mockClient.AssertExpectations(t)
 	}
-
-	iter := &mockBQIterator{
-		rows: rows,
-	}
-
-	mockClient.On("RunQuery", mock.Anything, mock.Anything).Return(iter, nil)
-
-	inbatch := service.MessageBatch{
-		service.NewMessage([]byte(`{"term": "test1"}`)),
-		service.NewMessage([]byte(`{"term": "test2"}`)),
-	}
-
-	batches, err := proc.ProcessBatch(context.Background(), inbatch)
-	require.NoError(t, err)
-	require.Len(t, batches, 1)
-
-	// Assert that we generated the right parameters for each BQ query
-	mockClient.AssertNumberOfCalls(t, "RunQuery", 2)
-	call1 := mockClient.Calls[0]
-	args1 := call1.Arguments[1].(*bqQueryBuilderOptions).args
-	require.ElementsMatch(t, args1, []string{"test1"})
-	call2 := mockClient.Calls[1]
-	args2 := call2.Arguments[1].(*bqQueryBuilderOptions).args
-	require.ElementsMatch(t, args2, []string{"test2"})
-
-	outbatch := batches[0]
-	require.Len(t, outbatch, 2)
-
-	msg1, err := outbatch[0].AsBytes()
-	require.NoError(t, err)
-	require.JSONEq(t, string(expectedMsg), string(msg1))
-
-	msg2, err := outbatch[0].AsBytes()
-	require.NoError(t, err)
-	require.JSONEq(t, string(expectedMsg), string(msg2))
-
-	mockClient.AssertExpectations(t)
 }
 
 func TestGCPBigQuerySelectProcessor_IteratorError(t *testing.T) {
@@ -145,4 +193,77 @@ func TestGCPBigQuerySelectProcessor_IteratorError(t *testing.T) {
 	require.Contains(t, msgErr.Error(), testErr.Error())
 
 	mockClient.AssertExpectations(t)
+}
+
+var dynTrueButWithColumns = `
+project: job-project
+table: ${! this.table }
+columns:
+  - name
+  - age
+where: ${! this.where }
+unsafe_dynamic_query: true
+args_mapping: |
+  root = [ this.term ]
+`
+
+var dynFalseButWithColumnsMapping = `
+project: job-project
+table: ${! this.table }
+columns_mapping: root = this.columns
+where: ${! this.where }
+unsafe_dynamic_query: false
+args_mapping: |
+  root = [ this.term ]
+`
+
+var columnsAndColumnsMapping = `
+project: job-project
+table: ${! this.table }
+columns_mapping: root = this.columns
+columns:
+  - name
+  - age
+where: ${! this.where }
+unsafe_dynamic_query: true
+args_mapping: |
+  root = [ this.term ]
+`
+
+func TestGCPBigQuerySelectProcessor_ParseConfigs(t *testing.T) {
+	testConfigs := []struct {
+		name          string
+		yamlConfig    string
+		expectedError string
+	}{
+		{
+			name:          "Unsafe dynamic query set to true but columns provided",
+			yamlConfig:    dynTrueButWithColumns,
+			expectedError: "failed to parse config: invalid gcp_bigquery_select config: unsafe_dynamic_query set to true but no columns_mapping provided",
+		},
+		{
+			name:          "Unsafe dynamic query set to false but columns_mapping provided",
+			yamlConfig:    dynFalseButWithColumnsMapping,
+			expectedError: "failed to parse config: invalid gcp_bigquery_select config: unsafe_dynamic_query set to false but columns_mapping provided",
+		},
+		{
+			name:          "Unsafe dynamic query set to false but columns_mapping provided",
+			yamlConfig:    columnsAndColumnsMapping,
+			expectedError: "failed to parse config: invalid gcp_bigquery_select config: cannot set both columns_mapping and columns field",
+		},
+	}
+
+	for _, tc := range testConfigs {
+
+		spec := newBigQuerySelectProcessorConfig()
+
+		parsed, err := spec.ParseYAML(tc.yamlConfig, nil)
+		require.NoError(t, err)
+
+		_, err = newBigQuerySelectProcessor(parsed, &bigQueryProcessorOptions{
+			clientOptions: []option.ClientOption{option.WithoutAuthentication()},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), tc.expectedError)
+	}
 }

--- a/website/docs/components/processors/gcp_bigquery_select.md
+++ b/website/docs/components/processors/gcp_bigquery_select.md
@@ -106,11 +106,11 @@ pipeline:
 An example to show the use of the unsafe_dynamic_query field:
 
 ```yaml
-# {"table": "test.people", "where": "city IN (?,?,?)", "columns": ["name", "age", "city"], "args": ["London", "Paris", "Dublin"]}
+# {"table": "test.people", "columns": ["name", "age", "city"], "args": ["London", "Paris", "Dublin"]}
 pipeline:
   processors:
     - gcp_bigquery_select:
-        project: ${GGP_PROJECT}
+        project: ${GCP_PROJECT}
         table: ${! this.table } # test.people
         columns_mapping: root = this.columns #["name", "age", "city"]
         where:  ${! "city IN ("+this.args.join(",").re_replace_all("\\b\\w+\\b","?")+")" } # city IN (?,?,?)

--- a/website/docs/components/processors/gcp_bigquery_select.md
+++ b/website/docs/components/processors/gcp_bigquery_select.md
@@ -211,7 +211,7 @@ Type: `string`
 
 ### `unsafe_dynamic_query`
 
-Whether to enable [interpolation functions](/docs/configuration/interpolation/#bloblang-queries) in the columns & where fields. Great care should be made to ensure your queries are defended against injection attacks.
+Whether to enable [interpolation functions](/docs/configuration/interpolation/#bloblang-queries) in the columns_mapping, table & where fields. When `unsafe_dynamic_query` is set to true, you should provide a bloblang mapping via the `columns_mapping` config field, and not `columns`. Great care should be made to ensure your queries are defended against injection attacks.
 
 
 Type: `bool`  

--- a/website/docs/components/processors/gcp_bigquery_select.md
+++ b/website/docs/components/processors/gcp_bigquery_select.md
@@ -37,7 +37,6 @@ gcp_bigquery_select:
   project: "" # No default (required)
   table: bigquery-public-data.samples.shakespeare # No default (required)
   columns: [] # No default (optional)
-  columns_mapping: "" # No default (optional)
   where: type = ? and created_at > ? # No default (optional)
   job_labels: {}
   args_mapping: root = [ "article", now().ts_format("2006-01-02") ] # No default (optional)
@@ -158,6 +157,7 @@ An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluat
 
 
 Type: `string`  
+Requires version 1.5.0 or newer  
 
 ### `where`
 


### PR DESCRIPTION
Will enable things like: 

```yaml
# {"table": "test.people", "where": "city IN (?,?,?)", "columns": ["name", "age", "city"], "args": ["London", "Paris", "Dublin"]}
pipeline:
  processors:
    - gcp_bigquery_select:
        project: ${GGP_PROJECT}
        table: ${! this.table } # test.people
        columns_mapping: root = this.columns #["name", "age", "city"]
        where:  ${! "city IN ("+this.args.join(",").re_replace_all("\\b\\w+\\b","?")+")" } # city IN (?,?,?)
        args_mapping: root = this.args # ["London", "Paris", "Dublin"]
        unsafe_dynamic_query: true
```

So that there is greater flexibility with this processor. 