### PR TITLE
Disable strict mode with incompatible Bloblang functions & method

### DIFF
--- a/internal/bundle/strict/bloblang.go
+++ b/internal/bundle/strict/bloblang.go
@@ -1,0 +1,41 @@
+package strict
+
+import (
+	"github.com/warpstreamlabs/bento/internal/bloblang"
+	"github.com/warpstreamlabs/bento/internal/bloblang/query"
+	"github.com/warpstreamlabs/bento/internal/bundle"
+)
+
+func StrictBloblangEnvironment(nm bundle.NewManagement) *bloblang.Environment {
+	env := nm.BloblEnvironment()
+	newEnv := bloblang.NewEnvironment()
+
+	env.WalkFunctions(func(name string, spec query.FunctionSpec) {
+		newEnv.RegisterFunction(spec, func(args *query.ParsedParams) (query.Function, error) {
+			if isBloblangFunctionIncompatible(name) {
+				nm.Logger().Warn("Disabling strict mode due to incompatible Bloblang function(s) of type '%s'", name)
+				nm.SetGeneric(strictModeEnabledKey, false)
+			} else {
+				// For compatible processors, set true if not already set
+				nm.GetOrSetGeneric(strictModeEnabledKey, true)
+			}
+
+			return query.InitFunctionHelper(name, args.Raw()...)
+		})
+	})
+
+	env.WalkMethods(func(name string, spec query.MethodSpec) {
+		newEnv.RegisterMethod(spec, func(target query.Function, args *query.ParsedParams) (query.Function, error) {
+			if isBloblangMethodIncompatible(name) {
+				nm.Logger().Warn("Disabling strict mode due to incompatible Bloblang method(s) of type '%s'", name)
+				nm.SetGeneric(strictModeEnabledKey, false)
+			} else {
+				// For compatible processors, set true if not already set
+				nm.GetOrSetGeneric(strictModeEnabledKey, true)
+			}
+			return query.InitMethodHelper(name, target, args.Raw()...)
+		})
+	})
+
+	return newEnv
+}

--- a/internal/bundle/strict/bloblang.go
+++ b/internal/bundle/strict/bloblang.go
@@ -11,7 +11,7 @@ func StrictBloblangEnvironment(nm bundle.NewManagement) *bloblang.Environment {
 	newEnv := bloblang.NewEnvironment()
 
 	env.WalkFunctions(func(name string, spec query.FunctionSpec) {
-		newEnv.RegisterFunction(spec, func(args *query.ParsedParams) (query.Function, error) {
+		_ = newEnv.RegisterFunction(spec, func(args *query.ParsedParams) (query.Function, error) {
 			if isBloblangFunctionIncompatible(name) {
 				nm.Logger().Warn("Disabling strict mode due to incompatible Bloblang function(s) of type '%s'", name)
 				nm.SetGeneric(strictModeEnabledKey, false)
@@ -25,7 +25,7 @@ func StrictBloblangEnvironment(nm bundle.NewManagement) *bloblang.Environment {
 	})
 
 	env.WalkMethods(func(name string, spec query.MethodSpec) {
-		newEnv.RegisterMethod(spec, func(target query.Function, args *query.ParsedParams) (query.Function, error) {
+		_ = newEnv.RegisterMethod(spec, func(target query.Function, args *query.ParsedParams) (query.Function, error) {
 			if isBloblangMethodIncompatible(name) {
 				nm.Logger().Warn("Disabling strict mode due to incompatible Bloblang method(s) of type '%s'", name)
 				nm.SetGeneric(strictModeEnabledKey, false)

--- a/internal/bundle/strict/bundle.go
+++ b/internal/bundle/strict/bundle.go
@@ -7,6 +7,7 @@ import (
 	"github.com/warpstreamlabs/bento/internal/component/output"
 	oprocessors "github.com/warpstreamlabs/bento/internal/component/output/processors"
 	"github.com/warpstreamlabs/bento/internal/component/processor"
+	"github.com/warpstreamlabs/bento/internal/manager"
 	"github.com/warpstreamlabs/bento/internal/pipeline"
 	"github.com/warpstreamlabs/bento/internal/pipeline/constructor"
 )
@@ -27,6 +28,42 @@ func isStrictModeEnabled(mgr bundle.NewManagement) bool {
 		return false
 	}
 	return enabled
+}
+
+//------------------------------------------------------------------------------
+
+// OptSetRetryModeFromManager returns a set of options that re-configure a manager to automatically
+// retry failed/errored messages. It applies retryable configurations to all plugins within the bundle.Environment,
+// affecting both components and resources, in addition to functions and methods of the bloblang.Environment.
+// This ensures the manager operates in a mode suitable for retrying errored messages.
+func OptSetRetryModeFromManager() []manager.OptFunc {
+	return []manager.OptFunc{
+		func(t *manager.Type) {
+			blobEnv := StrictBloblangEnvironment(t)
+			manager.OptSetBloblangEnvironment(blobEnv)(t)
+		},
+		func(t *manager.Type) {
+			env := RetryBundle(t.Environment())
+			manager.OptSetEnvironment(env)(t)
+		},
+	}
+}
+
+// OptSetStrictModeFromManager returns a set of options that re-configure a manager to automatically
+// reject failed/errored messages. It applies strict rejection configurations to all plugins within the bundle.Environment,
+// affecting both components and resources, in addition to functions and methods of the bloblang.Environment.
+// This ensures the manager operates in a mode suitable for rejecting all errored messages.
+func OptSetStrictModeFromManager() []manager.OptFunc {
+	return []manager.OptFunc{
+		func(t *manager.Type) {
+			blobEnv := StrictBloblangEnvironment(t)
+			manager.OptSetBloblangEnvironment(blobEnv)(t)
+		},
+		func(t *manager.Type) {
+			env := StrictBundle(t.Environment())
+			manager.OptSetEnvironment(env)(t)
+		},
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/internal/bundle/strict/bundle_test.go
+++ b/internal/bundle/strict/bundle_test.go
@@ -3,6 +3,7 @@ package strict_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -203,20 +204,20 @@ func TestStrictBundleOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	// include a DLQ where errored messages go to stdout
-	err = streamBuilder.AddOutputYAML(`
+	err = streamBuilder.AddOutputYAML(fmt.Sprintf(`
 switch: 
   cases:
     - check: !errored()
       continue: true
       output:
         file:
-          path: ./tmp/data.txt
+          path: %s/data.txt
           codec: lines
     - check: errored()
       continue: false
       output:
         stdout: {}
-`)
+`, t.TempDir()))
 	require.NoError(t, err)
 
 	sendFn, err := streamBuilder.AddProducerFunc()

--- a/internal/bundle/strict/bundle_test.go
+++ b/internal/bundle/strict/bundle_test.go
@@ -272,7 +272,7 @@ processors:
 
 	mgr, err := manager.New(
 		manager.ResourceConfig{},
-		strict.OptSetRetryModeFromManager()...,
+		strict.OptSetStrictModeFromManager()...,
 	)
 	require.NoError(t, err)
 
@@ -306,7 +306,7 @@ processors:
 
 	mgr, err := manager.New(
 		manager.ResourceConfig{},
-		strict.OptSetRetryModeFromManager()...,
+		strict.OptSetStrictModeFromManager()...,
 	)
 	require.NoError(t, err)
 

--- a/internal/bundle/strict/bundle_test.go
+++ b/internal/bundle/strict/bundle_test.go
@@ -126,7 +126,11 @@ func TestStrictBundleProcessorMultiMessage(t *testing.T) {
 	tCtx := context.Background()
 
 	pConf, err := testutil.ProcessorFromYAML(`
-bloblang: root = this
+processors:
+  - mapping: |
+      root = this
+  - mapping: |
+      root = "What is love?"
 `)
 	require.NoError(t, err)
 
@@ -170,8 +174,25 @@ bloblang: root = this
 	require.Empty(t, msgs)
 	require.Error(t, res)
 	assert.ErrorContains(t, res, "invalid character 'o' in literal null (expecting 'u')")
+
+	// Multiple errored messages
+	msg = message.QuickBatch([][]byte{
+		[]byte(`{"msg":"Baby don't hurt me"}`),
+		[]byte(`{"msg":"Don't hurt me"}`),
+		[]byte(`{"msg":"No more"}`),
+	})
+	msgs, res = proc.ProcessBatch(tCtx, msg)
+	require.NotEmpty(t, msgs)
+	require.NoError(t, res)
+
+	assert.Equal(t, 3, msgs[0].Len())
+	assert.Equal(t, "What is love?", string(msgs[0].Get(0).AsBytes()))
+	assert.Equal(t, "What is love?", string(msgs[0].Get(1).AsBytes()))
+	assert.Equal(t, "What is love?", string(msgs[0].Get(2).AsBytes()))
+
 }
 
+// FIXME: The output should be in memory, not a file.
 func TestStrictBundleOutput(t *testing.T) {
 	streamBuilder := service.NewStreamBuilder()
 	err := streamBuilder.SetLoggerYAML(`level: off`)
@@ -235,4 +256,106 @@ switch:
 	r.Close()
 
 	assert.Equal(t, "praise be to the omnissiah\n", buf.String())
+}
+
+func TestStrictBundleBloblangFunction(t *testing.T) {
+	tCtx := context.Background()
+	pConf, err := testutil.ProcessorFromYAML(`
+processors:
+  - mapping: |
+      root = this
+  - mapping: |
+      root = if errored() { "naughty" } else { "nice" }
+`)
+	require.NoError(t, err)
+
+	mgr, err := manager.New(
+		manager.ResourceConfig{},
+		strict.OptSetRetryModeFromManager()...,
+	)
+	require.NoError(t, err)
+
+	proc, err := mgr.NewProcessor(pConf)
+	require.NoError(t, err)
+
+	msg := message.QuickBatch([][]byte{[]byte("not a structured doc")})
+	msgs, res := proc.ProcessBatch(tCtx, msg)
+	require.Len(t, msgs, 1)
+	require.NoError(t, res)
+	assert.Equal(t, "naughty", string(msgs[0].Get(0).AsBytes()))
+
+	msg = message.QuickBatch([][]byte{[]byte(`{"hello":"world"}`)})
+	msgs, res = proc.ProcessBatch(tCtx, msg)
+	require.NoError(t, res)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, 1, msgs[0].Len())
+	assert.Equal(t, "nice", string(msgs[0].Get(0).AsBytes()))
+}
+
+func TestDisableStrictBundleBloblangFunction(t *testing.T) {
+	tCtx := context.Background()
+	pConf, err := testutil.ProcessorFromYAML(`
+processors:
+  - mapping: |
+      root = this
+  - mapping: |
+      root = if errored() { "naughty" } else { "nice" }
+`)
+	require.NoError(t, err)
+
+	mgr, err := manager.New(
+		manager.ResourceConfig{},
+		strict.OptSetRetryModeFromManager()...,
+	)
+	require.NoError(t, err)
+
+	proc, err := mgr.NewProcessor(pConf)
+	require.NoError(t, err)
+
+	msg := message.QuickBatch([][]byte{[]byte("not a structured doc")})
+	msgs, res := proc.ProcessBatch(tCtx, msg)
+	require.Len(t, msgs, 1)
+	require.NoError(t, res)
+	assert.Equal(t, "naughty", string(msgs[0].Get(0).AsBytes()))
+
+	msg = message.QuickBatch([][]byte{[]byte(`{"hello":"world"}`)})
+	msgs, res = proc.ProcessBatch(tCtx, msg)
+	require.NoError(t, res)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, 1, msgs[0].Len())
+	assert.Equal(t, "nice", string(msgs[0].Get(0).AsBytes()))
+}
+
+func TestDisableStrictBundleBloblangMethods(t *testing.T) {
+	tCtx := context.Background()
+	pConf, err := testutil.ProcessorFromYAML(`
+processors:
+  - mapping: |
+      root = this.catch(err -> {"error": err})
+  - mapping: |
+      root = if this.exists("error") { "naughty" } else { "nice" }
+`)
+	require.NoError(t, err)
+
+	mgr, err := manager.New(
+		manager.ResourceConfig{},
+		strict.OptSetRetryModeFromManager()...,
+	)
+	require.NoError(t, err)
+
+	proc, err := mgr.NewProcessor(pConf)
+	require.NoError(t, err)
+
+	msg := message.QuickBatch([][]byte{[]byte("not a structured doc")})
+	msgs, res := proc.ProcessBatch(tCtx, msg)
+	require.Len(t, msgs, 1)
+	require.NoError(t, res)
+	assert.Equal(t, "naughty", string(msgs[0].Get(0).AsBytes()))
+
+	msg = message.QuickBatch([][]byte{[]byte(`{"hello":"world"}`)})
+	msgs, res = proc.ProcessBatch(tCtx, msg)
+	require.NoError(t, res)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, 1, msgs[0].Len())
+	assert.Equal(t, "nice", string(msgs[0].Get(0).AsBytes()))
 }

--- a/internal/bundle/strict/package.go
+++ b/internal/bundle/strict/package.go
@@ -5,13 +5,20 @@ import "slices"
 var incompatibleProcessors = []string{
 	"try",
 	"catch",
-	"switch",
 	"retry",
 }
 
 var incompatibleOutputs = []string{
 	"reject_errored",
-	"switch",
+}
+
+var incompatibleBloblangFunctions = []string{
+	"error",
+	"errored",
+}
+
+var incompatibleBloblangMethods = []string{
+	"catch",
 }
 
 func isProcessorIncompatible(name string) bool {
@@ -20,4 +27,12 @@ func isProcessorIncompatible(name string) bool {
 
 func isOutputIncompatible(name string) bool {
 	return slices.Contains(incompatibleOutputs, name)
+}
+
+func isBloblangFunctionIncompatible(name string) bool {
+	return slices.Contains(incompatibleBloblangFunctions, name)
+}
+
+func isBloblangMethodIncompatible(name string) bool {
+	return slices.Contains(incompatibleBloblangMethods, name)
 }

--- a/internal/cli/common/manager.go
+++ b/internal/cli/common/manager.go
@@ -112,20 +112,10 @@ func CreateManager(
 	}
 
 	if conf.ErrorHandling.Strategy == "reject" {
-		mgrOpts = append(mgrOpts, func(t *manager.Type) {
-			env := strict.StrictBundle(t.Environment())
-			manager.OptSetEnvironment(env)(t)
-		})
+		mgrOpts = append(mgrOpts, strict.OptSetStrictModeFromManager()...)
 	} else if conf.ErrorHandling.Strategy == "retry" {
 		mgrOpts = append(mgrOpts, manager.OptSetPipelineCtor(strict.NewRetryFeedbackPipelineCtor()))
-		mgrOpts = append(mgrOpts, func(t *manager.Type) {
-			env := strict.RetryBundle(t.Environment())
-			manager.OptSetEnvironment(env)(t)
-		})
-		mgrOpts = append(mgrOpts, func(t *manager.Type) {
-			blobEnv := strict.StrictBloblangEnvironment(t)
-			manager.OptSetBloblangEnvironment(blobEnv)(t)
-		})
+		mgrOpts = append(mgrOpts, strict.OptSetRetryModeFromManager()...)
 	}
 
 	// Create resource manager.

--- a/internal/cli/common/manager.go
+++ b/internal/cli/common/manager.go
@@ -112,10 +112,20 @@ func CreateManager(
 	}
 
 	if conf.ErrorHandling.Strategy == "reject" {
-		mgrOpts = append(mgrOpts, manager.OptSetEnvironment(strict.StrictBundle(bundle.GlobalEnvironment)))
+		mgrOpts = append(mgrOpts, func(t *manager.Type) {
+			env := strict.StrictBundle(t.Environment())
+			manager.OptSetEnvironment(env)(t)
+		})
 	} else if conf.ErrorHandling.Strategy == "retry" {
-		mgrOpts = append(mgrOpts, manager.OptSetEnvironment(strict.RetryBundle(bundle.GlobalEnvironment)))
 		mgrOpts = append(mgrOpts, manager.OptSetPipelineCtor(strict.NewRetryFeedbackPipelineCtor()))
+		mgrOpts = append(mgrOpts, func(t *manager.Type) {
+			env := strict.RetryBundle(t.Environment())
+			manager.OptSetEnvironment(env)(t)
+		})
+		mgrOpts = append(mgrOpts, func(t *manager.Type) {
+			blobEnv := strict.StrictBloblangEnvironment(t)
+			manager.OptSetBloblangEnvironment(blobEnv)(t)
+		})
 	}
 
 	// Create resource manager.


### PR DESCRIPTION
## Changes

- Disables strict mode when using a Bloblang:
  - `error` or `errored` function
  - `catch` method
- The `switch` keyword/processor no longer disables strict mode.

## Testing

- Fixes `TestStrictBundleOutput` DLQ test not cleaning up the temporary file.
- Added a `TestStrictBundleBloblangFunction` and `TestDisableStrictBundleBloblangMethods` test
