### PR TITLE
fix(rateLimit): fix plugin registration for custom byte-based limiters

### DIFF
--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -500,6 +500,14 @@ func (e *Environment) RegisterRateLimit(name string, spec *ConfigSpec, ctor Rate
 		}
 		// TODO: This MessageAwareRateLimit should eventually replace V1
 		// Try to upgrade to message aware rate-limiter if possible.
+
+		// When registering from an internal rate limit (local rate limit, redis rate limit)
+		if rl, ok := r.(ratelimit.MessageAwareRateLimit); ok {
+			agrl := newReverseAirGapMessageAwareRateLimit(rl)
+			return newAirGapMessageAwareRateLimit(agrl, nm.Metrics()), nil
+		}
+
+		// When registering an external rate limit via the plugin
 		if rl, ok := r.(MessageAwareRateLimit); ok {
 			return newAirGapMessageAwareRateLimit(rl, nm.Metrics()), nil
 		}

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -498,11 +498,10 @@ func (e *Environment) RegisterRateLimit(name string, spec *ConfigSpec, ctor Rate
 		if err != nil {
 			return nil, err
 		}
-		// TODO: This MessageAwareRateLimit shoud eventually replace V1
+		// TODO: This MessageAwareRateLimit should eventually replace V1
 		// Try to upgrade to message aware rate-limiter if possible.
-		if rl, ok := r.(ratelimit.MessageAwareRateLimit); ok {
-			agrl := newReverseAirGapMessageAwareRateLimit(rl)
-			return newAirGapMessageAwareRateLimit(agrl, nm.Metrics()), nil
+		if rl, ok := r.(MessageAwareRateLimit); ok {
+			return newAirGapMessageAwareRateLimit(rl, nm.Metrics()), nil
 		}
 
 		return newAirGapRateLimit(r, nm.Metrics()), nil

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -693,3 +693,10 @@ func (e *Environment) RegisterTemplateYAML(yamlStr string) error {
 func XFormatConfigJSON() ([]byte, error) {
 	return json.Marshal(config.Spec())
 }
+
+// XRateLimitInitForTest is a helper specifically for testing the internal rate
+// limit initialization process based on the environment's registered components.
+// DO NOT USE OUTSIDE OF TESTS.
+func (e *Environment) XRateLimitInitForTest(conf ratelimit.Config, mgr bundle.NewManagement) (ratelimit.V1, error) {
+	return e.internal.RateLimitInit(conf, mgr)
+}

--- a/public/service/environment_test.go
+++ b/public/service/environment_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/warpstreamlabs/bento/internal/message"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -18,6 +17,7 @@ import (
 	"github.com/warpstreamlabs/bento/internal/component/ratelimit"
 	"github.com/warpstreamlabs/bento/internal/filepath/ifs"
 	"github.com/warpstreamlabs/bento/internal/manager/mock"
+	"github.com/warpstreamlabs/bento/internal/message"
 	"github.com/warpstreamlabs/bento/public/bloblang"
 	"github.com/warpstreamlabs/bento/public/service"
 )


### PR DESCRIPTION
When registering a new rate limit via the use of the plugin (`RegisterRateLimit`), the current assertion
https://github.com/warpstreamlabs/bento/blob/b2dd8d100dc4bfb234ffdbe3d78bc9cf8a5b3ef7/public/service/environment.go#L503
will always be false since it checks whether it corresponds to the **internal** MessageAwareRateLimit
https://github.com/warpstreamlabs/bento/blob/b2dd8d100dc4bfb234ffdbe3d78bc9cf8a5b3ef7/internal/component/ratelimit/message_rate_limit.go#L11-L26

Anybody using the plugin can only implement the **public** MessageAwareRateLimit
https://github.com/warpstreamlabs/bento/blob/b2dd8d100dc4bfb234ffdbe3d78bc9cf8a5b3ef7/public/service/rate_limit.go#L23-L37

Here, I add a new branch case to handle this registration via the plugin by also checking the public interface.


Note: without doing this, when registering a custom message-aware rate limit via the plugin, the `Add` method **never** gets called by the `Process` method [here](https://github.com/warpstreamlabs/bento/blob/b2dd8d100dc4bfb234ffdbe3d78bc9cf8a5b3ef7/internal/impl/pure/processor_rate_limit.go#L77-L82) since the rate limit is **not** converted to an internal MessageAwareRateLimit upon registration, but systematically to an internal.V1 instead (i.e. non-message aware).

