### PR TITLE
fix-aws-cloudwatch-metric-shutdown

### DIFF
--- a/internal/impl/aws/metrics_cloudwatch.go
+++ b/internal/impl/aws/metrics_cloudwatch.go
@@ -523,6 +523,9 @@ func (c *cwMetrics) HandlerFunc() http.HandlerFunc {
 }
 
 func (c *cwMetrics) Close(ctx context.Context) error {
-	c.cancel()
-	return c.flush(ctx)
+	defer c.cancel()
+	if err := c.flush(ctx); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/impl/aws/metrics_cloudwatch_test.go
+++ b/internal/impl/aws/metrics_cloudwatch_test.go
@@ -432,7 +432,6 @@ func TestCloudWatchShutdown(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 
 	ctx := context.Background()
-	cw.cancel()
 	cw.Close(ctx)
 
 	expKey := fmt.Sprintf("counter.foo:%v", expTagMap)


### PR DESCRIPTION
Fixes an issue where `aws_cloudwatch` metrics were not sent on Close().