### PR TITLE
Add object deletion for AWS S3 processor

### DIFF
--- a/internal/impl/aws/processor_s3_integration_test.go
+++ b/internal/impl/aws/processor_s3_integration_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/internal/component/processor"
 	"github.com/warpstreamlabs/bento/internal/component/testutil"
 	"github.com/warpstreamlabs/bento/internal/manager/mock"
@@ -27,10 +29,24 @@ func TestIntegrationS3Processor(t *testing.T) {
 	objectKey := "example.txt"
 	objectData := "hello world"
 
-	uploadFile(servicePort, bucketName, objectKey, objectData)
+	client, err := uploadFile(servicePort, bucketName, objectKey, objectData)
+	require.NoError(t, err)
 
 	t.Run("s3Processor", func(t *testing.T) {
 		s3ProcessorTest(t, bucketName, servicePort)
+	})
+
+	t.Run("delete_on_process", func(t *testing.T) {
+		s3ProcessorTestDeleteObject(t, bucketName, servicePort)
+		resp, err := client.GetObject(context.TODO(), &s3.GetObjectInput{
+			Key:    aws.String("example.txt"),
+			Bucket: aws.String("test-bucket"),
+		})
+		require.Nil(t, resp)
+		require.Error(t, err)
+
+		var noSuchKey *types.NoSuchKey
+		require.ErrorAs(t, err, &noSuchKey)
 	})
 }
 
@@ -92,12 +108,56 @@ aws_s3:
 
 }
 
-func uploadFile(s3Port string, bucketName string, objectKey string, objectData string) {
+func s3ProcessorTestDeleteObject(t *testing.T, bucketName string, servicePort string) {
+	confStr := fmt.Sprintf(`
+aws_s3:
+  bucket: %s
+  key: example.txt
+  force_path_style_urls: true
+  delete_objects: true
+  region: eu-west-1
+  endpoint: http://localhost:%s
+  credentials:
+    id: xxxxx
+    secret: xxxxx
+    token: xxxxx
+  scanner:
+    to_the_end: {}
+`, bucketName, servicePort)
+
+	p, err := createS3ProcessorFromYaml(confStr)
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+	msg := message.QuickBatch([][]byte{[]byte("test message")})
+	resBatches, err := p.ProcessBatch(ctx, msg)
+	resBatch := resBatches[0]
+
+	expectedMsg := message.QuickBatch([][]byte{[]byte("hello world")})
+	var expectedContentLength int64 = 11
+	for _, part := range expectedMsg {
+		part.MetaSetMut("s3_key", "example.txt")
+		part.MetaSetMut("s3_bucket", "test-bucket")
+		part.MetaSetMut("s3_content_type", "application/octet-stream")
+		part.MetaSetMut("s3_content_length", expectedContentLength)
+	}
+
+	for _, part := range resBatch {
+		part.MetaDelete("s3_last_modified")
+		part.MetaDelete("s3_last_modified_unix")
+	}
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedMsg.Get(0), resBatch.Get(0))
+
+}
+
+func uploadFile(s3Port string, bucketName string, objectKey string, objectData string) (*s3.Client, error) {
 	endpoint := fmt.Sprintf("http://localhost:%v", s3Port)
 
 	ctx := context.TODO()
 
-	conf, _ := config.LoadDefaultConfig(ctx,
+	conf, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion("eu-west-1"),
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("xxxxx", "xxxxx", "xxxxx")),
 		config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
@@ -108,14 +168,22 @@ func uploadFile(s3Port string, bucketName string, objectKey string, objectData s
 			}, nil
 		})),
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	client := s3.NewFromConfig(conf, func(o *s3.Options) {
 		o.UsePathStyle = true
 	})
 
-	_, _ = client.PutObject(ctx, &s3.PutObjectInput{
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(objectKey),
 		Body:   bytes.NewReader([]byte(objectData)),
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
 }

--- a/website/docs/components/processors/aws_s3.md
+++ b/website/docs/components/processors/aws_s3.md
@@ -51,6 +51,7 @@ aws_s3:
   bucket: "" # No default (required)
   key: "" # No default (required)
   force_path_style_urls: false
+  delete_objects: false
   region: ""
   endpoint: ""
   credentials:
@@ -154,6 +155,15 @@ Forces the client API to use path style URLs for downloading keys, which is ofte
 
 Type: `bool`  
 Default: `false`  
+
+### `delete_objects`
+
+Whether to delete downloaded objects from the bucket once they are processed.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.5.0 or newer  
 
 ### `region`
 


### PR DESCRIPTION
## Motivation

This PR allows for objects to be deleted once consumed and processed by the S3 processor -- which has already been implemented by the S3 input component.

## Changes

- Add a deferred delete operation that removes an S3 object after processing if it is read in without error.
- Adds a test case where this new field is enabled, with an existent check for the deleted object.
- Update docs.