### PR TITLE
Disable strict mode in the presence of incompatible processors

### DIFF
--- a/internal/bundle/strict/bundle.go
+++ b/internal/bundle/strict/bundle.go
@@ -1,6 +1,8 @@
 package strict
 
 import (
+	"sync/atomic"
+
 	"github.com/warpstreamlabs/bento/internal/bundle"
 	"github.com/warpstreamlabs/bento/internal/component/processor"
 )
@@ -11,14 +13,28 @@ import (
 func StrictBundle(b *bundle.Environment) *bundle.Environment {
 	strictEnv := b.Clone()
 
+	// Allows us to globally toggle strict mode for all processors in a thread-safe way.
+	// TODO: Create a custom environment/NewManagement that can manage state better.
+	var isStrictEnabled = &atomic.Bool{}
+	isStrictEnabled.Store(true)
+
 	for _, spec := range b.ProcessorDocs() {
 		_ = strictEnv.ProcessorAdd(func(conf processor.Config, nm bundle.NewManagement) (processor.V1, error) {
+			if isProcessorIncompatible(conf.Type) {
+				nm.Logger().Warn("Disabling strict mode due to incompatible processor(s) of type '%s'", conf.Type)
+				if isStrictEnabled.Load() {
+					isStrictEnabled.Store(false)
+				}
+			}
+
 			proc, err := b.ProcessorInit(conf, nm)
 			if err != nil {
 				return nil, err
 			}
-			proc = wrapWithStrict(proc)
-			return proc, err
+
+			// Pass global flag to all processors
+			strictProc := wrapWithStrict(proc, setAtomicStrictFlag(isStrictEnabled))
+			return strictProc, nil
 		}, spec)
 	}
 

--- a/internal/bundle/strict/bundle_test.go
+++ b/internal/bundle/strict/bundle_test.go
@@ -48,6 +48,73 @@ bloblang: root = this
 	assert.Equal(t, `{"hello":"world"}`, string(msgs[0].Get(0).AsBytes()))
 }
 
+func TestStrictBundleProcessorNested(t *testing.T) {
+	senv := strict.StrictBundle(bundle.GlobalEnvironment)
+	tCtx := context.Background()
+
+	pConf, err := testutil.ProcessorFromYAML(`
+processors:
+ - bloblang: root = this
+`)
+	require.NoError(t, err)
+
+	mgr, err := manager.New(
+		manager.ResourceConfig{},
+		manager.OptSetEnvironment(senv),
+	)
+	require.NoError(t, err)
+
+	proc, err := mgr.NewProcessor(pConf)
+	require.NoError(t, err)
+
+	msg := message.QuickBatch([][]byte{[]byte("not a structured doc")})
+	msgs, res := proc.ProcessBatch(tCtx, msg)
+	require.Empty(t, msgs)
+	require.Error(t, res)
+	assert.ErrorContains(t, res, "invalid character 'o' in literal null (expecting 'u')")
+
+	msg = message.QuickBatch([][]byte{[]byte(`{"hello":"world"}`)})
+	msgs, res = proc.ProcessBatch(tCtx, msg)
+	require.NoError(t, res)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, 1, msgs[0].Len())
+	assert.Equal(t, `{"hello":"world"}`, string(msgs[0].Get(0).AsBytes()))
+}
+
+func TestDisableStrictBundleProcessor(t *testing.T) {
+	senv := strict.StrictBundle(bundle.GlobalEnvironment)
+	tCtx := context.Background()
+
+	pConf, err := testutil.ProcessorFromYAML(`
+processors:
+ - bloblang: root = this
+ - catch: []
+`)
+	require.NoError(t, err)
+
+	mgr, err := manager.New(
+		manager.ResourceConfig{},
+		manager.OptSetEnvironment(senv),
+	)
+	require.NoError(t, err)
+
+	proc, err := mgr.NewProcessor(pConf)
+	require.NoError(t, err)
+
+	msg := message.QuickBatch([][]byte{[]byte("not a structured doc")})
+	msgs, res := proc.ProcessBatch(tCtx, msg)
+	require.Len(t, msgs, 1)
+	require.NoError(t, res)
+	assert.Equal(t, "not a structured doc", string(msgs[0].Get(0).AsBytes()))
+
+	msg = message.QuickBatch([][]byte{[]byte(`{"hello":"world"}`)})
+	msgs, res = proc.ProcessBatch(tCtx, msg)
+	require.NoError(t, res)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, 1, msgs[0].Len())
+	assert.Equal(t, `{"hello":"world"}`, string(msgs[0].Get(0).AsBytes()))
+}
+
 func TestStrictBundleProcessorMultiMessage(t *testing.T) {
 	senv := strict.StrictBundle(bundle.GlobalEnvironment)
 	tCtx := context.Background()

--- a/internal/bundle/strict/package.go
+++ b/internal/bundle/strict/package.go
@@ -1,0 +1,18 @@
+package strict
+
+import "slices"
+
+var incompatibleProcessors []string
+
+func init() {
+	incompatibleProcessors = []string{
+		"try",
+		"catch",
+		"switch",
+	}
+}
+
+func isProcessorIncompatible(name string) bool {
+	return slices.Contains(incompatibleProcessors, name)
+
+}

--- a/internal/bundle/strict/package.go
+++ b/internal/bundle/strict/package.go
@@ -2,17 +2,13 @@ package strict
 
 import "slices"
 
-var incompatibleProcessors []string
-
-func init() {
-	incompatibleProcessors = []string{
-		"try",
-		"catch",
-		"switch",
-	}
+var incompatibleProcessors = []string{
+	"try",
+	"catch",
+	"switch",
+	"retry",
 }
 
 func isProcessorIncompatible(name string) bool {
 	return slices.Contains(incompatibleProcessors, name)
-
 }

--- a/website/docs/components/processors/about.md
+++ b/website/docs/components/processors/about.md
@@ -75,7 +75,9 @@ error_handling:
   strategy: reject
 ```
 
-This behavior also bypasses Bento's traditional error handling mechanisms like `catch` and `try` (described in [Error Handling][error_handling]) since the entire transaction is rejected before messages can reach error handling components.
+Note, that `try`, `catch`, and `switch` processors (described in [Error Handling][error_handling]) are currently incompatible with a global error handling strategy since the entire transaction is rejected before messages can reach error handling components.
+
+To avoid behaviour conflicts, any global error configuration will be disabled when _any_ of the above processors are present in your Bento configuration.
 
 More stable alternatives to `error_handling` could be considered:
 

--- a/website/docs/components/processors/about.md
+++ b/website/docs/components/processors/about.md
@@ -75,7 +75,7 @@ error_handling:
   strategy: reject
 ```
 
-Note, that `try`, `catch`, and `switch` processors (described in [Error Handling][error_handling]) are currently incompatible with a global error handling strategy since the entire transaction is rejected before messages can reach error handling components.
+Note, that `try`, `catch`, `retry`, and `switch` processors (described in [Error Handling][error_handling]) are currently incompatible with a global error handling strategy since the entire transaction is rejected before messages can reach error handling components.
 
 To avoid behaviour conflicts, any global error configuration will be disabled when _any_ of the above processors are present in your Bento configuration.
 


### PR DESCRIPTION
## Changes

Adds an atomic flag to all strict processors used to toggle whether strict mode is enabled or not. This is currently used to prevent strict mode being activated when a `try`, `catch`, or `switch` processor is present.

Future versions will better cater for these custom scenarios in strict mode, but for now, we'll favour declarative error handling over the experimental strict mode.