### PR TITLE
deprecated open_message; added open_messages, which allows multiple m…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,6 @@ Please always make sure a pull request has been:
 - Unit tested with `make test`
 - Linted with `make lint`
 - Formatted with `make fmt`
-- Regenerated docs with `make docs`
 
 If your change impacts inputs, outputs or other connectors then try to test them with `make test-integration`. If the integration tests aren't working on your machine then don't panic, just mention it in your PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ Please always make sure a pull request has been:
 - Unit tested with `make test`
 - Linted with `make lint`
 - Formatted with `make fmt`
+- Regenerated docs with `make docs`
 
 If your change impacts inputs, outputs or other connectors then try to test them with `make test-integration`. If the integration tests aren't working on your machine then don't panic, just mention it in your PR.
 

--- a/internal/impl/io/input_websocket.go
+++ b/internal/impl/io/input_websocket.go
@@ -147,6 +147,7 @@ func newWebsocketReaderFromParsed(conf *service.ParsedConfig, mgr bundle.NewMana
 		}
 	} else if openMsgStr, _ = conf.FieldString("open_message"); openMsgStr != "" {
 		ws.openMsg = make([][]byte, 1)
+		ws.openMsg[0] = []byte(openMsgStr)
 	}
 	return ws, nil
 }

--- a/internal/impl/io/input_websocket.go
+++ b/internal/impl/io/input_websocket.go
@@ -47,7 +47,7 @@ func websocketInputSpec() *service.ConfigSpec {
 				Description("An optional message to send to the server upon connection.").
 				Advanced().Optional().Deprecated(),
 			service.NewStringListField("open_messages").
-				Description("An optional list of messages to send to the server upon connection.").
+				Description("An optional list of messages to send to the server upon connection. This field replaces `open_message`, which will be removed in a future version.").
 				Advanced().Optional(),
 			service.NewStringAnnotatedEnumField("open_message_type", map[string]string{
 				string(wsOpenMsgTypeBinary): "Binary data open_message.",
@@ -57,6 +57,7 @@ func websocketInputSpec() *service.ConfigSpec {
 			service.NewAutoRetryNacksToggleField(),
 			service.NewTLSToggledField("tls"),
 		).
+		LintRule(`root = match {this.exists("open_message") && this.open_messages != [] => "both open_message and open_messages cannot be set"}`).
 		Fields(config.AsyncOptsFields()...).
 		Fields(service.NewHTTPRequestAuthSignerFields()...)
 }

--- a/internal/impl/io/input_websocket.go
+++ b/internal/impl/io/input_websocket.go
@@ -45,6 +45,9 @@ func websocketInputSpec() *service.ConfigSpec {
 				Advanced().Optional(),
 			service.NewStringField("open_message").
 				Description("An optional message to send to the server upon connection.").
+				Advanced().Optional().Deprecated(),
+			service.NewStringListField("open_messages").
+				Description("An optional list of messages to send to the server upon connection.").
 				Advanced().Optional(),
 			service.NewStringAnnotatedEnumField("open_message_type", map[string]string{
 				string(wsOpenMsgTypeBinary): "Binary data open_message.",
@@ -104,7 +107,7 @@ type websocketReader struct {
 	reqSigner      func(f fs.FS, req *http.Request) error
 
 	openMsgType wsOpenMsgType
-	openMsg     []byte
+	openMsg     [][]byte
 }
 
 func newWebsocketReaderFromParsed(conf *service.ParsedConfig, mgr bundle.NewManagement) (*websocketReader, error) {
@@ -132,12 +135,18 @@ func newWebsocketReaderFromParsed(conf *service.ParsedConfig, mgr bundle.NewMana
 		return nil, err
 	}
 	var openMsgStr, openMsgTypeStr string
+	var openMsgsStr []string
 	if openMsgTypeStr, err = conf.FieldString("open_message_type"); err != nil {
 		return nil, err
 	}
 	ws.openMsgType = wsOpenMsgType(openMsgTypeStr)
-	if openMsgStr, _ = conf.FieldString("open_message"); openMsgStr != "" {
-		ws.openMsg = []byte(openMsgStr)
+	if openMsgsStr, _ = conf.FieldStringList("open_messages"); len(openMsgsStr) > 0 {
+		ws.openMsg = make([][]byte, len(openMsgsStr))
+		for i, msg := range openMsgsStr {
+			ws.openMsg[i] = []byte(msg)
+		}
+	} else if openMsgStr, _ = conf.FieldString("open_message"); openMsgStr != "" {
+		ws.openMsg = make([][]byte, 1)
 	}
 	return ws, nil
 }
@@ -202,8 +211,8 @@ func (w *websocketReader) Connect(ctx context.Context) error {
 		return fmt.Errorf("unrecognised open_message_type: %s", w.openMsgType)
 	}
 
-	if len(w.openMsg) > 0 {
-		if err := client.WriteMessage(openMsgType, w.openMsg); err != nil {
+	for _, msg := range w.openMsg {
+		if err := client.WriteMessage(openMsgType, msg); err != nil {
 			return err
 		}
 	}

--- a/website/docs/components/inputs/websocket.md
+++ b/website/docs/components/inputs/websocket.md
@@ -103,7 +103,7 @@ Type: `string`
 
 ### `open_messages`
 
-An optional list of messages to send to the server upon connection.
+An optional list of messages to send to the server upon connection. This field replaces `open_message`, which will be removed in a future version.
 
 
 Type: `array`  

--- a/website/docs/components/inputs/websocket.md
+++ b/website/docs/components/inputs/websocket.md
@@ -44,7 +44,7 @@ input:
   websocket:
     url: ws://localhost:4195/get/ws # No default (required)
     proxy_url: "" # No default (optional)
-    open_message: "" # No default (optional)
+    open_messages: [] # No default (optional)
     open_message_type: binary
     auto_replay_nacks: true
     tls:
@@ -101,12 +101,12 @@ An optional HTTP proxy URL.
 
 Type: `string`  
 
-### `open_message`
+### `open_messages`
 
-An optional message to send to the server upon connection.
+An optional list of messages to send to the server upon connection.
 
 
-Type: `string`  
+Type: `array`  
 
 ### `open_message_type`
 


### PR DESCRIPTION
…essages to be sent on connect.

This is meant to resolve issue [#295](https://github.com/warpstreamlabs/bento/issues/295)