### PR TITLE
allow sending multiple open_messages on connect

### DIFF
--- a/internal/impl/io/input_websocket_test.go
+++ b/internal/impl/io/input_websocket_test.go
@@ -82,7 +82,7 @@ func TestWebsocketOpenMsg(t *testing.T) {
 		"baz",
 	}
 
-	testHandler := func(expMsgType int, w http.ResponseWriter, r *http.Request) {
+	testHandler := func(expOpenMsgs []string, expMsgType int, w http.ResponseWriter, r *http.Request) {
 		upgrader := websocket.Upgrader{}
 
 		var ws *websocket.Conn
@@ -93,15 +93,18 @@ func TestWebsocketOpenMsg(t *testing.T) {
 
 		defer ws.Close()
 
-		msgType, data, err := ws.ReadMessage()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if exp, act := "hello world", string(data); exp != act {
-			t.Errorf("Wrong open message: %v != %v", act, exp)
-		}
-		if msgType != expMsgType {
-			t.Errorf("Wrong open message type: %v != %v", msgType, expMsgType)
+		for expIdx, exp := range expOpenMsgs {
+			msgType, data, err := ws.ReadMessage()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if act := string(data); exp != act {
+				t.Errorf("Wrong open message (i=%v): %v != %v", expIdx, act, exp)
+			}
+			if msgType != expMsgType {
+				t.Errorf("Wrong open message type (i=%v): %v != %v", expIdx, msgType, expMsgType)
+			}
+
 		}
 
 		for _, msg := range expMsgs {
@@ -112,24 +115,37 @@ func TestWebsocketOpenMsg(t *testing.T) {
 	}
 
 	tests := []struct {
-		handler       func(expMsgType int, w http.ResponseWriter, r *http.Request)
+		handler       func(expOpenMsgs []string, expMsgType int, w http.ResponseWriter, r *http.Request)
+		openMsgSep    string
 		openMsgType   wsOpenMsgType
+		wsOpenMsgs    []string
 		wsOpenMsgType int
 		errStr        string
 	}{
 		{
 			handler:       testHandler,
+			openMsgSep:    "",
 			openMsgType:   wsOpenMsgTypeBinary,
+			wsOpenMsgs:    []string{"hello world"},
 			wsOpenMsgType: websocket.BinaryMessage,
 		},
 		{
 			handler:       testHandler,
+			openMsgSep:    "",
 			openMsgType:   wsOpenMsgTypeText,
+			wsOpenMsgs:    []string{"hello world"},
+			wsOpenMsgType: websocket.TextMessage,
+		},
+		{
+			handler:       testHandler,
+			openMsgSep:    " ",
+			openMsgType:   wsOpenMsgTypeText,
+			wsOpenMsgs:    []string{"hello", "world"},
 			wsOpenMsgType: websocket.TextMessage,
 		},
 		{
 			// Use a simplified handler to avoid the blocking call to `ws.ReadMessage()` when no OpenMsg gets sent
-			handler: func(_ int, w http.ResponseWriter, r *http.Request) {
+			handler: func(_ []string, _ int, w http.ResponseWriter, r *http.Request) {
 				upgrader := websocket.Upgrader{}
 
 				var ws *websocket.Conn
@@ -147,7 +163,7 @@ func TestWebsocketOpenMsg(t *testing.T) {
 
 	for id, test := range tests {
 		t.Run(strconv.Itoa(id), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { test.handler(test.wsOpenMsgType, w, r) }))
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { test.handler(test.wsOpenMsgs, test.wsOpenMsgType, w, r) }))
 			t.Cleanup(server.Close)
 
 			wsURL, err := url.Parse(server.URL)
@@ -158,8 +174,9 @@ func TestWebsocketOpenMsg(t *testing.T) {
 			pConf, err := websocketInputSpec().ParseYAML(fmt.Sprintf(`
 url: %v
 open_message: "hello world"
+open_message_sep: "%s"
 open_message_type: %v
-`, wsURL.String(), test.openMsgType), nil)
+`, wsURL.String(), test.openMsgSep, test.openMsgType), nil)
 			require.NoError(t, err)
 
 			m, err := newWebsocketReaderFromParsed(pConf, mock.NewManager())

--- a/website/docs/components/inputs/websocket.md
+++ b/website/docs/components/inputs/websocket.md
@@ -45,6 +45,7 @@ input:
     url: ws://localhost:4195/get/ws # No default (required)
     proxy_url: "" # No default (optional)
     open_message: "" # No default (optional)
+    open_message_sep: "" # No default (optional)
     open_message_type: binary
     auto_replay_nacks: true
     tls:


### PR DESCRIPTION
introduced optional field `open_message_sep`, which if specified, can be used to split `open_message` and allow for sending multiple `open_message`s on new connection.

see [#295](https://github.com/warpstreamlabs/bento/issues/295).