### PR TITLE
remove t.Parallel() in gcp_pubsub int. tests

### DIFF
--- a/internal/impl/gcp/integration_pubsub_test.go
+++ b/internal/impl/gcp/integration_pubsub_test.go
@@ -17,7 +17,6 @@ import (
 
 func TestIntegrationGCPPubSub(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)


### PR DESCRIPTION
can't run these in parallel because of the setting of env vars:

panic: testing: t.Setenv called after t.Parallel; cannot set environment variables in parallel tests [recovered]
	panic: testing: t.Setenv called after t.Parallel; cannot set environment variables in parallel tests