### PR TITLE
chore: Remove deprecated warnings & fix formatting

### DIFF
--- a/internal/bloblang/query/methods_strings.go
+++ b/internal/bloblang/query/methods_strings.go
@@ -347,6 +347,7 @@ root.encrypted = this.value.encrypt_aes("ctr", $key, $vector).encode("hex")`,
 		case "ofb":
 			schemeFn = func(b []byte) (string, error) {
 				ciphertext := make([]byte, len(b))
+				//nolint:staticcheck // Ignore SA1019 deprecation warning for NewOFB
 				stream := cipher.NewOFB(block, iv)
 				stream.XORKeyStream(ciphertext, b)
 				return string(ciphertext), nil
@@ -456,6 +457,8 @@ root.decrypted = this.value.decode("hex").decrypt_aes("ctr", $key, $vector).stri
 		case "ofb":
 			schemeFn = func(b []byte) ([]byte, error) {
 				plaintext := make([]byte, len(b))
+				// TODO(gregfurman): This has been deprecated. Consider slently using NewCTR as recommended by Go team.
+				//nolint:staticcheck // Ignore SA1019 deprecation warning for NewOFB
 				stream := cipher.NewOFB(block, iv)
 				stream.XORKeyStream(plaintext, b)
 				return plaintext, nil

--- a/internal/cli/blobl/server.go
+++ b/internal/cli/blobl/server.go
@@ -240,7 +240,7 @@ func runServer(c *cli.Context) error {
 		openBrowserAt(u.String())
 	}
 
-	log.Printf("Serving at: http://" + bindAddress + "?mode=server")
+	log.Printf("Serving at: http://%s?mode=server", bindAddress)
 
 	server := http.Server{
 		Addr:    bindAddress,


### PR DESCRIPTION
- Fixes a go vet issue with formatting and non-constant strings
- Silences a deprecation warning on linter for `cypher.NewOFB()` usage