### PR TITLE
Replace `golang.org/x/exp/rand` with `math/rand/v2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.32.0
 	go.uber.org/multierr v1.11.0
 	golang.org/x/crypto v0.35.0
-	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f
 	golang.org/x/net v0.34.0
 	golang.org/x/oauth2 v0.24.0
 	golang.org/x/sync v0.11.0
@@ -159,7 +158,10 @@ require (
 	modernc.org/sqlite v1.28.0
 )
 
-require github.com/go-zeromq/goczmq/v4 v4.2.2 // indirect
+require (
+	github.com/go-zeromq/goczmq/v4 v4.2.2 // indirect
+	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f // indirect
+)
 
 require (
 	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect

--- a/internal/batch/policy/policy.go
+++ b/internal/batch/policy/policy.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"strconv"
 	"time"
-
-	"golang.org/x/exp/rand"
 
 	"github.com/warpstreamlabs/bento/internal/batch/policy/batchconfig"
 	"github.com/warpstreamlabs/bento/internal/bloblang/mapping"
@@ -200,7 +199,7 @@ func (p *Batcher) UntilNext() time.Duration {
 
 	var jitter time.Duration
 	if p.jitter > 0 {
-		jitter = time.Duration(rand.Int63n(int64(p.jitter * float64(p.period))))
+		jitter = time.Duration(rand.Int64N(int64(p.jitter * float64(p.period))))
 	}
 
 	tUntil := time.Until(p.lastBatch.Add(p.period + jitter))


### PR DESCRIPTION
`golang.org/x/exp/rand` has been deprecated and scheduled to be deleted.

Reference: https://github.com/golang/exp/commit/f9890c6ad9f380fd3cdb66a33843f522d4790e03
Reference: https://go.dev/doc/go1.22#math_rand_v2