### PR TITLE
Log warnings for deprecated fields

### DIFF
--- a/config/template_examples/processor_log_and_drop.yaml
+++ b/config/template_examples/processor_log_and_drop.yaml
@@ -11,9 +11,7 @@ mapping: |
     {
       "log": {
         "level": "ERROR",
-        "fields": {
-          "content": "${! content() }"
-        },
+        "fields_mapping": "root.content = content()",
         "message": "${! error() }"
       }
     },
@@ -34,7 +32,6 @@ tests:
       catch:
         - log:
             level: ERROR
-            fields:
-              content: "${! content() }"
+            fields_mapping: root.content = content()
             message: "${! error() }"
         - bloblang: root = deleted()

--- a/internal/cli/common/reader.go
+++ b/internal/cli/common/reader.go
@@ -26,6 +26,7 @@ func ReadConfig(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) (mainPath st
 		config.OptSetFullSpec(cliOpts.MainConfigSpecCtor),
 		config.OptAddOverrides(c.StringSlice("set")...),
 		config.OptTestSuffix("_bento_test"),
+		config.OptSetLintConfigWarnDeprecated(),
 	}
 	if streamsMode {
 		opts = append(opts, config.OptSetStreamPaths(c.Args().Slice()...))

--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -124,7 +124,7 @@ func initStreamsMode(
 	streamMgr := strmmgr.New(mgr, strmmgr.OptAPIEnabled(enableAPI))
 
 	streamConfs := map[string]stream.Config{}
-	lints, err := confReader.ReadStreams(streamConfs)
+	lints, lintWarns, err := confReader.ReadStreams(streamConfs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Stream configuration file read error: %v\n", err)
 		os.Exit(1)
@@ -140,6 +140,10 @@ func initStreamsMode(
 	if strict && len(lints) > 0 {
 		logger.Error(opts.ExecTemplate("Shutting down due to stream linter errors, to prevent shutdown run {{.ProductName}} with --chilled"))
 		os.Exit(1)
+	}
+
+	for _, lintWarn := range lintWarns {
+		logger.With("lint", lintWarn).Warn("Config lint warning")
 	}
 
 	for id, conf := range streamConfs {

--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -23,7 +23,7 @@ import (
 func RunService(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) int {
 	mainPath, inferredMainPath, confReader := ReadConfig(c, cliOpts, streamsMode)
 
-	conf, pConf, lints, err := confReader.Read()
+	conf, pConf, lints, lintWarns, err := confReader.Read()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Configuration file read error: %v\n", err)
 		return 1
@@ -58,6 +58,10 @@ func RunService(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) int {
 	if strict && len(lints) > 0 {
 		logger.Error(cliOpts.ExecTemplate("Shutting down due to linter errors, to prevent shutdown run {{.ProductName}} with --chilled"))
 		return 1
+	}
+
+	for _, lintWarn := range lintWarns {
+		logger.With("lint", lintWarn).Warn("Config lint warning")
 	}
 
 	stoppableManager, err := CreateManager(c, cliOpts, logger, streamsMode, conf)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -252,7 +252,7 @@ variables have been resolved:
   {{.BinaryName}} -c ./config.yaml echo | less`)[1:],
 				Action: func(c *cli.Context) error {
 					_, _, confReader := common.ReadConfig(c, opts, false)
-					_, pConf, _, err := confReader.Read()
+					_, pConf, _, _, err := confReader.Read()
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "Configuration file read error: %v\n", err)
 						os.Exit(1)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,8 +20,10 @@ import (
 	"github.com/warpstreamlabs/bento/internal/manager/mock"
 	"github.com/warpstreamlabs/bento/internal/stream"
 
+	_ "github.com/warpstreamlabs/bento/public/components/amqp1"
 	_ "github.com/warpstreamlabs/bento/public/components/io"
 	_ "github.com/warpstreamlabs/bento/public/components/pure"
+	_ "github.com/warpstreamlabs/bento/public/components/sql"
 )
 
 func testConfToAny(t testing.TB, conf any) any {
@@ -47,9 +49,10 @@ func TestSetOverridesOnNothing(t *testing.T) {
 		"output.type=drop",
 	))
 
-	conf, _, lints, _, err := rdr.Read()
+	conf, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	assert.Empty(t, lints)
+	assert.Empty(t, lintWarns)
 
 	v := gabs.Wrap(testConfToAny(t, conf))
 
@@ -110,9 +113,10 @@ input:
 		"output.type=drop",
 	))
 
-	conf, _, lints, _, err := rdr.Read()
+	conf, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	assert.Empty(t, lints)
+	assert.Empty(t, lintWarns)
 
 	v := gabs.Wrap(testConfToAny(t, conf))
 
@@ -166,9 +170,10 @@ tests:
 
 	rdr := config.NewReader(fullPath, []string{resourceOnePath, resourceTwoPath, resourceThreePath})
 
-	conf, _, lints, _, err := rdr.Read()
+	conf, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	assert.Empty(t, lints)
+	assert.Empty(t, lintWarns)
 
 	v := gabs.Wrap(testConfToAny(t, conf))
 
@@ -218,12 +223,13 @@ cache_resources:
 
 	rdr := config.NewReader(fullPath, []string{resourceOnePath, resourceTwoPath})
 
-	conf, _, lints, _, err := rdr.Read()
+	conf, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	require.Len(t, lints, 3)
 	assert.Contains(t, lints[0], "/main.yaml(3,1) field meow1 ")
 	assert.Contains(t, lints[1], "/res1.yaml(5,1) field meow2 ")
 	assert.Contains(t, lints[2], "/res2.yaml(5,1) field meow3 ")
+	require.Empty(t, lintWarns)
 
 	v := gabs.Wrap(testConfToAny(t, conf))
 
@@ -236,6 +242,47 @@ cache_resources:
 
 	assert.Equal(t, "bar", v.S("cache_resources", "1", "label").Data())
 	assert.Equal(t, "13s", v.S("cache_resources", "1", "memory", "default_ttl").Data())
+}
+
+func TestLintWarns(t *testing.T) {
+	dir := t.TempDir()
+
+	fullPath := filepath.Join(dir, "main.yaml")
+	require.NoError(t, os.WriteFile(fullPath, []byte(`
+input:
+  stdin: {}
+  
+output:
+  stdout: {}`), 0o644))
+
+	resourceOnePath := filepath.Join(dir, "res1.yaml")
+	require.NoError(t, os.WriteFile(resourceOnePath, []byte(`
+input_resources:
+  - label: foo
+    amqp_1:
+      url: amqp://guest:guest@localhost:5672/
+      source_address: foo
+`), 0o644))
+
+	resourceTwoPath := filepath.Join(dir, "res2.yaml")
+	require.NoError(t, os.WriteFile(resourceTwoPath, []byte(`
+output_resources:
+  - label: bar
+    sql:
+      driver: postgres
+      data_source_name: postgresql://user:password@postgres:5432/db?sslmode=disable
+      query: INSERT INTO table (foo, bar, baz) VALUES (?, ?, ?);
+      args_mapping: root = [ "neo", "cypher", "trinity" ]
+`), 0o644))
+
+	rdr := config.NewReader(fullPath, []string{resourceOnePath, resourceTwoPath}, config.OptSetLintConfigWarnDeprecated())
+
+	_, _, lints, lintWarns, err := rdr.Read()
+	require.NoError(t, err)
+	require.Len(t, lintWarns, 2)
+	assert.Contains(t, lintWarns[0], "field url is deprecated")
+	assert.Contains(t, lintWarns[1], "component sql is deprecated")
+	require.Empty(t, lints)
 }
 
 func TestDefaultBasedOverridesWithYAML(t *testing.T) {
@@ -353,3 +400,5 @@ input:
 
 	require.NoError(t, s.Stop(context.Background()))
 }
+
+// add test jem

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -400,5 +400,3 @@ input:
 
 	require.NoError(t, s.Stop(context.Background()))
 }
-
-// add test jem

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,7 +47,7 @@ func TestSetOverridesOnNothing(t *testing.T) {
 		"output.type=drop",
 	))
 
-	conf, _, lints, err := rdr.Read()
+	conf, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	assert.Empty(t, lints)
 
@@ -88,7 +88,7 @@ func TestSetOverrideErrors(t *testing.T) {
 	for _, test := range tests {
 		rdr := config.NewReader("", nil, config.OptAddOverrides(test.input))
 
-		_, _, _, err := rdr.Read()
+		_, _, _, _, err := rdr.Read()
 		assert.Contains(t, err.Error(), test.err)
 	}
 }
@@ -110,7 +110,7 @@ input:
 		"output.type=drop",
 	))
 
-	conf, _, lints, err := rdr.Read()
+	conf, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	assert.Empty(t, lints)
 
@@ -166,7 +166,7 @@ tests:
 
 	rdr := config.NewReader(fullPath, []string{resourceOnePath, resourceTwoPath, resourceThreePath})
 
-	conf, _, lints, err := rdr.Read()
+	conf, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	assert.Empty(t, lints)
 
@@ -218,7 +218,7 @@ cache_resources:
 
 	rdr := config.NewReader(fullPath, []string{resourceOnePath, resourceTwoPath})
 
-	conf, _, lints, err := rdr.Read()
+	conf, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	require.Len(t, lints, 3)
 	assert.Contains(t, lints[0], "/main.yaml(3,1) field meow1 ")

--- a/internal/config/reader.go
+++ b/internal/config/reader.go
@@ -154,6 +154,14 @@ func OptSetLintConfig(lConf docs.LintConfig) OptFunc {
 	}
 }
 
+// OptSetLintConfigWarnDeprecated sets the option to warn about deprecated
+// fields and components in the lint configuration.
+func OptSetLintConfigWarnDeprecated() OptFunc {
+	return func(r *Reader) {
+		r.lintConf.WarnDeprecated = true
+	}
+}
+
 // OptSetStreamPaths marks this config reader as operating in streams mode, and
 // adds a list of paths to obtain individual stream configs from.
 func OptSetStreamPaths(streamsPaths ...string) OptFunc {

--- a/internal/config/reader.go
+++ b/internal/config/reader.go
@@ -334,11 +334,11 @@ func (r *Reader) readMain(mainPath string) (conf Type, pConf *docs.ParsedConfig,
 	if !bytes.HasPrefix(confBytes, []byte("# BENTO LINT DISABLE")) {
 		lintFilePrefix := mainPath
 		for _, lint := range confSpec.LintYAML(r.lintCtx(), rawNode) {
-			if lint.Level == docs.LintError {
-				lints = append(lints, fmt.Sprintf("%v%v", lintFilePrefix, lint.Error()))
-			}
-			if lint.Level == docs.LintWarning {
+			switch lint.Level {
+			case docs.LintWarning:
 				lintWarns = append(lintWarns, fmt.Sprintf("%v%v", lintFilePrefix, lint.Error()))
+			default:
+				lints = append(lints, fmt.Sprintf("%v%v", lintFilePrefix, lint.Error()))
 			}
 		}
 	}

--- a/internal/config/reader_test.go
+++ b/internal/config/reader_test.go
@@ -80,7 +80,7 @@ processor_resources:
 	}}
 	rdr := newDummyReader("foo_main.yaml", []string{"a.yaml", "b.yaml"}, OptUseFS(testFS))
 
-	conf, _, lints, err := rdr.Read()
+	conf, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
 
@@ -133,7 +133,7 @@ processor_resources:
 	}}
 	rdr := newDummyReader("foo_main.yaml", nil, OptUseFS(testFS))
 
-	conf, _, lints, err := rdr.Read()
+	conf, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
 

--- a/internal/config/reader_test.go
+++ b/internal/config/reader_test.go
@@ -80,9 +80,10 @@ processor_resources:
 	}}
 	rdr := newDummyReader("foo_main.yaml", []string{"a.yaml", "b.yaml"}, OptUseFS(testFS))
 
-	conf, _, lints, _, err := rdr.Read()
+	conf, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	assert.Equal(t, "fooin", conf.Input.Label)
 	assert.Equal(t, "fooout", conf.Output.Label)
@@ -133,9 +134,10 @@ processor_resources:
 	}}
 	rdr := newDummyReader("foo_main.yaml", nil, OptUseFS(testFS))
 
-	conf, _, lints, _, err := rdr.Read()
+	conf, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	assert.Equal(t, "fooin", conf.Input.Label)
 	assert.Equal(t, "fooout", conf.Output.Label)

--- a/internal/config/resource_reader.go
+++ b/internal/config/resource_reader.go
@@ -173,18 +173,20 @@ func (r *Reader) resourcePathsExpanded() ([]string, error) {
 	return resourcePaths, nil
 }
 
-func (r *Reader) readResources(conf *manager.ResourceConfig) (lints []string, err error) {
+func (r *Reader) readResources(conf *manager.ResourceConfig) (lints []string, lintWarns []string, err error) {
 	resourcesPaths, err := r.resourcePathsExpanded()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, path := range resourcesPaths {
 		var rconf manager.ResourceConfig
 		var rLints []string
-		if rconf, rLints, err = r.readResource(path); err != nil {
+		var rLintWarns []string
+		if rconf, rLints, rLintWarns, err = r.readResource(path); err != nil {
 			return
 		}
 		lints = append(lints, rLints...)
+		lintWarns = append(lintWarns, rLintWarns...)
 
 		resInfo := resInfoFromConfig(&rconf)
 		r.resourceFileInfo[path] = resInfo
@@ -198,7 +200,7 @@ func (r *Reader) readResources(conf *manager.ResourceConfig) (lints []string, er
 	return
 }
 
-func (r *Reader) readResource(path string) (conf manager.ResourceConfig, lints []string, err error) {
+func (r *Reader) readResource(path string) (conf manager.ResourceConfig, lints []string, lintWarns []string, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("%v: %w", path, err)
@@ -226,7 +228,12 @@ func (r *Reader) readResource(path string) (conf manager.ResourceConfig, lints [
 	}, r.specResources...)
 	if !bytes.HasPrefix(confBytes, []byte("# BENTO LINT DISABLE")) {
 		for _, lint := range spec.LintYAML(r.lintCtx(), rawNode) {
-			lints = append(lints, fmt.Sprintf("%v%v", path, lint.Error()))
+			if lint.Level == docs.LintError {
+				lints = append(lints, fmt.Sprintf("%v%v", path, lint.Error()))
+			}
+			if lint.Level == docs.LintWarning {
+				lintWarns = append(lintWarns, fmt.Sprintf("%v%v", path, lint.Error()))
+			}
 		}
 	}
 
@@ -242,7 +249,7 @@ func (r *Reader) readResource(path string) (conf manager.ResourceConfig, lints [
 // TriggerResourceUpdate attempts to re-read a resource configuration file and
 // apply changes to the provided manager as appropriate.
 func (r *Reader) TriggerResourceUpdate(mgr bundle.NewManagement, strict bool, path string) error {
-	newResConf, lints, err := r.readResource(path)
+	newResConf, lints, lintWarns, err := r.readResource(path)
 	if errors.Is(err, fs.ErrNotExist) {
 		return r.TriggerResourceDelete(mgr, path)
 	}
@@ -266,6 +273,10 @@ func (r *Reader) TriggerResourceUpdate(mgr bundle.NewManagement, strict bool, pa
 	if strict && len(lints) > 0 {
 		mgr.Logger().Error("Rejecting updated resource config due to linter errors, to allow linting errors run Bento with --chilled")
 		return noReread(errors.New("file contained linting errors and is running in strict mode"))
+	}
+
+	for _, lintWarn := range lintWarns {
+		lintlog.Warn(lintWarn)
 	}
 
 	newInfo := resInfoFromConfig(&newResConf)

--- a/internal/config/resource_reader.go
+++ b/internal/config/resource_reader.go
@@ -228,11 +228,11 @@ func (r *Reader) readResource(path string) (conf manager.ResourceConfig, lints [
 	}, r.specResources...)
 	if !bytes.HasPrefix(confBytes, []byte("# BENTO LINT DISABLE")) {
 		for _, lint := range spec.LintYAML(r.lintCtx(), rawNode) {
-			if lint.Level == docs.LintError {
-				lints = append(lints, fmt.Sprintf("%v%v", path, lint.Error()))
-			}
-			if lint.Level == docs.LintWarning {
+			switch lint.Level {
+			case docs.LintWarning:
 				lintWarns = append(lintWarns, fmt.Sprintf("%v%v", path, lint.Error()))
+			default:
+				lints = append(lints, fmt.Sprintf("%v%v", path, lint.Error()))
 			}
 		}
 	}

--- a/internal/config/resource_reader_test.go
+++ b/internal/config/resource_reader_test.go
@@ -48,9 +48,10 @@ processor_resources:
 	rdr.changeDelayPeriod = 1 * time.Millisecond
 	rdr.changeFlushPeriod = 1 * time.Millisecond
 
-	conf, _, lints, _, err := rdr.Read()
+	conf, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	require.NoError(t, rdr.SubscribeConfigChanges(func(conf *Type) error {
 		return nil
@@ -164,9 +165,10 @@ processor_resources:
 	rdr.changeDelayPeriod = 1 * time.Millisecond
 	rdr.changeFlushPeriod = 1 * time.Millisecond
 
-	conf, _, lints, _, err := rdr.Read()
+	conf, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	require.NoError(t, rdr.SubscribeConfigChanges(func(conf *Type) error {
 		return nil

--- a/internal/config/resource_reader_test.go
+++ b/internal/config/resource_reader_test.go
@@ -48,7 +48,7 @@ processor_resources:
 	rdr.changeDelayPeriod = 1 * time.Millisecond
 	rdr.changeFlushPeriod = 1 * time.Millisecond
 
-	conf, _, lints, err := rdr.Read()
+	conf, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
 
@@ -164,7 +164,7 @@ processor_resources:
 	rdr.changeDelayPeriod = 1 * time.Millisecond
 	rdr.changeFlushPeriod = 1 * time.Millisecond
 
-	conf, _, lints, err := rdr.Read()
+	conf, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
 

--- a/internal/config/stream_reader.go
+++ b/internal/config/stream_reader.go
@@ -68,11 +68,11 @@ func (r *Reader) readStreamFileConfig(path string) (conf stream.Config, lints []
 
 	if !bytes.HasPrefix(confBytes, []byte("# BENTO LINT DISABLE")) {
 		for _, lint := range confSpec.LintYAML(r.lintCtx(), rawNode) {
-			if lint.Level == docs.LintError {
-				lints = append(lints, fmt.Sprintf("%v%v", path, lint.Error()))
-			}
-			if lint.Level == docs.LintWarning {
+			switch lint.Level {
+			case docs.LintWarning:
 				lintWarns = append(lintWarns, fmt.Sprintf("%v%v", path, lint.Error()))
+			default:
+				lints = append(lints, fmt.Sprintf("%v%v", path, lint.Error()))
 			}
 		}
 	}

--- a/internal/config/stream_reader.go
+++ b/internal/config/stream_reader.go
@@ -43,7 +43,7 @@ func inferStreamID(dir, path string) (string, error) {
 	return id, nil
 }
 
-func (r *Reader) readStreamFileConfig(path string) (conf stream.Config, lints []string, err error) {
+func (r *Reader) readStreamFileConfig(path string) (conf stream.Config, lints []string, lintWarns []string, err error) {
 	var confBytes []byte
 	var dLints []docs.Lint
 	var modTime time.Time
@@ -68,7 +68,12 @@ func (r *Reader) readStreamFileConfig(path string) (conf stream.Config, lints []
 
 	if !bytes.HasPrefix(confBytes, []byte("# BENTO LINT DISABLE")) {
 		for _, lint := range confSpec.LintYAML(r.lintCtx(), rawNode) {
-			lints = append(lints, fmt.Sprintf("%v%v", path, lint.Error()))
+			if lint.Level == docs.LintError {
+				lints = append(lints, fmt.Sprintf("%v%v", path, lint.Error()))
+			}
+			if lint.Level == docs.LintWarning {
+				lintWarns = append(lintWarns, fmt.Sprintf("%v%v", path, lint.Error()))
+			}
 		}
 	}
 
@@ -81,21 +86,21 @@ func (r *Reader) readStreamFileConfig(path string) (conf stream.Config, lints []
 	return
 }
 
-func (r *Reader) readStreamFile(id, path string, confs map[string]stream.Config) ([]string, error) {
+func (r *Reader) readStreamFile(id, path string, confs map[string]stream.Config) ([]string, []string, error) {
 	if id == "" {
-		return nil, fmt.Errorf("stream id could not be inferred from file: %v", path)
+		return nil, nil, fmt.Errorf("stream id could not be inferred from file: %v", path)
 	}
 	if _, exists := confs[id]; exists {
-		return nil, fmt.Errorf("stream id (%v) collision from file: %v", id, path)
+		return nil, nil, fmt.Errorf("stream id (%v) collision from file: %v", id, path)
 	}
 
-	conf, lints, err := r.readStreamFileConfig(path)
+	conf, lints, lintWarns, err := r.readStreamFileConfig(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	confs[id] = conf
-	return lints, nil
+	return lints, lintWarns, nil
 }
 
 func (r *Reader) streamPathsExpanded() ([]string, error) {
@@ -157,18 +162,19 @@ func (r *Reader) streamPathsExpanded() ([]string, error) {
 	return paths, nil
 }
 
-func (r *Reader) readStreamFiles(streamMap map[string]stream.Config) (pathLints []string, err error) {
+func (r *Reader) readStreamFiles(streamMap map[string]stream.Config) (pathLints []string, pathLintWarns []string, err error) {
 	var streamsPaths []string
 	if streamsPaths, err = r.streamPathsExpanded(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, target := range streamsPaths {
-		tmpPathLints, err := r.readStreamFile(r.streamFileInfo[target].id, target, streamMap)
+		tmpPathLints, tmpPathLintWarns, err := r.readStreamFile(r.streamFileInfo[target].id, target, streamMap)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load config '%v': %v", target, err)
+			return nil, nil, fmt.Errorf("failed to load config '%v': %v", target, err)
 		}
 		pathLints = append(pathLints, tmpPathLints...)
+		pathLintWarns = append(pathLintWarns, tmpPathLintWarns...)
 	}
 	return
 }
@@ -189,7 +195,7 @@ func (r *Reader) TriggerStreamUpdate(mgr bundle.NewManagement, strict bool, path
 		return nil
 	}
 
-	conf, lints, err := r.readStreamFileConfig(path)
+	conf, lints, lintWarns, err := r.readStreamFileConfig(path)
 	if errors.Is(err, fs.ErrNotExist) {
 		info, exists := r.streamFileInfo[path]
 		if !exists {
@@ -229,6 +235,9 @@ func (r *Reader) TriggerStreamUpdate(mgr bundle.NewManagement, strict bool, path
 	if strict && len(lints) > 0 {
 		mgr.Logger().Error("Rejecting updated stream %v config due to linter errors, to allow linting errors run Bento with --chilled.", info.id)
 		return noReread(errors.New("file contained linting errors and is running in strict mode"))
+	}
+	for _, lintWarn := range lintWarns {
+		lintlog.Warn(lintWarn)
 	}
 
 	if err := r.streamUpdateFn(info.id, &conf); err != nil {

--- a/internal/config/stream_reader_test.go
+++ b/internal/config/stream_reader_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/warpstreamlabs/bento/internal/config"
 	"github.com/warpstreamlabs/bento/internal/stream"
 
+	_ "github.com/warpstreamlabs/bento/public/components/amqp1"
 	_ "github.com/warpstreamlabs/bento/public/components/pure"
+	_ "github.com/warpstreamlabs/bento/public/components/sql"
 )
 
 func TestStreamsLints(t *testing.T) {
@@ -50,13 +52,15 @@ cache_resources:
 
 	rdr := config.NewReader(generalConfPath, nil, config.OptSetStreamPaths(streamOnePath, streamTwoPath))
 
-	_, _, lints, _, err := rdr.Read()
+	_, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	streamConfs := map[string]stream.Config{}
-	lints, err = rdr.ReadStreams(streamConfs)
+	lints, lintWarns, err = rdr.ReadStreams(streamConfs)
 	require.NoError(t, err)
+	require.Empty(t, lintWarns)
 
 	require.Len(t, lints, 2)
 	assert.Contains(t, lints[0], "/first.yaml(3,1) field meow1 ")
@@ -68,6 +72,49 @@ cache_resources:
 
 	assert.Equal(t, "generate", streamConfs["first"].Input.Type)
 	assert.Equal(t, `root = "meow"`, firstAny.S("input", "generate", "mapping").Data())
+}
+
+func TestStreamsLintWarnings(t *testing.T) {
+	dir := t.TempDir()
+
+	generalConfPath := filepath.Join(dir, "main.yaml")
+	require.NoError(t, os.WriteFile(generalConfPath, []byte(`
+logger:
+  level: ALL
+`), 0o644))
+
+	streamOnePath := filepath.Join(dir, "first.yaml")
+	require.NoError(t, os.WriteFile(streamOnePath, []byte(`
+input:
+  amqp_1:
+    url: amqp://guest:guest@localhost:5672/
+    source_address: foo
+
+output:
+  sql:
+    driver: postgres
+    data_source_name: postgresql://user:password@postgres:5432/db?sslmode=disable
+    query: INSERT INTO table (foo, bar, baz) VALUES (?, ?, ?);
+    args_mapping: root = [ "neo", "cypher", "trinity" ]
+`), 0o644))
+
+	opts := []config.OptFunc{config.OptSetStreamPaths(streamOnePath), config.OptSetLintConfigWarnDeprecated()}
+
+	rdr := config.NewReader(generalConfPath, nil, opts...)
+
+	_, _, lints, lintWarns, err := rdr.Read()
+	require.NoError(t, err)
+	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
+
+	streamConfs := map[string]stream.Config{}
+	lints, lintWarns, err = rdr.ReadStreams(streamConfs)
+	require.NoError(t, err)
+	require.Empty(t, lints)
+
+	require.Len(t, lintWarns, 2)
+	assert.Contains(t, lintWarns[0], "field url is deprecated")
+	assert.Contains(t, lintWarns[1], "component sql is deprecated")
 }
 
 func TestStreamsDirectoryWalk(t *testing.T) {
@@ -98,14 +145,16 @@ pipeline:
 
 	rdr := config.NewReader("", nil, config.OptSetStreamPaths(streamOnePath, filepath.Join(dir, "nested")))
 
-	_, _, lints, _, err := rdr.Read()
+	_, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	streamConfs := map[string]stream.Config{}
-	lints, err = rdr.ReadStreams(streamConfs)
+	lints, lintWarns, err = rdr.ReadStreams(streamConfs)
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	require.Len(t, streamConfs, 3)
 	require.Contains(t, streamConfs, "first")

--- a/internal/config/stream_reader_test.go
+++ b/internal/config/stream_reader_test.go
@@ -50,7 +50,7 @@ cache_resources:
 
 	rdr := config.NewReader(generalConfPath, nil, config.OptSetStreamPaths(streamOnePath, streamTwoPath))
 
-	_, _, lints, err := rdr.Read()
+	_, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
 
@@ -98,7 +98,7 @@ pipeline:
 
 	rdr := config.NewReader("", nil, config.OptSetStreamPaths(streamOnePath, filepath.Join(dir, "nested")))
 
-	_, _, lints, err := rdr.Read()
+	_, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
 

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -507,7 +507,7 @@ processor_resources:
 
 	rdr := newDummyReader("", []string{confDir + "/*.yaml"})
 
-	conf, _, lints, err := rdr.Read()
+	conf, _, lints, _, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
 

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -162,9 +162,10 @@ func TestReaderStreamDirectWatching(t *testing.T) {
 	initConfs := map[string]stream.Config{}
 	rdr := newDummyReader("", nil, OptSetStreamPaths(confAPath, confBPath, confCPath))
 
-	lints, err := rdr.ReadStreams(initConfs)
+	lints, lintWarns, err := rdr.ReadStreams(initConfs)
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	assert.Equal(t, "a1", initConfs["a"].Output.Label)
 	assert.Equal(t, "b1", initConfs["b"].Output.Label)
@@ -246,9 +247,10 @@ func TestReaderStreamWildcardWatching(t *testing.T) {
 	initConfs := map[string]stream.Config{}
 	rdr := newDummyReader("", nil, OptSetStreamPaths(confDir+"/*.yaml"))
 
-	lints, err := rdr.ReadStreams(initConfs)
+	lints, lintWarns, err := rdr.ReadStreams(initConfs)
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	assert.Equal(t, "a1", initConfs["a"].Output.Label)
 	assert.NotContains(t, initConfs, "b")
@@ -330,9 +332,10 @@ func TestReaderStreamDirWatching(t *testing.T) {
 	initConfs := map[string]stream.Config{}
 	rdr := newDummyReader("", nil, OptSetStreamPaths(confDir))
 
-	lints, err := rdr.ReadStreams(initConfs)
+	lints, lintWarns, err := rdr.ReadStreams(initConfs)
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	assert.Equal(t, "a1", initConfs["inner_a"].Output.Label)
 	assert.NotContains(t, initConfs, "b")
@@ -415,9 +418,10 @@ func TestReaderWatcherRace(t *testing.T) {
 	initConfs := map[string]stream.Config{}
 	rdr := newDummyReader("", nil, OptSetStreamPaths(confDir))
 
-	lints, err := rdr.ReadStreams(initConfs)
+	lints, lintWarns, err := rdr.ReadStreams(initConfs)
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	assert.Equal(t, "a1", initConfs["inner_a"].Output.Label)
 	assert.NotContains(t, initConfs, "b")
@@ -507,9 +511,10 @@ processor_resources:
 
 	rdr := newDummyReader("", []string{confDir + "/*.yaml"})
 
-	conf, _, lints, _, err := rdr.Read()
+	conf, _, lints, lintWarns, err := rdr.Read()
 	require.NoError(t, err)
 	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
 
 	require.Len(t, conf.ResourceProcessors, 2)
 	require.Equal(t, "a", conf.ResourceProcessors[0].Label)

--- a/internal/docs/field.go
+++ b/internal/docs/field.go
@@ -678,6 +678,9 @@ type LintConfig struct {
 	// Reject any deprecated components or fields as linting errors.
 	RejectDeprecated bool
 
+	// Warn any deprecated components or fields as linting warnings.
+	WarnDeprecated bool
+
 	// Require labels for components.
 	RequireLabels bool
 }

--- a/internal/docs/format_yaml.go
+++ b/internal/docs/format_yaml.go
@@ -594,6 +594,8 @@ func (f FieldSpec) LintYAML(ctx LintContext, node *yaml.Node) []Lint {
 
 	if ctx.conf.RejectDeprecated && f.IsDeprecated {
 		lints = append(lints, NewLintError(node.Line, LintDeprecated, fmt.Errorf("field %v is deprecated", f.Name)))
+	} else if f.IsDeprecated {
+		lints = append(lints, NewLintWarning(node.Line, LintDeprecated, fmt.Sprintf("field %v is deprecated", f.Name)))
 	}
 
 	// Execute custom linters, if the kind is non-scalar this means we execute

--- a/internal/docs/format_yaml.go
+++ b/internal/docs/format_yaml.go
@@ -538,6 +538,8 @@ func LintYAML(ctx LintContext, cType Type, node *yaml.Node) []Lint {
 
 	if ctx.conf.RejectDeprecated && cSpec.Status == StatusDeprecated {
 		lints = append(lints, NewLintError(node.Line, LintDeprecated, fmt.Errorf("component %v is deprecated", cSpec.Name)))
+	} else if ctx.conf.WarnDeprecated && cSpec.Status == StatusDeprecated {
+		lints = append(lints, NewLintWarning(node.Line, LintDeprecated, fmt.Sprintf("component %v is deprecated", cSpec.Name)))
 	}
 
 	nameFound := false

--- a/internal/docs/format_yaml.go
+++ b/internal/docs/format_yaml.go
@@ -594,7 +594,7 @@ func (f FieldSpec) LintYAML(ctx LintContext, node *yaml.Node) []Lint {
 
 	if ctx.conf.RejectDeprecated && f.IsDeprecated {
 		lints = append(lints, NewLintError(node.Line, LintDeprecated, fmt.Errorf("field %v is deprecated", f.Name)))
-	} else if f.IsDeprecated {
+	} else if ctx.conf.WarnDeprecated && f.IsDeprecated {
 		lints = append(lints, NewLintWarning(node.Line, LintDeprecated, fmt.Sprintf("field %v is deprecated", f.Name)))
 	}
 


### PR DESCRIPTION
Currently if you run a config that contains a deprecated field or component - you will not get a warning. 

This PR adds warning logs when you create a stream with deprecated field/component when you create a stream via: 

 - bento 'normal mode' `bento -c config.yaml` 
 - bento 'streams mode' `bento streams ./*.yaml` 
 - creation of streams via REST API 
 
It also will now print any deprecated warnings when calling `bento lint` without setting `--deprecated`. The new behaviour is: 

`bento lint config.yaml` -> print any deprecated warnings but still return exit code 0
`bento lint --deprecated config.yaml` -> print deprecated warnings but return exit code 1 (same as before the PR)

 It will not change the behaviour when creating streams via the library using StreamBuilder. 
 
 ```
 INFO Running main config from specified file       @service=bento bento_version="" path=./tmp/log_deprecated_fields/deprecated.yaml
WARN Config lint warning                           @service=bento lint="tmp/log_deprecated_fields/deprecated.yaml(3,1) field url is deprecated"
INFO Listening for HTTP requests at: http://0.0.0.0:4195  @service=bento
INFO Launching a Bento instance, use CTRL+C to close  @service=bento
INFO Output type stdout is now active              @service=bento label="" path=root.output
INFO Input type amqp_1 is now active               @service=bento label="" path=root.input
 ```
 
 - [x] Add Lint Warning Logs to subcommand `bento lint`