### PR TITLE
fix(strictMode): handle strict mode in StreamBuilder when 'error_handling.strategy: reject'

### DIFF
--- a/public/service/stream_builder_test.go
+++ b/public/service/stream_builder_test.go
@@ -1529,7 +1529,7 @@ error_handling:
 				if test.expectMultipleLogErrors {
 					require.Greater(t, strings.Count(logs, test.expectLogError), 1)
 				} else {
-					require.Equal(t, strings.Count(logs, test.expectLogError), 1)
+					require.Equal(t, 1, strings.Count(logs, test.expectLogError))
 				}
 			} else {
 				require.NotContains(t, logs, "failed assignment")

--- a/public/service/stream_builder_test.go
+++ b/public/service/stream_builder_test.go
@@ -1319,3 +1319,176 @@ output:
 		},
 	}, eventKeys)
 }
+
+// mockPrintLogger is a helper logger to capture stdout in tests
+type mockPrintLogger struct {
+	buf bytes.Buffer
+	mut sync.Mutex
+}
+
+func (tpl *mockPrintLogger) Printf(format string, v ...any) {
+	tpl.mut.Lock()
+	defer tpl.mut.Unlock()
+
+	tpl.buf.WriteString(fmt.Sprintf(format, v...))
+}
+
+func (tpl *mockPrintLogger) Println(v ...any) {
+	tpl.mut.Lock()
+	defer tpl.mut.Unlock()
+
+	tpl.buf.WriteString(fmt.Sprintln(v...))
+}
+
+func (tpl *mockPrintLogger) Content() string {
+	return tpl.buf.String()
+}
+
+func TestStreamBuilder_ErrorHandlingReject_SuppressesOutput(t *testing.T) {
+	tests := []struct {
+		name                  string
+		configYAML            string
+		expectMessageReceived bool
+		expectLogError        string
+	}{
+		{
+			name: "Do not reject message if message is valid and error strategy is reject",
+			configYAML: `input:
+  generate:
+    count: 1
+    interval: 1ms
+    mapping: 'root = {"hello": "world"}'
+
+pipeline:
+  processors:
+    - bloblang: |
+        root = content().parse_json(use_number: false)
+
+error_handling:
+  strategy: reject
+`,
+			expectMessageReceived: true,
+			expectLogError:        "",
+		},
+		{
+			name: "Reject message if message is invalid and error strategy is reject",
+			configYAML: `input:
+  generate:
+    count: 1
+    interval: 1ms
+    mapping: 'root = "not a valid json message"'
+    
+pipeline:
+  processors:
+    - bloblang: |
+        root = content().parse_json(use_number: false)
+
+error_handling:
+  strategy: reject
+`,
+			expectMessageReceived: false,
+			expectLogError:        "invalid character 'o' in literal null (expecting 'u')",
+		},
+		{
+			name: "Do not reject message if message is invalid and error strategy is none but expect error log anyway",
+			configYAML: `input:
+  generate:
+    count: 1
+    interval: 1ms
+    mapping: 'root = "not a valid json message"'
+
+pipeline:
+  processors:
+    - bloblang: |
+        root = content().parse_json(use_number: false)
+
+error_handling:
+  strategy: none
+`,
+			expectMessageReceived: true,
+			expectLogError:        "invalid character 'o' in literal null (expecting 'u')",
+		},
+		{
+			name: "Do not reject message if message is valid and error strategy is none and expect no error log",
+			configYAML: `input:
+  generate:
+    count: 1
+    interval: 1ms
+    mapping: 'root = {"hello": "world"}'
+
+pipeline:
+  processors:
+    - bloblang: |
+        root = content().parse_json(use_number: false)
+
+error_handling:
+  strategy: none
+`,
+			expectMessageReceived: true,
+			expectLogError:        "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.configYAML, func(t *testing.T) {
+
+			sb := service.NewStreamBuilder()
+
+			mockedPrintLogger := &mockPrintLogger{}
+			sb.SetPrintLogger(mockedPrintLogger)
+
+			err := sb.SetYAML(test.configYAML)
+			require.NoError(t, err)
+
+			var messageWasReceived bool
+			var consumerMut sync.Mutex
+
+			err = sb.AddBatchConsumerFunc(func(ctx context.Context, b service.MessageBatch) error {
+				consumerMut.Lock()
+				defer consumerMut.Unlock()
+				messageWasReceived = true
+				//t.Log("Consumer func: message received when it should have been rejected!")
+				return nil
+			})
+			require.NoError(t, err)
+
+			strm, err := sb.Build()
+			require.NoError(t, err)
+
+			runCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			streamDoneChan := make(chan error, 1)
+			go func() {
+				// Run the stream
+				streamDoneChan <- strm.Run(runCtx)
+			}()
+
+			// We leave the goroutine running until either the pipeline finishes (for non-erroring cases) or the timeout
+			// expires (for erroring cases that are retried forever).
+			select {
+			case runErr := <-streamDoneChan:
+				require.NoError(t, runErr)
+			case <-runCtx.Done():
+				// We get in this case if the pipeline never ends (because an error makes it retry, for example)
+				// In that case, we need to make sure the stream is stopped.
+				stopCtx, stopCancel := context.WithTimeout(context.Background(), 1*time.Second)
+				defer stopCancel()
+				_ = strm.Stop(stopCtx)
+			}
+
+			consumerMut.Lock()
+			require.Equal(t, test.expectMessageReceived, messageWasReceived)
+			consumerMut.Unlock()
+
+			logs := mockedPrintLogger.Content()
+			if test.expectLogError != "" {
+				require.Contains(t, logs, "failed assignment")
+				require.Contains(t, logs, test.expectLogError)
+			} else {
+				require.NotContains(t, logs, "failed assignment")
+			}
+		})
+	}
+
+}

--- a/public/service/stream_builder_test.go
+++ b/public/service/stream_builder_test.go
@@ -1447,7 +1447,6 @@ error_handling:
 				consumerMut.Lock()
 				defer consumerMut.Unlock()
 				messageWasReceived = true
-				//t.Log("Consumer func: message received when it should have been rejected!")
 				return nil
 			})
 			require.NoError(t, err)


### PR DESCRIPTION
The strict mode was added in https://github.com/warpstreamlabs/bento/pull/174

It works perfectly fine when running Bento from the CLI because the parsing of `error_handling.strategy` is handled there:
https://github.com/warpstreamlabs/bento/blob/9f291ba9eaede36faadfe964e0877254a375dfec/internal/cli/common/manager.go#L113-L119

However, the `error_handling.strategy` is not handled when running the Bento GO library (from streamBuilder.Build()).

Here, I am adding the same logic in the stream_builder so that it also reads a `error_handling.strategy: reject` from a config.

--------

EDIT: I am not sure about what we want in the `StrictBuild` case (since it is only used in a test for now, maybe it doesn't matter). 
I assume we want:
- if we are calling it from a `StrictBuild` => we want to make sure we are in a strict mode, no matter what the config is
- if we are calling it from another build => we want to take the strategy from the config.
The logic for that is in this commit: https://github.com/warpstreamlabs/bento/pull/325/commits/559da8e2cbd3f460d535a285e54604d29d68b538
But I can also remove it if you disagree.