### PR TITLE
fix for nats_kv to be consistent in passing meta values along

### DIFF
--- a/internal/impl/nats/integration_kv_test.go
+++ b/internal/impl/nats/integration_kv_test.go
@@ -151,6 +151,7 @@ cache_resources:
 			require.NoError(t, err)
 
 			m := service.NewMessage([]byte("hello"))
+			m.MetaSetMut("inherited", "world")
 			return p.Process(context.Background(), m)
 		}
 
@@ -172,6 +173,12 @@ cache_resources:
 			bytes, err := m.AsBytes()
 			require.NoError(t, err)
 			assert.Equal(t, []byte("lawblog"), bytes)
+			if v, ok := m.MetaGetMut("inherited"); ok {
+				assert.Equal(t, "world", v)
+			} else {
+				t.Error("inherited metadata not found")
+			}
+
 		})
 
 		t.Run("get_revision operation", func(t *testing.T) {
@@ -193,6 +200,12 @@ cache_resources:
 			bytes, err := m.AsBytes()
 			require.NoError(t, err)
 			assert.Equal(t, []byte("lawblog"), bytes)
+			if v, ok := m.MetaGetMut("inherited"); ok {
+				assert.Equal(t, "world", v)
+			} else {
+				t.Error("inherited metadata not found")
+			}
+
 		})
 
 		t.Run("create operation (success)", func(t *testing.T) {
@@ -210,6 +223,12 @@ cache_resources:
 			bytes, err := m.AsBytes()
 			require.NoError(t, err)
 			assert.Equal(t, []byte("hello"), bytes)
+			if v, ok := m.MetaGetMut("inherited"); ok {
+				assert.Equal(t, "world", v)
+			} else {
+				t.Error("inherited metadata not found")
+			}
+
 		})
 
 		t.Run("create operation (error)", func(t *testing.T) {


### PR DESCRIPTION
The `nats_kv` processor removed all meta values from message on succes. That is not consistent behaviour with other operations.

- The operations `get` and `get_revision` now copy any pre existing meta values on success.
- Test `get` and `get_revision` as well as one other operation for consistency.