### PR TITLE
Fixing protocol buffer import_paths documentation

### DIFF
--- a/internal/impl/protobuf/processor_protobuf.go
+++ b/internal/impl/protobuf/processor_protobuf.go
@@ -64,7 +64,7 @@ Attempts to create a target protobuf message from a generic JSON structure.
 			Description("If `true`, the `to_json` operator deserializes fields exactly as named in schema file.").
 			Default(false),
 		service.NewStringListField(fieldImportPaths).
-			Description("A list of directories containing .proto files, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported. Either this field or `bsr` must be populated.").
+			Description("A list of directories containing .proto files or list of file paths, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported. Either this field or `bsr` must be populated.").
 			Default([]string{}),
 		service.NewObjectListField(fieldBsrConfig,
 			service.NewStringField(fieldBsrModule).

--- a/website/docs/components/processors/protobuf.md
+++ b/website/docs/components/processors/protobuf.md
@@ -275,7 +275,7 @@ Default: `false`
 
 ### `import_paths`
 
-A list of directories containing .proto files or list of files, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported. Either this field or `bsr` must be populated.
+A list of directories containing .proto files or list of file paths, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported. Either this field or `bsr` must be populated.
 
 
 Type: `array`  

--- a/website/docs/components/processors/protobuf.md
+++ b/website/docs/components/processors/protobuf.md
@@ -275,7 +275,7 @@ Default: `false`
 
 ### `import_paths`
 
-A list of directories containing .proto files, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported. Either this field or `bsr` must be populated.
+A list of directories containing .proto files or list of files, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported. Either this field or `bsr` must be populated.
 
 
 Type: `array`  


### PR DESCRIPTION
The doc says `import_paths` should be a list of directories.

The code is actually using  https://pkg.go.dev/path/filepath#Walk  

Which gives us an option to pass a file path.
It is really helpful when a protocol buffer file is mounted from a configmap in Kubernetes, if we only specify the directory with bento, many copies of it will be mounted in dot directories (for changes purpose) and the walk will hit them and halt because it found duplicates.

By specifying the full path, we can solve that issue. (I tried using recent bento)

Not sure it was intended that way, but it should be kept, it is also how protoc `-I` works.