### PR TITLE
add expected_headers & expected_number_of_fields to csv scanner

### DIFF
--- a/internal/impl/pure/scanner_csv.go
+++ b/internal/impl/pure/scanner_csv.go
@@ -49,7 +49,7 @@ This scanner adds the following metadata to each message:
 				Example([]string{"first_name", "last_name", "age"}).
 				Optional(),
 			service.NewIntField(scsvFieldExpectedNumberOfFields).
-				Description("The numer of expected fields in the csv file.").
+				Description("The number of expected fields in the csv file.").
 				LintRule(`root = if this < 1 { [ "`+scsvFieldExpectedNumberOfFields+` must be at least 1" ] }`).
 				Optional(),
 		)

--- a/internal/impl/pure/scanner_csv.go
+++ b/internal/impl/pure/scanner_csv.go
@@ -5,15 +5,18 @@ import (
 	"encoding/csv"
 	"errors"
 	"io"
+	"slices"
 
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
 const (
-	scsvFieldCustomDelimiter = "custom_delimiter"
-	scsvFieldParseHeaderRow  = "parse_header_row"
-	scsvFieldLazyQuotes      = "lazy_quotes"
-	scsvFieldContinueOnError = "continue_on_error"
+	scsvFieldCustomDelimiter        = "custom_delimiter"
+	scsvFieldParseHeaderRow         = "parse_header_row"
+	scsvFieldLazyQuotes             = "lazy_quotes"
+	scsvFieldContinueOnError        = "continue_on_error"
+	scsvFieldExpectedHeaders        = "expected_headers"
+	scsvFieldExpectedNumberOfFields = "expected_number_of_fields"
 )
 
 func csvScannerSpec() *service.ConfigSpec {
@@ -41,6 +44,14 @@ This scanner adds the following metadata to each message:
 			service.NewBoolField(scsvFieldContinueOnError).
 				Description("If a row fails to parse due to any error emit an empty message marked with the error and then continue consuming subsequent rows when possible. This can sometimes be useful in situations where input data contains individual rows which are malformed. However, when a row encounters a parsing error it is impossible to guarantee that following rows are valid, as this indicates that the input data is unreliable and could potentially emit misaligned rows.").
 				Default(false),
+			service.NewStringListField(scsvFieldExpectedHeaders).
+				Description("An optional list of expected headers in the header row, that will be checked against the file contents.").
+				Example([]string{"first_name", "last_name", "age"}).
+				Optional(),
+			service.NewIntField(scsvFieldExpectedNumberOfFields).
+				Description("The numer of expected fields in the csv file.").
+				LintRule(`root = if this < 1 { [ "`+scsvFieldExpectedNumberOfFields+` must be at least 1" ] }`).
+				Optional(),
 		)
 }
 
@@ -70,14 +81,26 @@ func csvScannerFromParsed(conf *service.ParsedConfig) (l *csvScannerCreator, err
 	if l.continueOnError, err = conf.FieldBool(scsvFieldContinueOnError); err != nil {
 		return
 	}
+	if conf.Contains(scsvFieldExpectedHeaders) {
+		if l.expectedHeaders, err = conf.FieldStringList(scsvFieldExpectedHeaders); err != nil {
+			return
+		}
+	}
+	if conf.Contains(scsvFieldExpectedNumberOfFields) {
+		if l.expectedNumberOfFields, err = conf.FieldInt(scsvFieldExpectedNumberOfFields); err != nil {
+			return
+		}
+	}
 	return
 }
 
 type csvScannerCreator struct {
-	customDelim     string
-	parseHeaderRow  bool
-	lazyQuotes      bool
-	continueOnError bool
+	customDelim            string
+	parseHeaderRow         bool
+	lazyQuotes             bool
+	continueOnError        bool
+	expectedHeaders        []string
+	expectedNumberOfFields int
 }
 
 func (c *csvScannerCreator) Create(rdr io.ReadCloser, aFn service.AckFunc, details *service.ScannerSourceDetails) (service.BatchScanner, error) {
@@ -86,6 +109,7 @@ func (c *csvScannerCreator) Create(rdr io.ReadCloser, aFn service.AckFunc, detai
 	if c.customDelim != "" {
 		cRdr.Comma = []rune(c.customDelim)[0]
 	}
+	cRdr.FieldsPerRecord = c.expectedNumberOfFields
 
 	var headers []string
 	if c.parseHeaderRow {
@@ -93,8 +117,10 @@ func (c *csvScannerCreator) Create(rdr io.ReadCloser, aFn service.AckFunc, detai
 		if err != nil {
 			return nil, err
 		}
-		headers = make([]string, len(tmpHeaders))
-		_ = copy(headers, tmpHeaders)
+		if len(c.expectedHeaders) > 0 && slices.Compare(c.expectedHeaders, tmpHeaders) != 0 {
+			return nil, errors.New("expected_headers don't match file contents")
+		}
+		headers = append([]string{}, tmpHeaders...)
 	}
 
 	return service.AutoAggregateBatchScannerAcks(&csvScanner{

--- a/internal/impl/pure/scanner_csv.go
+++ b/internal/impl/pure/scanner_csv.go
@@ -45,7 +45,7 @@ This scanner adds the following metadata to each message:
 				Description("If a row fails to parse due to any error emit an empty message marked with the error and then continue consuming subsequent rows when possible. This can sometimes be useful in situations where input data contains individual rows which are malformed. However, when a row encounters a parsing error it is impossible to guarantee that following rows are valid, as this indicates that the input data is unreliable and could potentially emit misaligned rows.").
 				Default(false),
 			service.NewStringListField(scsvFieldExpectedHeaders).
-				Description("An optional list of expected headers in the header row, that will be checked against the file contents.").
+				Description("An optional list of expected headers in the header row. If provided, the scanner will check the file contents and emit an error if any expected headers don't match.").
 				Example([]string{"first_name", "last_name", "age"}).
 				Optional(),
 			service.NewIntField(scsvFieldExpectedNumberOfFields).

--- a/internal/impl/pure/scanner_csv_test.go
+++ b/internal/impl/pure/scanner_csv_test.go
@@ -1,6 +1,9 @@
 package pure_test
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -80,4 +83,112 @@ a4,b4,c4
 		`["a3","b3","c3"]`,
 		`["a4","b4","c4"]`,
 	)
+}
+
+func TestCSVScannerExpectedHeaders(t *testing.T) {
+	confSpec := service.NewConfigSpec().Field(service.NewScannerField("test"))
+	pConf, err := confSpec.ParseYAML(`
+test:
+  csv:
+    expected_headers:
+      - a
+      - b
+      - c
+`, nil)
+	require.NoError(t, err)
+
+	rdr, err := pConf.FieldScanner("test")
+	require.NoError(t, err)
+
+	testutil.ScannerTestSuite(t, rdr, nil, []byte(`a,b,c
+a1,b1,c1
+a2,b2,c2
+a3,b3,c3
+a4,b4,c4
+`),
+		`{"a":"a1","b":"b1","c":"c1"}`,
+		`{"a":"a2","b":"b2","c":"c2"}`,
+		`{"a":"a3","b":"b3","c":"c3"}`,
+		`{"a":"a4","b":"b4","c":"c4"}`,
+	)
+}
+
+func TestCSVScannerExpectedHeadersErr(t *testing.T) {
+	confSpec := service.NewConfigSpec().Field(service.NewScannerField("test"))
+	pConf, err := confSpec.ParseYAML(`
+test:
+  csv:
+    expected_headers:
+      - a
+      - b
+      - c
+      - d
+`, nil)
+	require.NoError(t, err)
+
+	rdr, err := pConf.FieldScanner("test")
+	require.NoError(t, err)
+
+	buf := io.NopCloser(bytes.NewReader([]byte(`a,b,c
+a1,b1,c1
+a2,b2,c2
+a3,b3,c3
+a4,b4,c4
+`)))
+
+	_, err = rdr.Create(buf, func(ctx context.Context, err error) error {
+		return nil
+	}, &service.ScannerSourceDetails{})
+	require.ErrorContains(t, err, "expected_headers don't match file contents")
+}
+
+func TestCSVScannerExpectedNumberOfFields(t *testing.T) {
+	confSpec := service.NewConfigSpec().Field(service.NewScannerField("test"))
+	pConf, err := confSpec.ParseYAML(`
+test:
+  csv:
+    expected_number_of_fields: 3
+`, nil)
+
+	require.NoError(t, err)
+
+	rdr, err := pConf.FieldScanner("test")
+	require.NoError(t, err)
+
+	testutil.ScannerTestSuite(t, rdr, nil, []byte(`a,b,c
+a1,b1,c1
+a2,b2,c2
+a3,b3,c3
+a4,b4,c4
+`),
+		`{"a":"a1","b":"b1","c":"c1"}`,
+		`{"a":"a2","b":"b2","c":"c2"}`,
+		`{"a":"a3","b":"b3","c":"c3"}`,
+		`{"a":"a4","b":"b4","c":"c4"}`,
+	)
+}
+
+func TestCSVScannerExpectedNumberOfErr(t *testing.T) {
+	confSpec := service.NewConfigSpec().Field(service.NewScannerField("test"))
+	pConf, err := confSpec.ParseYAML(`
+test:
+  csv:
+    expected_number_of_fields: 4
+`, nil)
+	require.NoError(t, err)
+
+	rdr, err := pConf.FieldScanner("test")
+	require.NoError(t, err)
+
+	buf := io.NopCloser(bytes.NewReader([]byte(`a,b,c
+a1,b1,c1
+a2,b2,c2
+a3,b3,c3
+a4,b4,c4
+`)))
+
+	_, err = rdr.Create(buf, func(ctx context.Context, err error) error {
+		return nil
+	}, &service.ScannerSourceDetails{})
+	require.ErrorContains(t, err, "wrong number of fields")
 }

--- a/website/docs/components/scanners/csv.md
+++ b/website/docs/components/scanners/csv.md
@@ -23,6 +23,8 @@ csv:
   parse_header_row: true
   lazy_quotes: false
   continue_on_error: false
+  expected_headers: [] # No default (optional)
+  expected_number_of_fields: 0 # No default (optional)
 ```
 
 ### Metadata
@@ -65,5 +67,28 @@ If a row fails to parse due to any error emit an empty message marked with the e
 
 Type: `bool`  
 Default: `false`  
+
+### `expected_headers`
+
+An optional list of expected headers in the header row, that will be checked against the file contents.
+
+
+Type: `array`  
+
+```yml
+# Examples
+
+expected_headers:
+  - first_name
+  - last_name
+  - age
+```
+
+### `expected_number_of_fields`
+
+The numer of expected fields in the csv file.
+
+
+Type: `int`  
 
 

--- a/website/docs/components/scanners/csv.md
+++ b/website/docs/components/scanners/csv.md
@@ -70,7 +70,7 @@ Default: `false`
 
 ### `expected_headers`
 
-An optional list of expected headers in the header row, that will be checked against the file contents.
+An optional list of expected headers in the header row. If provided, the scanner will check the file contents and emit an error if any expected headers don't match.
 
 
 Type: `array`  

--- a/website/docs/components/scanners/csv.md
+++ b/website/docs/components/scanners/csv.md
@@ -86,7 +86,7 @@ expected_headers:
 
 ### `expected_number_of_fields`
 
-The numer of expected fields in the csv file.
+The number of expected fields in the csv file.
 
 
 Type: `int`  


### PR DESCRIPTION
adds a couple of fields to the csv scanner

- expected_headers - optional list of strings to check the csv file headers against
- expected_number_of_fields - optional int that will check against the file's number of fields