### PR TITLE
fix(govet): Refactor test helpers to fix non-constant format string error

### DIFF
--- a/internal/component/testutil/from_yaml.go
+++ b/internal/component/testutil/from_yaml.go
@@ -18,80 +18,105 @@ import (
 	"github.com/warpstreamlabs/bento/internal/stream"
 )
 
-func BufferFromYAML(confStr string, args ...any) (buffer.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
-	if err != nil {
-		return buffer.Config{}, err
+func fromYAMLGenericWithArgs[T any](confStr string, args []any, fromAny func(prov docs.Provider, value any) (T, error)) (T, error) {
+	var zero T
+
+	var formattedStr string
+	if len(args) > 0 {
+		formattedStr = fmt.Sprintf(confStr, args...)
+	} else {
+		formattedStr = confStr
 	}
-	return buffer.FromAny(bundle.GlobalEnvironment, node)
+
+	node, err := docs.UnmarshalYAML([]byte(formattedStr))
+	if err != nil {
+		return zero, err
+	}
+	return fromAny(bundle.GlobalEnvironment, node)
 }
 
-func CacheFromYAML(confStr string, args ...any) (cache.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
-	if err != nil {
-		return cache.Config{}, err
-	}
-	return cache.FromAny(bundle.GlobalEnvironment, node)
+func fromYAMLGeneric[T any](confStr string, fromAny func(prov docs.Provider, value any) (T, error)) (T, error) {
+	return fromYAMLGenericWithArgs(confStr, nil, fromAny)
 }
 
-func InputFromYAML(confStr string, args ...any) (input.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
-	if err != nil {
-		return input.Config{}, err
-	}
-	return input.FromAny(bundle.GlobalEnvironment, node)
+func BufferFromYAML(confStr string) (buffer.Config, error) {
+	return fromYAMLGeneric(confStr, buffer.FromAny)
 }
 
-func MetricsFromYAML(confStr string, args ...any) (metrics.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
-	if err != nil {
-		return metrics.Config{}, err
-	}
-	return metrics.FromAny(bundle.GlobalEnvironment, node)
+func BufferFromYAMLWithArgs(confStr string, args ...any) (buffer.Config, error) {
+	return fromYAMLGenericWithArgs(confStr, args, buffer.FromAny)
 }
 
-func OutputFromYAML(confStr string, args ...any) (output.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
-	if err != nil {
-		return output.Config{}, err
-	}
-	return output.FromAny(bundle.GlobalEnvironment, node)
+func CacheFromYAML(confStr string) (cache.Config, error) {
+	return fromYAMLGeneric(confStr, cache.FromAny)
 }
 
-func ProcessorFromYAML(confStr string, args ...any) (processor.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
-	if err != nil {
-		return processor.Config{}, err
-	}
-	return processor.FromAny(bundle.GlobalEnvironment, node)
+func CacheFromYAMLWithArgs(confStr string, args ...any) (cache.Config, error) {
+	return fromYAMLGenericWithArgs(confStr, args, cache.FromAny)
 }
 
-func RateLimitFromYAML(confStr string, args ...any) (ratelimit.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
-	if err != nil {
-		return ratelimit.Config{}, err
-	}
-	return ratelimit.FromAny(bundle.GlobalEnvironment, node)
+func InputFromYAML(confStr string) (input.Config, error) {
+	return fromYAMLGeneric(confStr, input.FromAny)
 }
 
-func TracerFromYAML(confStr string, args ...any) (tracer.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
-	if err != nil {
-		return tracer.Config{}, err
-	}
-	return tracer.FromAny(bundle.GlobalEnvironment, node)
+func InputFromYAMLWithArgs(confStr string, args ...any) (input.Config, error) {
+	return fromYAMLGenericWithArgs(confStr, args, input.FromAny)
 }
 
-func ManagerFromYAML(confStr string, args ...any) (manager.ResourceConfig, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
-	if err != nil {
-		return manager.ResourceConfig{}, err
-	}
-	return manager.FromAny(bundle.GlobalEnvironment, node)
+func MetricsFromYAML(confStr string) (metrics.Config, error) {
+	return fromYAMLGeneric(confStr, metrics.FromAny)
 }
 
-func StreamFromYAML(confStr string, args ...any) (stream.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func MetricsFromYAMLWithArgs(confStr string, args ...any) (metrics.Config, error) {
+	return fromYAMLGenericWithArgs(confStr, args, metrics.FromAny)
+}
+
+func OutputFromYAML(confStr string) (output.Config, error) {
+	return fromYAMLGeneric(confStr, output.FromAny)
+}
+
+func OutputFromYAMLWithArgs(confStr string, args ...any) (output.Config, error) {
+	return fromYAMLGenericWithArgs(confStr, args, output.FromAny)
+}
+
+func ProcessorFromYAML(confStr string) (processor.Config, error) {
+	return fromYAMLGeneric(confStr, processor.FromAny)
+}
+
+func ProcessorFromYAMLWithArgs(confStr string, args ...any) (processor.Config, error) {
+	return fromYAMLGenericWithArgs(confStr, args, processor.FromAny)
+}
+
+func RateLimitFromYAML(confStr string) (ratelimit.Config, error) {
+	return fromYAMLGeneric(confStr, ratelimit.FromAny)
+}
+
+func RateLimitFromYAMLWithArgs(confStr string, args ...any) (ratelimit.Config, error) {
+	return fromYAMLGenericWithArgs(confStr, args, ratelimit.FromAny)
+}
+
+func TracerFromYAML(confStr string) (tracer.Config, error) {
+	return fromYAMLGeneric(confStr, tracer.FromAny)
+}
+
+func TracerFromYAMLWithArgs(confStr string, args ...any) (tracer.Config, error) {
+	return fromYAMLGenericWithArgs(confStr, args, tracer.FromAny)
+}
+
+func ManagerFromYAML(confStr string) (manager.ResourceConfig, error) {
+	return fromYAMLGeneric(confStr, manager.FromAny)
+}
+
+func ManagerFromYAMLWithArgs(confStr string, args ...any) (manager.ResourceConfig, error) {
+	return fromYAMLGenericWithArgs(confStr, args, manager.FromAny)
+}
+
+func StreamFromYAML(confStr string) (stream.Config, error) {
+	return StreamFromYAMLWithArgs(confStr)
+}
+
+func StreamFromYAMLWithArgs(confStr string, args ...any) (stream.Config, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return stream.Config{}, err
 	}
@@ -106,8 +131,24 @@ func StreamFromYAML(confStr string, args ...any) (stream.Config, error) {
 	return stream.FromParsed(bundle.GlobalEnvironment, pConf, rawSource)
 }
 
-func ConfigFromYAML(confStr string, args ...any) (config.Type, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func ConfigFromYAML(confStr string) (config.Type, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
+	if err != nil {
+		return config.Type{}, err
+	}
+
+	var rawSource any
+	_ = node.Decode(&rawSource)
+
+	pConf, err := config.Spec().ParsedConfigFromAny(node)
+	if err != nil {
+		return config.Type{}, err
+	}
+	return config.FromParsed(bundle.GlobalEnvironment, pConf, rawSource)
+}
+
+func ConfigFromYAMLWithArgs(confStr string, args ...any) (config.Type, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return config.Type{}, err
 	}

--- a/internal/impl/pure/input_sequence_test.go
+++ b/internal/impl/pure/input_sequence_test.go
@@ -26,7 +26,7 @@ func writeFiles(t *testing.T, dir string, nameToContent map[string]string) {
 }
 
 func testInput(t testing.TB, confPattern string, args ...any) input.Streamed {
-	iConf, err := testutil.InputFromYAML(fmt.Sprintf(confPattern, args...))
+	iConf, err := testutil.InputFromYAMLWithArgs(confPattern, args...)
 	require.NoError(t, err)
 
 	i, err := mock.NewManager().NewInput(iConf)

--- a/internal/impl/pure/output_drop_on_test.go
+++ b/internal/impl/pure/output_drop_on_test.go
@@ -25,7 +25,7 @@ import (
 
 func parseYAMLOutputConf(t testing.TB, formatStr string, args ...any) output.Config {
 	t.Helper()
-	conf, err := testutil.OutputFromYAML(fmt.Sprintf(formatStr, args...))
+	conf, err := testutil.OutputFromYAMLWithArgs(formatStr, args...)
 	require.NoError(t, err)
 	return conf
 }

--- a/internal/impl/pure/output_switch_test.go
+++ b/internal/impl/pure/output_switch_test.go
@@ -17,12 +17,11 @@ import (
 	"github.com/warpstreamlabs/bento/internal/message"
 )
 
-func newSwitch(t testing.TB, mockOutputs []*mock.OutputChanneled, confStr string, args ...any) *switchOutput {
+func newSwitch(t testing.TB, mockOutputs []*mock.OutputChanneled, confStr string) *switchOutput {
 	t.Helper()
 
 	mgr := mock.NewManager()
-
-	pConf, err := switchOutputSpec().ParseYAML(fmt.Sprintf(confStr, args...), nil)
+	pConf, err := switchOutputSpec().ParseYAML(confStr, nil)
 	require.NoError(t, err)
 
 	s, err := switchOutputFromParsed(pConf, mgr)

--- a/internal/impl/pure/processor_grok_test.go
+++ b/internal/impl/pure/processor_grok_test.go
@@ -91,7 +91,7 @@ func TestGrok(t *testing.T) {
 			if test.definitions == nil {
 				test.definitions = map[string]any{}
 			}
-			conf, err := testutil.ProcessorFromYAML(`
+			conf, err := testutil.ProcessorFromYAMLWithArgs(`
 grok:
   expressions:
     - '%v'
@@ -115,7 +115,7 @@ grok:
 			if test.definitions == nil {
 				test.definitions = map[string]any{}
 			}
-			conf, err := testutil.ProcessorFromYAML(`
+			conf, err := testutil.ProcessorFromYAMLWithArgs(`
 grok:
   expressions:
     - '%v'
@@ -144,7 +144,7 @@ FOONESTED %{INT:nested.first:int} %{WORD:nested.second} %{WORD:nested.third}
 `), 0o777)
 	require.NoError(t, err)
 
-	conf, err := testutil.ProcessorFromYAML(`
+	conf, err := testutil.ProcessorFromYAMLWithArgs(`
 grok:
   expressions:
     - "%%{FOONESTED}"


### PR DESCRIPTION
## Motivation

In preperation for updating to Go 1.24, format print statements now require non-constant format strings to be explicitly handled -- otherwise govet causes the build to fail (see [docs](https://tip.golang.org/doc/go1.24#vet)).

## Changes

- Reworked helper functions to appease the the go vet checker.