### PR TITLE
update(parquet-go): Bump parquet-go and handle new LIST logical type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/opensearch-project/opensearch-go/v4 v4.3.0
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/oschwald/geoip2-golang v1.9.0
-	github.com/parquet-go/parquet-go v0.23.0
+	github.com/parquet-go/parquet-go v0.24.0
 	github.com/pebbe/zmq4 v1.2.11
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/pkg/sftp v1.13.7
@@ -355,7 +355,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
-	github.com/segmentio/encoding v0.4.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1784,8 +1784,8 @@ github.com/oschwald/geoip2-golang v1.9.0 h1:uvD3O6fXAXs+usU+UGExshpdP13GAqp4GBrz
 github.com/oschwald/geoip2-golang v1.9.0/go.mod h1:BHK6TvDyATVQhKNbQBdrj9eAvuwOMi2zSFXizL3K81Y=
 github.com/oschwald/maxminddb-golang v1.11.0 h1:aSXMqYR/EPNjGE8epgqwDay+P30hCBZIveY0WZbAWh0=
 github.com/oschwald/maxminddb-golang v1.11.0/go.mod h1:YmVI+H0zh3ySFR3w+oz8PCfglAFj3PuCmui13+P9zDg=
-github.com/parquet-go/parquet-go v0.23.0 h1:dyEU5oiHCtbASyItMCD2tXtT2nPmoPbKpqf0+nnGrmk=
-github.com/parquet-go/parquet-go v0.23.0/go.mod h1:MnwbUcFHU6uBYMymKAlPPAw9yh3kE1wWl6Gl1uLdkNk=
+github.com/parquet-go/parquet-go v0.24.0 h1:VrsifmLPDnas8zpoHmYiWDZ1YHzLmc7NmNwPGkI2JM4=
+github.com/parquet-go/parquet-go v0.24.0/go.mod h1:OqBBRGBl7+llplCvDMql8dEKaDqjaFA/VAPw+OJiNiw=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/paulmach/orb v0.11.1 h1:3koVegMC4X/WeiXYz9iswopaTwMem53NzTJuTF20JzU=
 github.com/paulmach/orb v0.11.1/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
@@ -1897,8 +1897,6 @@ github.com/s2-streamstore/s2-sdk-go v0.6.0/go.mod h1:VAK2MYAXfT2eMq4IpaWHRuL5ZBb
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
-github.com/segmentio/encoding v0.4.0 h1:MEBYvRqiUB2nfR2criEXWqwdY6HJOUrCn5hboVOVmy8=
-github.com/segmentio/encoding v0.4.0/go.mod h1:/d03Cd8PoaDeceuhUUUQWjU0KhWjrmYrWPgtJHYZSnI=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=

--- a/internal/impl/parquet/schema.go
+++ b/internal/impl/parquet/schema.go
@@ -163,7 +163,7 @@ func generateListType(
 ) (reflect.Type, error) {
 	fields, err := field.FieldAnyList("fields")
 	if err != nil {
-		return nil, fmt.Errorf("getting map fields: %w", err)
+		return nil, fmt.Errorf("getting list fields: %w", err)
 	}
 
 	if len(fields) != 1 {
@@ -172,7 +172,7 @@ func generateListType(
 
 	elementType, err := generateFieldType(fields[0], schemaOpts)
 	if err != nil {
-		return nil, fmt.Errorf("generating map key type: %w", err)
+		return nil, fmt.Errorf("generating list key type: %w", err)
 	}
 
 	return reflect.SliceOf(elementType), nil

--- a/website/docs/components/processors/parquet_decode.md
+++ b/website/docs/components/processors/parquet_decode.md
@@ -22,13 +22,49 @@ Decodes [Parquet files](https://parquet.apache.org/docs/) into a batch of struct
 
 Introduced in version 1.0.0.
 
+
+<Tabs defaultValue="common" values={[
+  { label: 'Common', value: 'common', },
+  { label: 'Advanced', value: 'advanced', },
+]}>
+
+<TabItem value="common">
+
 ```yml
-# Config fields, showing default values
+# Common config fields, showing default values
 label: ""
 parquet_decode: {}
 ```
 
+</TabItem>
+<TabItem value="advanced">
+
+```yml
+# All config fields, showing default values
+label: ""
+parquet_decode:
+  use_parquet_list_format: true
+```
+
+</TabItem>
+</Tabs>
+
 This processor uses [https://github.com/parquet-go/parquet-go](https://github.com/parquet-go/parquet-go), which is itself experimental. Therefore changes could be made into how this processor functions outside of major version releases.
+
+## Fields
+
+### `use_parquet_list_format`
+
+Whether to decode`LIST`type columns into their Parquet logical type format `{"list": [{"element": value_1}, {"element": value_2}, ...]}` instead of a Go slice `[value_1, value_2, ...]`.
+
+:::caution
+This flag will be disabled (set to `false`) by default and deprecated in future versions, with the logical format being deprecated in favour of the Go slice.
+:::
+
+
+Type: `bool`  
+Default: `true`  
+Requires version 1.8.0 or newer  
 
 ## Examples
 


### PR DESCRIPTION
## Changes

 - Bumps parquet-go from `0.23.0` to `0.24.0`
 - Adds a new flag `use_parquet_list_format` that allows for LIST types to be decoded into the logical type format -- following breaking changes in the upstream.
- Adds `TestParquetDecodeListFormat` as well as `TestParquetDecodeListFormatEdgeCases` -- where the latter is skipped due to a lack of support for 2D (and higher dimensional) arrays being encoded by upstream.

Closes #359