### PR TITLE
remove tls.enable_renegotiation 'requires version 1.0.0 or newer' text 

### DIFF
--- a/internal/tls/docs.go
+++ b/internal/tls/docs.go
@@ -17,7 +17,7 @@ func FieldSpec() docs.FieldSpec {
 
 		docs.FieldBool(
 			"enable_renegotiation", "Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.",
-		).AtVersion("1.0.0").Advanced().HasDefault(false),
+		).Advanced().HasDefault(false),
 
 		docs.FieldString(
 			"root_cas", "An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.", "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",

--- a/website/docs/components/caches/nats_kv.md
+++ b/website/docs/components/caches/nats_kv.md
@@ -164,7 +164,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/caches/redis.md
+++ b/website/docs/components/caches/redis.md
@@ -142,7 +142,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/amqp_0_9.md
+++ b/website/docs/components/inputs/amqp_0_9.md
@@ -268,7 +268,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/amqp_1.md
+++ b/website/docs/components/inputs/amqp_1.md
@@ -190,7 +190,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/cassandra.md
+++ b/website/docs/components/inputs/cassandra.md
@@ -160,7 +160,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/cockroachdb_changefeed.md
+++ b/website/docs/components/inputs/cockroachdb_changefeed.md
@@ -111,7 +111,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/cypher.md
+++ b/website/docs/components/inputs/cypher.md
@@ -190,7 +190,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/etcd.md
+++ b/website/docs/components/inputs/etcd.md
@@ -245,7 +245,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/http_client.md
+++ b/website/docs/components/inputs/http_client.md
@@ -497,7 +497,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -227,7 +227,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -331,7 +331,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/mqtt.md
+++ b/website/docs/components/inputs/mqtt.md
@@ -245,7 +245,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/nats.md
+++ b/website/docs/components/inputs/nats.md
@@ -222,7 +222,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/nats_jetstream.md
+++ b/website/docs/components/inputs/nats_jetstream.md
@@ -271,7 +271,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/nats_kv.md
+++ b/website/docs/components/inputs/nats_kv.md
@@ -238,7 +238,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/nats_object_store.md
+++ b/website/docs/components/inputs/nats_object_store.md
@@ -195,7 +195,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/nats_stream.md
+++ b/website/docs/components/inputs/nats_stream.md
@@ -244,7 +244,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/nsq.md
+++ b/website/docs/components/inputs/nsq.md
@@ -126,7 +126,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/redis_list.md
+++ b/website/docs/components/inputs/redis_list.md
@@ -145,7 +145,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/redis_pubsub.md
+++ b/website/docs/components/inputs/redis_pubsub.md
@@ -152,7 +152,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/redis_scan.md
+++ b/website/docs/components/inputs/redis_scan.md
@@ -158,7 +158,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/redis_streams.md
+++ b/website/docs/components/inputs/redis_streams.md
@@ -156,7 +156,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/inputs/websocket.md
+++ b/website/docs/components/inputs/websocket.md
@@ -160,7 +160,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/metrics/influxdb.md
+++ b/website/docs/components/metrics/influxdb.md
@@ -120,7 +120,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/amqp_0_9.md
+++ b/website/docs/components/outputs/amqp_0_9.md
@@ -349,7 +349,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/amqp_1.md
+++ b/website/docs/components/outputs/amqp_1.md
@@ -154,7 +154,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/cassandra.md
+++ b/website/docs/components/outputs/cassandra.md
@@ -199,7 +199,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/cypher.md
+++ b/website/docs/components/outputs/cypher.md
@@ -273,7 +273,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/elasticsearch.md
+++ b/website/docs/components/outputs/elasticsearch.md
@@ -238,7 +238,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -471,7 +471,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -191,7 +191,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/kafka_franz.md
+++ b/website/docs/components/outputs/kafka_franz.md
@@ -481,7 +481,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/mqtt.md
+++ b/website/docs/components/outputs/mqtt.md
@@ -242,7 +242,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/nats.md
+++ b/website/docs/components/outputs/nats.md
@@ -247,7 +247,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/nats_jetstream.md
+++ b/website/docs/components/outputs/nats_jetstream.md
@@ -252,7 +252,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/nats_kv.md
+++ b/website/docs/components/outputs/nats_kv.md
@@ -200,7 +200,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/nats_object_store.md
+++ b/website/docs/components/outputs/nats_object_store.md
@@ -190,7 +190,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/nats_stream.md
+++ b/website/docs/components/outputs/nats_stream.md
@@ -185,7 +185,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/nsq.md
+++ b/website/docs/components/outputs/nsq.md
@@ -120,7 +120,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/opensearch.md
+++ b/website/docs/components/outputs/opensearch.md
@@ -221,7 +221,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/questdb.md
+++ b/website/docs/components/outputs/questdb.md
@@ -268,7 +268,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/redis_hash.md
+++ b/website/docs/components/outputs/redis_hash.md
@@ -179,7 +179,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/redis_list.md
+++ b/website/docs/components/outputs/redis_list.md
@@ -164,7 +164,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/redis_pubsub.md
+++ b/website/docs/components/outputs/redis_pubsub.md
@@ -163,7 +163,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/redis_streams.md
+++ b/website/docs/components/outputs/redis_streams.md
@@ -173,7 +173,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/outputs/websocket.md
+++ b/website/docs/components/outputs/websocket.md
@@ -117,7 +117,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/processors/http.md
+++ b/website/docs/components/processors/http.md
@@ -489,7 +489,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/processors/nats_kv.md
+++ b/website/docs/components/processors/nats_kv.md
@@ -267,7 +267,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/processors/nats_object_store.md
+++ b/website/docs/components/processors/nats_object_store.md
@@ -193,7 +193,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/processors/nats_request_reply.md
+++ b/website/docs/components/processors/nats_request_reply.md
@@ -281,7 +281,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/processors/redis.md
+++ b/website/docs/components/processors/redis.md
@@ -204,7 +204,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/processors/redis_script.md
+++ b/website/docs/components/processors/redis_script.md
@@ -185,7 +185,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/processors/schema_registry_decode.md
+++ b/website/docs/components/processors/schema_registry_decode.md
@@ -308,7 +308,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/processors/schema_registry_encode.md
+++ b/website/docs/components/processors/schema_registry_encode.md
@@ -332,7 +332,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 

--- a/website/docs/components/rate_limits/redis.md
+++ b/website/docs/components/rate_limits/redis.md
@@ -146,7 +146,6 @@ Whether to allow the remote server to repeatedly request renegotiation. Enable t
 
 Type: `bool`  
 Default: `false`  
-Requires version 1.0.0 or newer  
 
 ### `tls.root_cas`
 


### PR DESCRIPTION
TODO - remove all instances of "Requires version 1.0.0 or newer" ? 

Noticed this when making a new component with tls fields - but we probably should get rid of all instances of "requires version 1.0.0 or newer" 🤔  