### PR TITLE
Documentation updates

### DIFF
--- a/internal/bloblang/query/docs.go
+++ b/internal/bloblang/query/docs.go
@@ -139,6 +139,10 @@ func (s FunctionSpec) Param(def ParamDefinition) FunctionSpec {
 
 // NewDeprecatedFunctionSpec creates a new function spec that is deprecated.
 func NewDeprecatedFunctionSpec(name, description string, examples ...ExampleSpec) FunctionSpec {
+	description = `:::caution DEPRECATED
+::: 
+` + description
+
 	return FunctionSpec{
 		Status:      StatusDeprecated,
 		Category:    FunctionCategoryDeprecated,

--- a/internal/impl/aws/output_dynamodb.go
+++ b/internal/impl/aws/output_dynamodb.go
@@ -80,7 +80,7 @@ The field `+"`string_columns`"+` is a map of column names to string values, wher
 string_columns:
   id: ${!json("id")}
   title: ${!json("body.title")}
-  topic: ${!meta("kafka_topic")}
+  topic: ${!metadata("kafka_topic")}
   full_content: ${!content()}
 `+"```"+`
 

--- a/internal/impl/aws/output_s3.go
+++ b/internal/impl/aws/output_s3.go
@@ -154,7 +154,7 @@ output:
     path: ${!count("files")}-${!timestamp_unix_nano()}.tar.gz
     tags:
       Key1: Value1
-      Timestamp: ${!meta("Timestamp")}
+      Timestamp: ${!metadata("Timestamp").string()}
 `+"```"+`
 
 ### Credentials
@@ -202,14 +202,14 @@ output:
 				Description("The path of each message to upload.").
 				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`).
 				Example(`${!count("files")}-${!timestamp_unix_nano()}.txt`).
-				Example(`${!meta("kafka_key")}.json`).
+				Example(`${!metadata("kafka_key")}.json`).
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`),
 			service.NewInterpolatedStringMapField(s3oFieldTags).
 				Description("Key/value pairs to store with the object as tags.").
 				Default(map[string]any{}).
 				Example(map[string]any{
 					"Key1":      "Value1",
-					"Timestamp": `${!meta("Timestamp")}`,
+					"Timestamp": `${!metadata("Timestamp")}`,
 				}),
 			service.NewInterpolatedStringField(s3oFieldContentType).
 				Description("The content type to set for each object.").

--- a/internal/impl/aws/processor_dynamodb_partiql.go
+++ b/internal/impl/aws/processor_dynamodb_partiql.go
@@ -34,7 +34,7 @@ pipeline:
         args_mapping: |
           root = [
             { "S": this.foo },
-            { "S": meta("kafka_topic") },
+            { "S": metadata("kafka_topic") },
             { "S": this.document.content },
           ]
 `,

--- a/internal/impl/azure/output_blob_storage.go
+++ b/internal/impl/azure/output_blob_storage.go
@@ -85,7 +85,7 @@ If the `+"`storage_connection_string`"+` does not contain the `+"`AccountName`"+
 			service.NewInterpolatedStringField(bsoFieldPath).
 				Description("The path of each message to upload.").
 				Example(`${!count("files")}-${!timestamp_unix_nano()}.json`).
-				Example(`${!meta("kafka_key")}.json`).
+				Example(`${!metadata("kafka_key")}.json`).
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`).
 				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`),
 			service.NewInterpolatedStringEnumField(bsoFieldBlobType, "BLOCK", "APPEND").

--- a/internal/impl/azure/processor_cosmosdb.go
+++ b/internal/impl/azure/processor_cosmosdb.go
@@ -52,7 +52,7 @@ input:
         database: testdb
         container: blobfish
         partition_keys_map: root = json("habitat")
-        item_id: ${! meta("id") }
+        item_id: ${! metadata("id").string() }
         operation: Patch
         patch_operations:
           # Add a new /diet field

--- a/internal/impl/couchbase/processor.go
+++ b/internal/impl/couchbase/processor.go
@@ -41,7 +41,7 @@ func ProcessorConfig() *service.ConfigSpec {
 			string(client.OperationReplace): "replace the contents of a document.",
 			string(client.OperationUpsert):  "creates a new document if it does not exist, if it does exist then it updates it.",
 		}).Description("Couchbase operation to perform.").Default(string(client.OperationGet))).
-		Field(service.NewBoolField("cas_enabled").Description("Enable CAS validation.").Default(true)). // TODO: Consider removal in next release?
+		Field(service.NewBoolField("cas_enabled").Description("Enable CAS validation.").Default(true).Version("1.3.0")). // TODO: Consider removal in next release?
 		LintRule(`root = if ((this.operation == "insert" || this.operation == "replace" || this.operation == "upsert") && !this.exists("content")) { [ "content must be set for insert, replace and upsert operations." ] }`)
 }
 

--- a/internal/impl/gcp/output_cloud_storage.go
+++ b/internal/impl/gcp/output_cloud_storage.go
@@ -132,7 +132,7 @@ output:
 			service.NewInterpolatedStringField(csoFieldPath).
 				Description("The path of each message to upload.").
 				Example(`${!count("files")}-${!timestamp_unix_nano()}.txt`).
-				Example(`${!meta("kafka_key")}.json`).
+				Example(`${!metadata("kafka_key")}.json`).
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`).
 				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`),
 			service.NewInterpolatedStringField(csoFieldContentType).

--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -256,7 +256,7 @@ You can access these metadata fields using [function interpolation](/docs/config
 			service.NewObjectField(hsiFieldResponse,
 				service.NewInterpolatedStringField(hsiFieldResponseStatus).
 					Description("Specify the status code to return with synchronous responses. This is a string value, which allows you to customize it based on resulting payloads and their metadata.").
-					Examples(`${! json("status") }`, `${! meta("status") }`).
+					Examples(`${! json("status") }`, `${! metadata("status").string() }`).
 					Default("200"),
 				service.NewInterpolatedStringMapField(hsiFieldResponseHeaders).
 					Description("Specify headers to return with synchronous responses.").

--- a/internal/impl/io/input_http_server_test.go
+++ b/internal/impl/io/input_http_server_test.go
@@ -1195,7 +1195,7 @@ func TestHTTPSyncResponseHeadersStatus(t *testing.T) {
 http_server:
   path: /testpost
   sync_response:
-    status: '${! meta("status").or("200") }'
+    status: '${! metadata("status").or("200").string() }'
     headers:
       Content-Type: application/json
       foo: '${!json("field1")}'

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -93,22 +93,27 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Advanced()).
 		Field(service.NewStringListField("group_balancers").
 			Description("Balancers sets the group balancers to use for dividing topic partitions among group members. This option is equivalent to Kafka's `partition.assignment.strategies` option.").
+			Version("1.3.0").
 			Default([]string{"cooperative_sticky"}).
 			Advanced()).
 		Field(service.NewDurationField("metadata_max_age").
 			Description("This sets the maximum age for the client's cached metadata, to allow detection of new topics, partitions, etc.").
+			Version("1.3.0").
 			Default("5m").
 			Advanced()).
 		Field(service.NewStringField("fetch_max_bytes").
 			Description("This sets the maximum amount of bytes a broker will try to send during a fetch. Note that brokers may not obey this limit if it has records larger than this limit. Also note that this client sends a fetch to each broker concurrently, meaning the client will buffer up to `<brokers * max bytes>` worth of memory. Equivalent to Kafka's `fetch.max.bytes` option.").
+			Version("1.3.0").
 			Default("50MiB").
 			Advanced()).
 		Field(service.NewStringField("fetch_max_partition_bytes").
 			Description("Sets the maximum amount of bytes that will be consumed for a single partition in a fetch request. Note that if a single batch is larger than this number, that batch will still be returned so the client can make progress. Equivalent to Kafka's `max.partition.fetch.bytes` option.").
+			Version("1.3.0").
 			Default("1MiB").
 			Advanced()).
 		Field(service.NewDurationField("fetch_max_wait").
 			Description("This sets the maximum amount of time a broker will wait for a fetch response to hit the minimum number of required bytes before returning, overriding the default 5s.").
+			Version("1.3.0").
 			Default("5s").
 			Advanced()).
 		Field(service.NewIntField("preferring_lag").
@@ -118,6 +123,7 @@ This allows you to re-order partitions before they are fetched, given each parti
 By default, the client rotates partitions fetched by one after every fetch request. Kafka answers fetch requests in the order that partitions are requested, filling the fetch response until` + "`fetch_max_bytes`" + ` and ` + "`fetch_max_partition_bytes`" + ` are hit. All partitions eventually rotate to the front, ensuring no partition is starved.
 
 With this option, you can return topic order and per-topic partition ordering. These orders will sort to the front (first by topic, then by partition). Any topic or partitions that you do not return are added to the end, preserving their original ordering.`).
+			Version("1.3.0").
 			Optional().
 			Advanced()).
 		Field(service.NewTLSToggledField("tls")).

--- a/internal/impl/kafka/output_kafka_franz_test.go
+++ b/internal/impl/kafka/output_kafka_franz_test.go
@@ -22,7 +22,7 @@ kafka_franz:
   seed_brokers: [ foo:1234 ]
   topic: foo
   partitioner: manual
-  partition: '${! meta("foo") }'
+  partition: '${! metadata("foo").string() }'
 `,
 		},
 		{
@@ -49,7 +49,7 @@ kafka_franz:
 kafka_franz:
   seed_brokers: [ foo:1234 ]
   topic: foo
-  partition: '${! meta("foo") }'
+  partition: '${! metadata("foo") }'
 `,
 			errContains: "a partition cannot be specified unless the partitioner is set to manual",
 		},

--- a/internal/impl/nats/output.go
+++ b/internal/impl/nats/output.go
@@ -28,7 +28,7 @@ func natsOutputConfig() *service.ConfigSpec {
 			Default(map[string]any{}).
 			Example(map[string]any{
 				"Content-Type": "application/json",
-				"Timestamp":    `${!meta("Timestamp")}`,
+				"Timestamp":    `${!metadata("Timestamp").string()}`,
 			})).
 		Field(service.NewMetadataFilterField("metadata").
 			Description("Determine which (if any) metadata values should be added to messages as headers.").

--- a/internal/impl/nats/output_jetstream.go
+++ b/internal/impl/nats/output_jetstream.go
@@ -30,7 +30,7 @@ func natsJetStreamOutputConfig() *service.ConfigSpec {
 			Default(map[string]any{}).
 			Example(map[string]any{
 				"Content-Type": "application/json",
-				"Timestamp":    `${!meta("Timestamp")}`,
+				"Timestamp":    `${!metadata("Timestamp").string()}`,
 			}).Version("1.0.0")).
 		Field(service.NewMetadataFilterField("metadata").
 			Description("Determine which (if any) metadata values should be added to messages as headers.").

--- a/internal/impl/nats/output_jetstream_test.go
+++ b/internal/impl/nats/output_jetstream_test.go
@@ -19,7 +19,7 @@ urls: [ url1, url2 ]
 subject: testsubject
 headers:
   Content-Type: application/json
-  Timestamp: ${!meta("Timestamp")}
+  Timestamp: ${!metadata("Timestamp").string() }
 auth:
   nkey_file: test auth n key file
   user_credentials_file: test auth user creds file

--- a/internal/impl/nats/processor_request_reply.go
+++ b/internal/impl/nats/processor_request_reply.go
@@ -50,7 +50,7 @@ You can access these metadata fields using [function interpolation](/docs/config
 			Default(map[string]any{}).
 			Example(map[string]any{
 				"Content-Type": "application/json",
-				"Timestamp":    `${!meta("Timestamp")}`,
+				"Timestamp":    `${!metadata("Timestamp").string()}`,
 			})).
 		Field(service.NewMetadataFilterField("metadata").
 			Description("Determine which (if any) metadata values should be added to messages as headers.").

--- a/internal/impl/parquet/processor_decode.go
+++ b/internal/impl/parquet/processor_decode.go
@@ -40,7 +40,7 @@ input:
 output:
   file:
     codec: lines
-    path: './foos/${! meta("s3_key") }.jsonl'
+    path: './foos/${! metadata("s3_key") }.jsonl'
 `)
 }
 

--- a/internal/impl/pure/buffer_system_window.go
+++ b/internal/impl/pure/buffer_system_window.go
@@ -53,7 +53,7 @@ A [Bloblang mapping](/docs/guides/bloblang/about) applied to each message during
 The timestamp value assigned to `+"`root`"+` must either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in ISO 8601 format. If the mapping fails or provides an invalid result the message will be dropped (with logging to describe the problem).
 `).
 			Default("root = now()").
-			Example("root = this.created_at").Example(`root = meta("kafka_timestamp_unix").number()`)).
+			Example("root = this.created_at").Example(`root = metadata("kafka_timestamp_unix").string()`)).
 		Field(service.NewStringField("size").
 			Description("A duration string describing the size of each window. By default windows are aligned to the zeroth minute and zeroth hour on the UTC clock, meaning windows of 1 hour duration will match the turn of each hour in the day, this can be adjusted with the `offset` field.").
 			Example("30s").Example("10m")).
@@ -110,7 +110,7 @@ pipeline:
         root = if batch_index() == 0 {
           {
             "traffic_light": this.traffic_light,
-            "created_at": meta("window_end_timestamp"),
+            "created_at": metadata("window_end_timestamp"),
             "total_cars": json("registration_plate").from_all().unique().length(),
             "passengers": json("passengers").from_all().sum(),
           }

--- a/internal/impl/pure/output_cache.go
+++ b/internal/impl/pure/output_cache.go
@@ -53,7 +53,7 @@ In order to create a unique `+"`key`"+` value per item you should use function i
 				Examples(
 					`${!count("items")}-${!timestamp_unix_nano()}`,
 					`${!json("doc.id")}`,
-					`${!meta("kafka_key")}`,
+					`${!metadata("kafka_key")}`,
 				).
 				Default(`${!count("items")}-${!timestamp_unix_nano()}`),
 			service.NewInterpolatedStringField(coFieldTTL).

--- a/internal/impl/pure/processor_archive_test.go
+++ b/internal/impl/pure/processor_archive_test.go
@@ -29,7 +29,7 @@ format: does not exist
 func TestArchiveTar(t *testing.T) {
 	conf, err := archiveProcConfig().ParseYAML(`
 format: tar
-path: 'foo-${!meta("path")}'
+path: 'foo-${!metadata("path")}'
 `, nil)
 	require.NoError(t, err)
 

--- a/internal/impl/pure/processor_cached.go
+++ b/internal/impl/pure/processor_cached.go
@@ -44,12 +44,12 @@ pipeline:
     - branch:
         processors:
           - cached:
-              key: '${! meta("kafka_topic") }-${! meta("kafka_partition") }'
+              key: '${! metadata("kafka_topic") }-${! metadata("kafka_partition").string() }'
               cache: foo_cache
               processors:
                 - mapping: 'root = ""'
                 - http:
-                    url: http://example.com/enrichment/${! meta("kafka_topic") }/${! meta("kafka_partition") }
+                    url: http://example.com/enrichment/${! metadata("kafka_topic") }/${! metadata("kafka_partition").string() }
                     verb: GET
         result_map: 'root.enrichment = this'
 

--- a/internal/impl/pure/processor_dedupe.go
+++ b/internal/impl/pure/processor_dedupe.go
@@ -72,6 +72,7 @@ cache_resources:
 				"LIFO": "Keeps the last value seen for each key.",
 			}).
 				Description("Controls how to handle duplicate values.").
+				Version("1.4.0").
 				Default("FIFO").Advanced(),
 		)
 }

--- a/internal/impl/pure/processor_dedupe.go
+++ b/internal/impl/pure/processor_dedupe.go
@@ -50,7 +50,7 @@ pipeline:
   processors:
     - dedupe:
         cache: keycache
-        key: ${! meta("kafka_key") }
+        key: ${! metadata("kafka_key") }
 
 cache_resources:
   - label: keycache
@@ -63,7 +63,7 @@ cache_resources:
 				Description("The [`cache` resource](/docs/components/caches/about) to target with this processor."),
 			service.NewInterpolatedStringField(dedupFieldKey).
 				Description("An interpolated string yielding the key to deduplicate by for each message.").
-				Examples(`${! meta("kafka_key") }`, `${! content().hash("xxhash64") }`),
+				Examples(`${! metadata("kafka_key") }`, `${! content().hash("xxhash64") }`),
 			service.NewBoolField(dedupFieldDropOnCacheErr).
 				Description("Whether messages should be dropped when the cache returns a general error such as a network issue.").
 				Default(true),

--- a/internal/impl/pure/processor_group_by.go
+++ b/internal/impl/pure/processor_group_by.go
@@ -46,7 +46,7 @@ pipeline:
 output:
   switch:
     cases:
-      - check: meta("grouping") == "foo"
+      - check: metadata("grouping") == "foo"
         output:
           gcp_pubsub:
             project: foo_prod

--- a/internal/impl/pure/processor_group_by_value.go
+++ b/internal/impl/pure/processor_group_by_value.go
@@ -36,7 +36,7 @@ If we were consuming Kafka messages and needed to group them by their key, archi
 pipeline:
   processors:
     - group_by_value:
-        value: ${! meta("kafka_key") }
+        value: ${! metadata("kafka_key") }
     - archive:
         format: tar
     - compress:
@@ -44,7 +44,7 @@ pipeline:
 output:
   aws_s3:
     bucket: TODO
-    path: docs/${! meta("kafka_key") }/${! count("files") }-${! timestamp_unix_nano() }.tar.gz
+    path: docs/${! metadata("kafka_key") }/${! count("files") }-${! timestamp_unix_nano() }.tar.gz
 `+"```"+``).
 			Field(service.NewInterpolatedStringField(gbvpFieldValue).
 				Description("The interpolated string to group based on.").

--- a/internal/impl/pure/processor_log.go
+++ b/internal/impl/pure/processor_log.go
@@ -45,7 +45,7 @@ pipeline:
           root.reason = "cus I wana"
           root.id = this.id
           root.age = this.user.age
-          root.kafka_topic = meta("kafka_topic")
+          root.kafka_topic = metadata("kafka_topic")
 `+"```"+`
 `).
 		Fields(
@@ -59,7 +59,7 @@ pipeline:
 					`root.reason = "cus I wana"
 root.id = this.id
 root.age = this.user.age.number()
-root.kafka_topic = meta("kafka_topic")`,
+root.kafka_topic = metadata("kafka_topic")`,
 				).
 				Optional(),
 			service.NewInterpolatedStringField(logPFieldMessage).

--- a/internal/impl/pure/processor_metric.go
+++ b/internal/impl/pure/processor_metric.go
@@ -89,8 +89,8 @@ pipeline:
         name: Foos
         type: counter
         labels:
-          topic: ${! meta("kafka_topic") }
-          partition: ${! meta("kafka_partition") }
+          topic: ${! metadata("kafka_topic") }
+          partition: ${! metadata("kafka_partition").string() }
           type: ${! json("document.type").or("unknown") }
 
 metrics:
@@ -114,7 +114,7 @@ pipeline:
         name: FooSize
         type: gauge
         labels:
-          topic: ${! meta("kafka_topic") }
+          topic: ${! metadata("kafka_topic") }
         value: ${! json("foo.size") }
 
 metrics:

--- a/internal/impl/questdb/output.go
+++ b/internal/impl/questdb/output.go
@@ -16,6 +16,7 @@ import (
 func questdbOutputConfig() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Summary("Pushes messages to a QuestDB table.").
+		Version("1.3.0").
 		Description(`
 :::warning Important
 We recommend that the dedupe feature is enabled on the QuestDB server. Please visit https://questdb.io/docs/ for more information about deploying, configuring, and using QuestDB.

--- a/internal/impl/redis/output_hash.go
+++ b/internal/impl/redis/output_hash.go
@@ -33,8 +33,8 @@ output:
     url: tcp://localhost:6379
     key: ${!json("id")}
     fields:
-      topic: ${!meta("kafka_topic")}
-      partition: ${!meta("kafka_partition")}
+      topic: ${!metadata("kafka_topic")}
+      partition: ${!metadata("kafka_partition").string()}
       content: ${!json("document.text")}
 `+"```"+`
 

--- a/internal/impl/redis/processor.go
+++ b/internal/impl/redis/processor.go
@@ -38,7 +38,7 @@ performed for each message and the message contents are replaced with the result
 			Version("1.0.0").
 			Optional().
 			Example("root = [ this.key ]").
-			Example(`root = [ meta("kafka_key"), this.count ]`)).
+			Example(`root = [ metadata("kafka_key"), this.count ]`)).
 		Field(service.NewStringAnnotatedEnumField("operator", map[string]string{
 			"keys":   `Returns an array of strings containing all the keys that match the pattern specified by the ` + "`key` field" + `.`,
 			"scard":  `Returns the cardinality of a set, or ` + "`0`" + ` if the key does not exist.`,
@@ -74,7 +74,7 @@ pipeline:
           - redis:
               url: TODO
               command: scard
-              args_mapping: 'root = [ meta("set_key") ]'
+              args_mapping: 'root = [ metadata("set_key") ]'
         result_map: 'root.cardinality = this'
 `).
 		Example("Running Total",

--- a/internal/impl/redis/script_processor.go
+++ b/internal/impl/redis/script_processor.go
@@ -32,11 +32,11 @@ In order to merge the result into the original message compose this processor wi
 		Field(service.NewBloblangField("args_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of arguments required for the specified Redis script.").
 			Example("root = [ this.key ]").
-			Example(`root = [ meta("kafka_key"), "hardcoded_value" ]`)).
+			Example(`root = [ metadata("kafka_key"), "hardcoded_value" ]`)).
 		Field(service.NewBloblangField("keys_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of keys matching in size to the number of arguments required for the specified Redis script.").
 			Example("root = [ this.key ]").
-			Example(`root = [ meta("kafka_key"), this.count ]`)).
+			Example(`root = [ metadata("kafka_key"), this.count ]`)).
 		Field(service.NewIntField("retries").
 			Description("The maximum number of retries before abandoning a request.").
 			Default(3).
@@ -62,7 +62,7 @@ pipeline:
           redis.call("ZADD", "XX", KEYS[1], ARGV[1], value)
 
           return value
-        keys_mapping: 'root = [ meta("key") ]'
+        keys_mapping: 'root = [ metadata("key") ]'
         args_mapping: 'root = [ timestamp_unix_nano() ]'
 `)
 }

--- a/internal/impl/snowflake/output_snowflake_put.go
+++ b/internal/impl/snowflake/output_snowflake_put.go
@@ -241,11 +241,11 @@ input:
       period: 3s
       processors:
         - mapping: |
-            meta kafka_start_offset = meta("kafka_offset").from(0)
-            meta kafka_end_offset = meta("kafka_offset").from(-1)
+            meta kafka_start_offset = metadata("kafka_offset").from(0).string()
+            meta kafka_end_offset = metadata("kafka_offset").from(-1).string()
             meta batch_timestamp = if batch_index() == 0 { now() }
         - mapping: |
-            meta batch_timestamp = if batch_index() != 0 { meta("batch_timestamp").from(0) }
+            meta batch_timestamp = if batch_index() != 0 { metadata("batch_timestamp").from(0).string() }
 
 output:
   snowflake_put:
@@ -258,7 +258,7 @@ output:
     schema: PUBLIC
     stage: "@%BENTO_TBL"
     path: bento/BENTO_TBL/${! @kafka_partition }
-    file_name: ${! @kafka_start_offset }_${! @kafka_end_offset }_${! meta("batch_timestamp") }
+    file_name: ${! @kafka_start_offset }_${! @kafka_end_offset }_${! metadata("batch_timestamp").string() }
     upload_parallel_threads: 4
     compression: NONE
     snowpipe: BENTO_PIPE

--- a/internal/impl/sql/input_sql_raw.go
+++ b/internal/impl/sql/input_sql_raw.go
@@ -28,7 +28,7 @@ func sqlRawInputConfig() *service.ConfigSpec {
 		Field(service.NewBloblangField("args_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of columns specified.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id").string() ]`).
 			Optional()).
 		Field(service.NewAutoRetryNacksToggleField())
 	for _, f := range connFields() {

--- a/internal/impl/sql/output_sql_deprecated.go
+++ b/internal/impl/sql/output_sql_deprecated.go
@@ -25,7 +25,7 @@ For basic inserts use the ` + "[`sql_insert`](/docs/components/outputs/sql)" + `
 		Field(service.NewBloblangField("args_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of placeholder arguments in the field `query`.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id").string() ]`).
 			Optional()).
 		Field(service.NewIntField("max_in_flight").
 			Description("The maximum number of inserts to run in parallel.").

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -33,7 +33,7 @@ func sqlInsertOutputConfig() *service.ConfigSpec {
 		Field(service.NewBloblangField("args_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of columns specified.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`)).
+			Example(`root = [ metadata("user.id").string() ]`)).
 		Field(service.NewStringField("prefix").
 			Description("An optional prefix to prepend to the insert query (before INSERT).").
 			Optional().
@@ -67,7 +67,7 @@ output:
       root = [
         this.user.id,
         this.user.name,
-        meta("kafka_topic"),
+        metadata("kafka_topic"),
       ]
 `,
 		)

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -31,7 +31,7 @@ func sqlRawOutputConfig() *service.ConfigSpec {
 		Field(service.NewBloblangField("args_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of placeholder arguments in the field `query`.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id").string() ]`).
 			Optional()).
 		Field(service.NewIntField("max_in_flight").
 			Description("The maximum number of inserts to run in parallel.").
@@ -56,7 +56,7 @@ output:
       root = [
         this.user.id,
         this.user.name,
-        meta("kafka_topic"),
+        metadata("kafka_topic").string(),
       ]
 `,
 		)

--- a/internal/impl/sql/processor_sql_deprecated.go
+++ b/internal/impl/sql/processor_sql_deprecated.go
@@ -31,7 +31,7 @@ For basic inserts or select queries use either the ` + "[`sql_insert`](/docs/com
 		Field(service.NewBloblangField("args_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of placeholder arguments in the field `query`.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id").string() ]`).
 			Optional()).
 		Field(service.NewStringField("result_codec").
 			Description("Result codec.").

--- a/internal/impl/sql/processor_sql_insert.go
+++ b/internal/impl/sql/processor_sql_insert.go
@@ -35,7 +35,7 @@ If the insert fails to execute then the message will still remain unchanged and 
 		Field(service.NewBloblangField("args_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of columns specified.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`)).
+			Example(`root = [ metadata("user.id").string() ]`)).
 		Field(service.NewStringField("prefix").
 			Description("An optional prefix to prepend to the insert query (before INSERT).").
 			Optional().
@@ -66,7 +66,7 @@ pipeline:
           root = [
             this.user.id,
             this.user.name,
-            meta("kafka_topic"),
+            metadata("kafka_topic"),
           ]
 `,
 		)

--- a/internal/impl/sql/processor_sql_raw.go
+++ b/internal/impl/sql/processor_sql_raw.go
@@ -35,7 +35,7 @@ If the query fails to execute then the message will remain unchanged and the err
 		Field(service.NewBloblangField("args_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of placeholder arguments in the field `query`.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id").string() ]`).
 			Optional()).
 		Field(service.NewBoolField("exec_only").
 			Description("Whether the query result should be discarded. When set to `true` the message contents will remain unchanged, which is useful in cases where you are executing inserts, updates, etc.").
@@ -56,7 +56,7 @@ pipeline:
         driver: mysql
         dsn: foouser:foopassword@tcp(localhost:3306)/foodb
         query: "INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?);"
-        args_mapping: '[ document.foo, document.bar, meta("kafka_topic") ]'
+        args_mapping: '[ document.foo, document.bar, metadata("kafka_topic") ]'
         exec_only: true
 `,
 		).

--- a/internal/impl/sql/processor_sql_select.go
+++ b/internal/impl/sql/processor_sql_select.go
@@ -41,7 +41,7 @@ If the query fails to execute then the message will remain unchanged and the err
 		Field(service.NewBloblangField("args_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of placeholder arguments in the field `where`.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id").string() ]`).
 			Optional()).
 		Field(service.NewStringField("prefix").
 			Description("An optional prefix to prepend to the query (before SELECT).").

--- a/website/docs/components/buffers/system_window.md
+++ b/website/docs/components/buffers/system_window.md
@@ -110,7 +110,7 @@ pipeline:
         root = if batch_index() == 0 {
           {
             "traffic_light": this.traffic_light,
-            "created_at": meta("window_end_timestamp"),
+            "created_at": metadata("window_end_timestamp"),
             "total_cars": json("registration_plate").from_all().unique().length(),
             "passengers": json("passengers").from_all().sum(),
           }
@@ -137,7 +137,7 @@ Default: `"root = now()"`
 
 timestamp_mapping: root = this.created_at
 
-timestamp_mapping: root = meta("kafka_timestamp_unix").number()
+timestamp_mapping: root = metadata("kafka_timestamp_unix").string()
 ```
 
 ### `size`

--- a/website/docs/components/inputs/http_server.md
+++ b/website/docs/components/inputs/http_server.md
@@ -332,7 +332,7 @@ Default: `"200"`
 
 status: ${! json("status") }
 
-status: ${! meta("status") }
+status: ${! metadata("status").string() }
 ```
 
 ### `sync_response.headers`

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -237,6 +237,7 @@ Balancers sets the group balancers to use for dividing topic partitions among gr
 
 Type: `array`  
 Default: `["cooperative_sticky"]`  
+Requires version 1.3.0 or newer  
 
 ### `metadata_max_age`
 
@@ -245,6 +246,7 @@ This sets the maximum age for the client's cached metadata, to allow detection o
 
 Type: `string`  
 Default: `"5m"`  
+Requires version 1.3.0 or newer  
 
 ### `fetch_max_bytes`
 
@@ -253,6 +255,7 @@ This sets the maximum amount of bytes a broker will try to send during a fetch. 
 
 Type: `string`  
 Default: `"50MiB"`  
+Requires version 1.3.0 or newer  
 
 ### `fetch_max_partition_bytes`
 
@@ -261,6 +264,7 @@ Sets the maximum amount of bytes that will be consumed for a single partition in
 
 Type: `string`  
 Default: `"1MiB"`  
+Requires version 1.3.0 or newer  
 
 ### `fetch_max_wait`
 
@@ -269,6 +273,7 @@ This sets the maximum amount of time a broker will wait for a fetch response to 
 
 Type: `string`  
 Default: `"5s"`  
+Requires version 1.3.0 or newer  
 
 ### `preferring_lag`
 
@@ -280,6 +285,7 @@ With this option, you can return topic order and per-topic partition ordering. T
 
 
 Type: `int`  
+Requires version 1.3.0 or newer  
 
 ### `tls`
 

--- a/website/docs/components/inputs/sql_raw.md
+++ b/website/docs/components/inputs/sql_raw.md
@@ -202,7 +202,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id").string() ]
 ```
 
 ### `auto_replay_nacks`

--- a/website/docs/components/outputs/aws_dynamodb.md
+++ b/website/docs/components/outputs/aws_dynamodb.md
@@ -91,7 +91,7 @@ The field `string_columns` is a map of column names to string values, where the 
 string_columns:
   id: ${!json("id")}
   title: ${!json("body.title")}
-  topic: ${!meta("kafka_topic")}
+  topic: ${!metadata("kafka_topic")}
   full_content: ${!content()}
 ```
 

--- a/website/docs/components/outputs/aws_s3.md
+++ b/website/docs/components/outputs/aws_s3.md
@@ -111,7 +111,7 @@ output:
     path: ${!count("files")}-${!timestamp_unix_nano()}.tar.gz
     tags:
       Key1: Value1
-      Timestamp: ${!meta("Timestamp")}
+      Timestamp: ${!metadata("Timestamp").string()}
 ```
 
 ### Credentials
@@ -180,7 +180,7 @@ Default: `"${!count(\"files\")}-${!timestamp_unix_nano()}.txt"`
 
 path: ${!count("files")}-${!timestamp_unix_nano()}.txt
 
-path: ${!meta("kafka_key")}.json
+path: ${!metadata("kafka_key")}.json
 
 path: ${!json("doc.namespace")}/${!json("doc.id")}.json
 ```
@@ -199,7 +199,7 @@ Default: `{}`
 
 tags:
   Key1: Value1
-  Timestamp: ${!meta("Timestamp")}
+  Timestamp: ${!metadata("Timestamp")}
 ```
 
 ### `content_type`

--- a/website/docs/components/outputs/azure_blob_storage.md
+++ b/website/docs/components/outputs/azure_blob_storage.md
@@ -147,7 +147,7 @@ Default: `"${!count(\"files\")}-${!timestamp_unix_nano()}.txt"`
 
 path: ${!count("files")}-${!timestamp_unix_nano()}.json
 
-path: ${!meta("kafka_key")}.json
+path: ${!metadata("kafka_key")}.json
 
 path: ${!json("doc.namespace")}/${!json("doc.id")}.json
 ```

--- a/website/docs/components/outputs/cache.md
+++ b/website/docs/components/outputs/cache.md
@@ -101,7 +101,7 @@ key: ${!count("items")}-${!timestamp_unix_nano()}
 
 key: ${!json("doc.id")}
 
-key: ${!meta("kafka_key")}
+key: ${!metadata("kafka_key")}
 ```
 
 ### `ttl`

--- a/website/docs/components/outputs/gcp_cloud_storage.md
+++ b/website/docs/components/outputs/gcp_cloud_storage.md
@@ -151,7 +151,7 @@ Default: `"${!count(\"files\")}-${!timestamp_unix_nano()}.txt"`
 
 path: ${!count("files")}-${!timestamp_unix_nano()}.txt
 
-path: ${!meta("kafka_key")}.json
+path: ${!metadata("kafka_key")}.json
 
 path: ${!json("doc.namespace")}/${!json("doc.id")}.json
 ```

--- a/website/docs/components/outputs/nats.md
+++ b/website/docs/components/outputs/nats.md
@@ -159,7 +159,7 @@ Default: `{}`
 
 headers:
   Content-Type: application/json
-  Timestamp: ${!meta("Timestamp")}
+  Timestamp: ${!metadata("Timestamp").string()}
 ```
 
 ### `metadata`

--- a/website/docs/components/outputs/nats_jetstream.md
+++ b/website/docs/components/outputs/nats_jetstream.md
@@ -164,7 +164,7 @@ Requires version 1.0.0 or newer
 
 headers:
   Content-Type: application/json
-  Timestamp: ${!meta("Timestamp")}
+  Timestamp: ${!metadata("Timestamp").string()}
 ```
 
 ### `metadata`

--- a/website/docs/components/outputs/questdb.md
+++ b/website/docs/components/outputs/questdb.md
@@ -20,6 +20,8 @@ This component is experimental and therefore subject to change or removal outsid
 :::
 Pushes messages to a QuestDB table.
 
+Introduced in version 1.3.0.
+
 
 <Tabs defaultValue="common" values={[
   { label: 'Common', value: 'common', },

--- a/website/docs/components/outputs/redis_hash.md
+++ b/website/docs/components/outputs/redis_hash.md
@@ -76,8 +76,8 @@ output:
     url: tcp://localhost:6379
     key: ${!json("id")}
     fields:
-      topic: ${!meta("kafka_topic")}
-      partition: ${!meta("kafka_partition")}
+      topic: ${!metadata("kafka_topic")}
+      partition: ${!metadata("kafka_partition").string()}
       content: ${!json("document.text")}
 ```
 

--- a/website/docs/components/outputs/snowflake_put.md
+++ b/website/docs/components/outputs/snowflake_put.md
@@ -261,11 +261,11 @@ input:
       period: 3s
       processors:
         - mapping: |
-            meta kafka_start_offset = meta("kafka_offset").from(0)
-            meta kafka_end_offset = meta("kafka_offset").from(-1)
+            meta kafka_start_offset = metadata("kafka_offset").from(0).string()
+            meta kafka_end_offset = metadata("kafka_offset").from(-1).string()
             meta batch_timestamp = if batch_index() == 0 { now() }
         - mapping: |
-            meta batch_timestamp = if batch_index() != 0 { meta("batch_timestamp").from(0) }
+            meta batch_timestamp = if batch_index() != 0 { metadata("batch_timestamp").from(0).string() }
 
 output:
   snowflake_put:
@@ -278,7 +278,7 @@ output:
     schema: PUBLIC
     stage: "@%BENTO_TBL"
     path: bento/BENTO_TBL/${! @kafka_partition }
-    file_name: ${! @kafka_start_offset }_${! @kafka_end_offset }_${! meta("batch_timestamp") }
+    file_name: ${! @kafka_start_offset }_${! @kafka_end_offset }_${! metadata("batch_timestamp").string() }
     upload_parallel_threads: 4
     compression: NONE
     snowpipe: BENTO_PIPE

--- a/website/docs/components/outputs/sql.md
+++ b/website/docs/components/outputs/sql.md
@@ -132,7 +132,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id").string() ]
 ```
 
 ### `max_in_flight`

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -120,7 +120,7 @@ output:
       root = [
         this.user.id,
         this.user.name,
-        meta("kafka_topic"),
+        metadata("kafka_topic"),
       ]
 ```
 
@@ -220,7 +220,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id").string() ]
 ```
 
 ### `prefix`

--- a/website/docs/components/outputs/sql_raw.md
+++ b/website/docs/components/outputs/sql_raw.md
@@ -116,7 +116,7 @@ output:
       root = [
         this.user.id,
         this.user.name,
-        meta("kafka_topic"),
+        metadata("kafka_topic").string(),
       ]
 ```
 
@@ -221,7 +221,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id").string() ]
 ```
 
 ### `max_in_flight`

--- a/website/docs/components/processors/aws_dynamodb_partiql.md
+++ b/website/docs/components/processors/aws_dynamodb_partiql.md
@@ -83,7 +83,7 @@ pipeline:
         args_mapping: |
           root = [
             { "S": this.foo },
-            { "S": meta("kafka_topic") },
+            { "S": metadata("kafka_topic") },
             { "S": this.document.content },
           ]
 ```

--- a/website/docs/components/processors/azure_cosmosdb.md
+++ b/website/docs/components/processors/azure_cosmosdb.md
@@ -129,7 +129,7 @@ input:
         database: testdb
         container: blobfish
         partition_keys_map: root = json("habitat")
-        item_id: ${! meta("id") }
+        item_id: ${! metadata("id").string() }
         operation: Patch
         patch_operations:
           # Add a new /diet field

--- a/website/docs/components/processors/cached.md
+++ b/website/docs/components/processors/cached.md
@@ -54,12 +54,12 @@ pipeline:
     - branch:
         processors:
           - cached:
-              key: '${! meta("kafka_topic") }-${! meta("kafka_partition") }'
+              key: '${! metadata("kafka_topic") }-${! metadata("kafka_partition").string() }'
               cache: foo_cache
               processors:
                 - mapping: 'root = ""'
                 - http:
-                    url: http://example.com/enrichment/${! meta("kafka_topic") }/${! meta("kafka_partition") }
+                    url: http://example.com/enrichment/${! metadata("kafka_topic") }/${! metadata("kafka_partition").string() }
                     verb: GET
         result_map: 'root.enrichment = this'
 

--- a/website/docs/components/processors/couchbase.md
+++ b/website/docs/components/processors/couchbase.md
@@ -189,5 +189,6 @@ Enable CAS validation.
 
 Type: `bool`  
 Default: `true`  
+Requires version 1.3.0 or newer  
 
 

--- a/website/docs/components/processors/dedupe.md
+++ b/website/docs/components/processors/dedupe.md
@@ -104,6 +104,7 @@ Controls how to handle duplicate values.
 
 Type: `string`  
 Default: `"FIFO"`  
+Requires version 1.4.0 or newer  
 
 | Option | Summary |
 |---|---|

--- a/website/docs/components/processors/dedupe.md
+++ b/website/docs/components/processors/dedupe.md
@@ -30,7 +30,7 @@ Deduplicates messages by storing a key value in a cache using the `add` operator
 label: ""
 dedupe:
   cache: "" # No default (required)
-  key: ${! meta("kafka_key") } # No default (required)
+  key: ${! metadata("kafka_key") } # No default (required)
   drop_on_err: true
 ```
 
@@ -42,7 +42,7 @@ dedupe:
 label: ""
 dedupe:
   cache: "" # No default (required)
-  key: ${! meta("kafka_key") } # No default (required)
+  key: ${! metadata("kafka_key") } # No default (required)
   drop_on_err: true
   strategy: FIFO
 ```
@@ -84,7 +84,7 @@ Type: `string`
 ```yml
 # Examples
 
-key: ${! meta("kafka_key") }
+key: ${! metadata("kafka_key") }
 
 key: ${! content().hash("xxhash64") }
 ```
@@ -126,7 +126,7 @@ pipeline:
   processors:
     - dedupe:
         cache: keycache
-        key: ${! meta("kafka_key") }
+        key: ${! metadata("kafka_key") }
 
 cache_resources:
   - label: keycache

--- a/website/docs/components/processors/group_by.md
+++ b/website/docs/components/processors/group_by.md
@@ -79,7 +79,7 @@ pipeline:
 output:
   switch:
     cases:
-      - check: meta("grouping") == "foo"
+      - check: metadata("grouping") == "foo"
         output:
           gcp_pubsub:
             project: foo_prod

--- a/website/docs/components/processors/group_by_value.md
+++ b/website/docs/components/processors/group_by_value.md
@@ -54,7 +54,7 @@ If we were consuming Kafka messages and needed to group them by their key, archi
 pipeline:
   processors:
     - group_by_value:
-        value: ${! meta("kafka_key") }
+        value: ${! metadata("kafka_key") }
     - archive:
         format: tar
     - compress:
@@ -62,6 +62,6 @@ pipeline:
 output:
   aws_s3:
     bucket: TODO
-    path: docs/${! meta("kafka_key") }/${! count("files") }-${! timestamp_unix_nano() }.tar.gz
+    path: docs/${! metadata("kafka_key") }/${! count("files") }-${! timestamp_unix_nano() }.tar.gz
 ```
 

--- a/website/docs/components/processors/log.md
+++ b/website/docs/components/processors/log.md
@@ -26,7 +26,7 @@ log:
     root.reason = "cus I wana"
     root.id = this.id
     root.age = this.user.age.number()
-    root.kafka_topic = meta("kafka_topic")
+    root.kafka_topic = metadata("kafka_topic")
   message: ""
 ```
 
@@ -46,7 +46,7 @@ pipeline:
           root.reason = "cus I wana"
           root.id = this.id
           root.age = this.user.age
-          root.kafka_topic = meta("kafka_topic")
+          root.kafka_topic = metadata("kafka_topic")
 ```
 
 
@@ -75,7 +75,7 @@ fields_mapping: |-
   root.reason = "cus I wana"
   root.id = this.id
   root.age = this.user.age.number()
-  root.kafka_topic = meta("kafka_topic")
+  root.kafka_topic = metadata("kafka_topic")
 ```
 
 ### `message`

--- a/website/docs/components/processors/metric.md
+++ b/website/docs/components/processors/metric.md
@@ -91,8 +91,8 @@ pipeline:
         name: Foos
         type: counter
         labels:
-          topic: ${! meta("kafka_topic") }
-          partition: ${! meta("kafka_partition") }
+          topic: ${! metadata("kafka_topic") }
+          partition: ${! metadata("kafka_partition").string() }
           type: ${! json("document.type").or("unknown") }
 
 metrics:
@@ -118,7 +118,7 @@ pipeline:
         name: FooSize
         type: gauge
         labels:
-          topic: ${! meta("kafka_topic") }
+          topic: ${! metadata("kafka_topic") }
         value: ${! json("foo.size") }
 
 metrics:

--- a/website/docs/components/processors/nats_request_reply.md
+++ b/website/docs/components/processors/nats_request_reply.md
@@ -193,7 +193,7 @@ Default: `{}`
 
 headers:
   Content-Type: application/json
-  Timestamp: ${!meta("Timestamp")}
+  Timestamp: ${!metadata("Timestamp").string()}
 ```
 
 ### `metadata`

--- a/website/docs/components/processors/parquet_decode.md
+++ b/website/docs/components/processors/parquet_decode.md
@@ -55,7 +55,7 @@ input:
 output:
   file:
     codec: lines
-    path: './foos/${! meta("s3_key") }.jsonl'
+    path: './foos/${! metadata("s3_key") }.jsonl'
 ```
 
 </TabItem>

--- a/website/docs/components/processors/redis.md
+++ b/website/docs/components/processors/redis.md
@@ -80,7 +80,7 @@ pipeline:
           - redis:
               url: TODO
               command: scard
-              args_mapping: 'root = [ meta("set_key") ]'
+              args_mapping: 'root = [ metadata("set_key") ]'
         result_map: 'root.cardinality = this'
 ```
 
@@ -346,7 +346,7 @@ Requires version 1.0.0 or newer
 
 args_mapping: root = [ this.key ]
 
-args_mapping: root = [ meta("kafka_key"), this.count ]
+args_mapping: root = [ metadata("kafka_key"), this.count ]
 ```
 
 ### `retries`

--- a/website/docs/components/processors/redis_script.md
+++ b/website/docs/components/processors/redis_script.md
@@ -96,7 +96,7 @@ pipeline:
           redis.call("ZADD", "XX", KEYS[1], ARGV[1], value)
 
           return value
-        keys_mapping: 'root = [ meta("key") ]'
+        keys_mapping: 'root = [ metadata("key") ]'
         args_mapping: 'root = [ timestamp_unix_nano() ]'
 ```
 
@@ -320,7 +320,7 @@ Type: `string`
 
 args_mapping: root = [ this.key ]
 
-args_mapping: root = [ meta("kafka_key"), "hardcoded_value" ]
+args_mapping: root = [ metadata("kafka_key"), "hardcoded_value" ]
 ```
 
 ### `keys_mapping`
@@ -335,7 +335,7 @@ Type: `string`
 
 keys_mapping: root = [ this.key ]
 
-keys_mapping: root = [ meta("kafka_key"), this.count ]
+keys_mapping: root = [ metadata("kafka_key"), this.count ]
 ```
 
 ### `retries`

--- a/website/docs/components/processors/sql.md
+++ b/website/docs/components/processors/sql.md
@@ -128,7 +128,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id").string() ]
 ```
 
 ### `result_codec`

--- a/website/docs/components/processors/sql_insert.md
+++ b/website/docs/components/processors/sql_insert.md
@@ -106,7 +106,7 @@ pipeline:
           root = [
             this.user.id,
             this.user.name,
-            meta("kafka_topic"),
+            metadata("kafka_topic"),
           ]
 ```
 
@@ -206,7 +206,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id").string() ]
 ```
 
 ### `prefix`

--- a/website/docs/components/processors/sql_raw.md
+++ b/website/docs/components/processors/sql_raw.md
@@ -100,7 +100,7 @@ pipeline:
         driver: mysql
         dsn: foouser:foopassword@tcp(localhost:3306)/foodb
         query: "INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?);"
-        args_mapping: '[ document.foo, document.bar, meta("kafka_topic") ]'
+        args_mapping: '[ document.foo, document.bar, metadata("kafka_topic") ]'
         exec_only: true
 ```
 
@@ -225,7 +225,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id").string() ]
 ```
 
 ### `exec_only`

--- a/website/docs/components/processors/sql_select.md
+++ b/website/docs/components/processors/sql_select.md
@@ -228,7 +228,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id").string() ]
 ```
 
 ### `prefix`

--- a/website/docs/guides/bloblang/functions.md
+++ b/website/docs/guides/bloblang/functions.md
@@ -679,6 +679,8 @@ root.uuid = fake("uuid_hyphenated")
 
 ### `count`
 
+:::caution DEPRECATED
+::: 
 The `count` function is a counter starting at 1 which increments after each time it is called. Count takes an argument which is an identifier for the counter, allowing you to specify multiple unique counters in your configuration.
 
 #### Parameters
@@ -701,6 +703,8 @@ root.id = count("bloblang_function_example")
 
 ### `meta`
 
+:::caution DEPRECATED
+::: 
 Returns the value of a metadata key from the input message as a string, or `null` if the key does not exist. Since values are extracted from the read-only input message they do NOT reflect changes made from within the map. In order to query metadata mutations made within a mapping use the [`root_meta` function](#root_meta). This function supports extracting metadata from other messages of a batch with the `from` method.
 
 #### Parameters
@@ -722,6 +726,8 @@ root.all_metadata = meta()
 
 ### `root_meta`
 
+:::caution DEPRECATED
+::: 
 Returns the value of a metadata key from the new message being created as a string, or `null` if the key does not exist. Changes made to metadata during a mapping will be reflected by this function.
 
 #### Parameters

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -177,7 +177,7 @@ const features = [
     description: (
       <>
         <p>
-          Bento is able to glue a wide range of <a href="/bento/docs/components/inputs/about">sources</a> and <a href="/bento/docs/components/outputs/about">sinks</a> together and hook into a variety of <a href="/bento/docs/components/processors/sql">databases</a>, <a href="/bento/docs/components/processors/cache">caches</a>, <a href="/bento/docs/components/processors/http">HTTP APIs</a>, <a href="/bento/docs/components/processors/aws_lambda">lambdas</a> and <a href="/bento/docs/components/processors/about">more</a>, enabling you to seamlessly drop it into your existing infrastructure.
+          Bento is able to glue a wide range of <a href="/bento/docs/components/inputs/about">sources</a> and <a href="/bento/docs/components/outputs/about">sinks</a> together and hook into a variety of <a href="/bento/docs/components/processors/sql_raw">databases</a>, <a href="/bento/docs/components/processors/cache">caches</a>, <a href="/bento/docs/components/processors/http">HTTP APIs</a>, <a href="/bento/docs/components/processors/aws_lambda">lambdas</a> and <a href="/bento/docs/components/processors/about">more</a>, enabling you to seamlessly drop it into your existing infrastructure.
         </p>
         <p>
           Working with disparate APIs and services can be a daunting task, doubly so in a streaming data context. With Bento it's possible to break these tasks down and automatically parallelize them as <a href="/bento/cookbooks/enrichments">a streaming workflow</a>.


### PR DESCRIPTION
- updated 'databases' link on index.tsx to be `sql_raw` rather than deprecated `sql` https://github.com/warpstreamlabs/bento/issues/98
- remove references to meta() bloblang function in component examples https://github.com/warpstreamlabs/bento/issues/112
- set the `version` of some fields and components added since 1.0.0 https://github.com/warpstreamlabs/bento/issues/153
- added a depreciated warning to deprecated bloblang function so more visible esp. if coming from an anchor link.