### PR TITLE
Add Dark mode to Bloblang editor

### DIFF
--- a/internal/cli/blobl/resources/playground/assets/css/components.css
+++ b/internal/cli/blobl/resources/playground/assets/css/components.css
@@ -365,64 +365,126 @@
   color: rgb(249, 38, 114);
 }
 
-/* Floating Discreet Theme Toggle */
+/* Dark Mode Toggle with Peek Effect */
 .floating-theme-toggle {
   position: fixed;
-  top: 20px;
-  left: 20px;
+  top: 50%;
+  right: -20px; /* Half hidden by default */
+  transform: translateY(-50%);
   z-index: 999;
   border: none;
-  background-color: rgba(253, 229, 216, 0.3);
+  background: linear-gradient(
+    135deg,
+    rgba(253, 229, 216, 0.95),
+    rgba(255, 240, 230, 0.9)
+  );
   color: var(--bento-text-heading);
-  border-radius: 50%;
-  width: 24px;
-  height: 24px;
-  font-size: 10px;
+  border-radius: 12px 0 0 12px; /* Rounded left side only */
+  width: 40px;
+  height: 50px;
+  font-size: 14px;
   cursor: pointer;
   font-family: var(--bento-font-family);
-  transition: all 0.3s ease;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: 0.4;
-  backdrop-filter: blur(4px);
-  border: 1px solid rgba(235, 135, 136, 0.2);
-}
-
-.floating-theme-toggle:hover {
-  opacity: 0.8;
-  transform: scale(1.1);
-  background-color: rgba(253, 229, 216, 0.9);
-  border-color: rgba(235, 135, 136, 0.4);
-}
-
-.floating-theme-toggle:active {
-  transform: scale(0.95);
-  opacity: 1;
-}
-
-/* Dark mode floating theme toggle */
-[data-theme="dark"] .floating-theme-toggle {
-  background-color: rgba(74, 53, 48, 0.4);
-  color: var(--bento-text-heading);
-  border-color: rgba(106, 90, 85, 0.3);
-  opacity: 0.3;
-}
-
-[data-theme="dark"] .floating-theme-toggle:hover {
-  background-color: rgba(74, 53, 48, 0.7);
-  border-color: rgba(106, 90, 85, 0.5);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(235, 135, 136, 0.3);
+  border-right: none;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
   opacity: 0.7;
 }
 
-[data-theme="dark"] .theme-icon::before {
-  content: "☀️";
+.floating-theme-toggle::before {
+  content: "";
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 20px;
+  background: linear-gradient(
+    to bottom,
+    var(--bento-primary),
+    var(--bento-secondary)
+  );
+  border-radius: 2px;
+  opacity: 0.6;
+}
+
+.floating-theme-toggle:hover {
+  right: 0; /* Slide in fully */
+  opacity: 1;
+  transform: translateY(-50%) scale(1.02);
+  background: linear-gradient(
+    135deg,
+    rgba(253, 229, 216, 1),
+    rgba(255, 240, 230, 0.95)
+  );
+  border-color: rgba(235, 135, 136, 0.5);
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.15);
+}
+
+.floating-theme-toggle:hover::before {
+  opacity: 1;
+  background: linear-gradient(to bottom, #ff6b6b, #ffa726);
+}
+
+.floating-theme-toggle:active {
+  transform: translateY(-50%) scale(0.98);
+  transition: all 0.1s ease;
+}
+
+/* Dark mode toggle */
+[data-theme="dark"] .floating-theme-toggle {
+  background: linear-gradient(
+    135deg,
+    rgba(74, 53, 48, 0.95),
+    rgba(64, 45, 40, 0.9)
+  );
+  color: var(--bento-text-heading);
+  border-color: rgba(106, 90, 85, 0.4);
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] .floating-theme-toggle::before {
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 206, 84, 0.8),
+    rgba(255, 183, 77, 0.6)
+  );
+}
+
+[data-theme="dark"] .floating-theme-toggle:hover {
+  background: linear-gradient(
+    135deg,
+    rgba(74, 53, 48, 1),
+    rgba(64, 45, 40, 0.95)
+  );
+  border-color: rgba(106, 90, 85, 0.6);
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .floating-theme-toggle:hover::before {
+  background: linear-gradient(to bottom, #ffce54, #ffb74d);
+}
+
+.theme-icon {
+  transform-origin: center center;
+  display: inline-block;
+  transition: transform 0.6s ease-in-out;
+  margin-left: 6px;
 }
 
 .theme-icon::before {
-  content: "🌙";
-  font-size: 10px;
+  content: "☀️";
+  font-size: 16px;
+  display: block;
+  text-align: center;
+  line-height: 1;
 }
+
 
 /* Toast Notifications */
 .notification {
@@ -478,5 +540,24 @@
   .format-btn {
     font-size: 10px;
     padding: 3px 6px;
+  }
+
+  /* Dark mode toggle adjustments */
+  .floating-theme-toggle {
+    width: 35px;
+    height: 45px;
+    right: -18px;
+    font-size: 12px;
+  }
+
+  .floating-theme-toggle::before {
+    width: 2px;
+    height: 16px;
+    left: 6px;
+  }
+
+  .theme-icon::before,
+  [data-theme="dark"] .theme-icon::before {
+    font-size: 14px;
   }
 }

--- a/internal/cli/blobl/resources/playground/assets/css/components.css
+++ b/internal/cli/blobl/resources/playground/assets/css/components.css
@@ -9,6 +9,12 @@
   flex-direction: column;
 }
 
+/* Dark mode panel styles */
+[data-theme="dark"] .panel {
+  background: var(--bento-bg-alt);
+  border-color: var(--bento-bg-highlight);
+}
+
 .panel.error {
   border-color: var(--bento-error);
   box-shadow: 0 0 0 2px rgba(211, 47, 47, 0.2);
@@ -21,7 +27,7 @@
 }
 
 .panel-header {
-  background: var(--bento-button-selected);
+  background: var(--bento-panel-header-bg);
   color: var(--bento-button-text);
   padding: 8px 16px;
   font-weight: 600;
@@ -86,6 +92,40 @@
   transition: transform 0.15s ease, box-shadow 0.15s ease,
     background-color 0.15s ease;
   margin-left: 4px;
+}
+
+/* Dark mode action button styles */
+[data-theme="dark"] .action-btn {
+  background-color: var(--bento-button-unselected);
+  color: var(--bento-button-text);
+  box-shadow: 0 3px 0 #1a1a17;
+  border-color: var(--bento-bg-highlight);
+}
+
+[data-theme="dark"] .action-btn:hover {
+  background-color: var(--bento-button-selected);
+  box-shadow: 0 4px 0 #1a1a17;
+}
+
+[data-theme="dark"] .action-btn:active {
+  background-color: var(--bento-button-selected);
+  box-shadow: 0 1px 0 #1a1a17;
+}
+
+[data-theme="dark"] .action-btn.primary {
+  background-color: var(--bento-accent);
+  color: var(--bento-text-body);
+  box-shadow: 0 3px 0 #cc4242;
+}
+
+[data-theme="dark"] .action-btn.primary:hover {
+  background-color: #ff6b6b;
+  box-shadow: 0 4px 0 #cc4242;
+}
+
+[data-theme="dark"] .action-btn.primary:active {
+  background-color: var(--bento-accent);
+  box-shadow: 0 1px 0 #cc4242;
 }
 
 .action-btn:hover {
@@ -179,6 +219,17 @@
   font-family: var(--bento-font-family);
 }
 
+/* Dark mode format button styles */
+[data-theme="dark"] .format-btn {
+  background: var(--bento-button-unselected);
+  border-color: var(--bento-bg-highlight);
+  color: var(--bento-text-heading);
+}
+
+[data-theme="dark"] .format-btn:hover {
+  background: var(--bento-button-selected);
+}
+
 .format-btn:hover {
   background: var(--bento-button-selected);
   transform: translateY(-1px);
@@ -205,6 +256,17 @@
 .output.success {
   background: #ffffff;
   color: var(--bento-text-body);
+}
+
+/* Dark mode output styles */
+[data-theme="dark"] .output.success {
+  background: var(--bento-bg-alt);
+  color: var(--bento-text-body);
+}
+
+[data-theme="dark"] .output.error {
+  background: var(--bento-error-bg);
+  color: var(--bento-error);
 }
 
 .output.json-formatted {
@@ -276,6 +338,90 @@
 
 .output .json-punctuation {
   color: var(--bento-text-heading);
+}
+
+/* Dark mode JSON syntax highlighting - Monokai colors from website */
+[data-theme="dark"] .output .json-string {
+  color: rgb(230, 219, 116);
+}
+
+[data-theme="dark"] .output .json-number {
+  color: rgb(174, 129, 255);
+}
+
+[data-theme="dark"] .output .json-null {
+  color: rgb(174, 129, 255);
+}
+
+[data-theme="dark"] .output .json-key {
+  color: rgb(249, 38, 114);
+}
+
+[data-theme="dark"] .output .json-boolean {
+  color: rgb(174, 129, 255);
+}
+
+[data-theme="dark"] .output .json-punctuation {
+  color: rgb(249, 38, 114);
+}
+
+/* Floating Discreet Theme Toggle */
+.floating-theme-toggle {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  z-index: 999;
+  border: none;
+  background-color: rgba(253, 229, 216, 0.3);
+  color: var(--bento-text-heading);
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  font-size: 10px;
+  cursor: pointer;
+  font-family: var(--bento-font-family);
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.4;
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(235, 135, 136, 0.2);
+}
+
+.floating-theme-toggle:hover {
+  opacity: 0.8;
+  transform: scale(1.1);
+  background-color: rgba(253, 229, 216, 0.9);
+  border-color: rgba(235, 135, 136, 0.4);
+}
+
+.floating-theme-toggle:active {
+  transform: scale(0.95);
+  opacity: 1;
+}
+
+/* Dark mode floating theme toggle */
+[data-theme="dark"] .floating-theme-toggle {
+  background-color: rgba(74, 53, 48, 0.4);
+  color: var(--bento-text-heading);
+  border-color: rgba(106, 90, 85, 0.3);
+  opacity: 0.3;
+}
+
+[data-theme="dark"] .floating-theme-toggle:hover {
+  background-color: rgba(74, 53, 48, 0.7);
+  border-color: rgba(106, 90, 85, 0.5);
+  opacity: 0.7;
+}
+
+[data-theme="dark"] .theme-icon::before {
+  content: "☀️";
+}
+
+.theme-icon::before {
+  content: "🌙";
+  font-size: 10px;
 }
 
 /* Toast Notifications */

--- a/internal/cli/blobl/resources/playground/assets/css/editor.css
+++ b/internal/cli/blobl/resources/playground/assets/css/editor.css
@@ -1,4 +1,12 @@
-/* Base editor styling */
+/* Base ACE Editor Styling */
+.ace-bento {
+  --ace-selection-light: rgba(235, 135, 136, 0.2);
+  --ace-selection-dark: rgba(235, 135, 136, 0.15);
+  --ace-active-line-light: rgba(253, 229, 216, 0.3);
+  --ace-active-line-dark: rgba(255, 244, 233, 0.08);
+  --ace-bracket-bg: rgba(235, 135, 136, 0.3);
+}
+
 .ace-bento .ace_editor {
   font-family: var(--bento-font-mono) !important;
   background-color: #ffffff !important;
@@ -15,21 +23,21 @@
   background-color: var(--bento-button-selected) !important;
 }
 
-/* Editor interaction elements */
+/* Editor Interaction Elements */
 .ace-bento .ace_cursor {
   color: var(--bento-text-heading) !important;
 }
 
 .ace-bento .ace_selection {
-  background-color: rgba(235, 135, 136, 0.2) !important;
+  background-color: var(--ace-selection-light) !important;
 }
 
 .ace-bento .ace_active-line {
-  background-color: rgba(253, 229, 216, 0.3) !important;
+  background-color: var(--ace-active-line-light) !important;
 }
 
 .ace-bento .ace_marker-layer .ace_bracket {
-  background: rgba(235, 135, 136, 0.3);
+  background: var(--ace-bracket-bg);
   border: 1px solid var(--bento-bg-highlight);
 }
 
@@ -37,13 +45,12 @@
   color: var(--bento-bg-highlight);
 }
 
-/* Syntax highlighting - Strings */
+/* Light Theme Syntax Highlighting */
 .ace-bento .ace_string {
   color: var(--bento-success) !important;
   font-weight: 500 !important;
 }
 
-/* Syntax highlighting - Numbers and constants */
 .ace-bento .ace_constant.ace_numeric {
   color: var(--bento-bg-highlight) !important;
   font-weight: 500 !important;
@@ -59,7 +66,6 @@
   font-style: italic !important;
 }
 
-/* Syntax highlighting - Keywords and operators */
 .ace-bento .ace_keyword {
   color: var(--bento-text-highlight) !important;
   font-weight: 600 !important;
@@ -69,7 +75,6 @@
   color: var(--bento-text-heading) !important;
 }
 
-/* Syntax highlighting - Functions and methods */
 .ace-bento .ace_support.ace_function {
   color: var(--bento-success) !important;
   font-weight: 500 !important;
@@ -80,19 +85,17 @@
   font-weight: 500 !important;
 }
 
-/* Syntax highlighting - Variables and identifiers */
 .ace-bento .ace_variable {
   color: var(--bento-bg-highlight) !important;
   font-weight: 500 !important;
 }
 
-/* Syntax highlighting - Comments */
 .ace-bento .ace_comment {
   color: #999999 !important;
   font-style: italic !important;
 }
 
-/* Bloblang-specific syntax highlighting */
+/* Bloblang-specific Syntax Highlighting */
 .ace-bento .ace_bloblang_root {
   color: var(--bento-text-highlight);
   font-weight: 700;
@@ -107,31 +110,172 @@
   border-radius: 3px;
 }
 
-/* Documentation Tooltip Styling */
+/* Dark Theme Styles */
+[data-theme="dark"] .ace-bento .ace_editor {
+  background-color: #272822 !important;
+  color: var(--bento-text-body) !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_gutter {
+  background-color: var(--bento-bg-alt) !important;
+  color: var(--bento-text-heading) !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_active-line {
+  background-color: var(--ace-active-line-dark) !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_selection {
+  background-color: var(--ace-selection-dark) !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_gutter-active-line {
+  background-color: var(--bento-button-selected) !important;
+}
+
+/* Dark Theme Syntax Highlighting - Monokai Colors */
+[data-theme="dark"] .ace-bento .ace_string {
+  color: rgb(230, 219, 116) !important;
+  font-weight: 500 !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_constant.ace_numeric,
+[data-theme="dark"] .ace-bento .ace_constant.ace_language,
+[data-theme="dark"] .ace-bento .ace_constant.ace_language.ace_null {
+  color: rgb(174, 129, 255) !important;
+  font-weight: 500 !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_constant.ace_language {
+  font-weight: 600 !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_constant.ace_language.ace_null {
+  font-style: italic !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_keyword,
+[data-theme="dark"] .ace-bento .ace_punctuation {
+  color: rgb(249, 38, 114) !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_keyword {
+  font-weight: 600 !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_support.ace_function,
+[data-theme="dark"] .ace-bento .ace_support.ace_method {
+  color: rgb(166, 226, 46) !important;
+  font-weight: 500 !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_variable {
+  color: rgb(248, 248, 242) !important;
+  font-weight: 500 !important;
+}
+
+[data-theme="dark"] .ace-bento .ace_comment {
+  color: rgb(136, 132, 111) !important;
+  font-style: italic !important;
+}
+
+/* Documentation Tooltip Base */
 .ace_tooltip {
+  background-color: transparent;
+  padding: 0;
+  border-radius: 50px;
+  border: none;
   background-image: none;
   white-space: normal;
-  border: none;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
+  overflow: visible;
+  z-index: 10000;
+  max-width: min(480px, 85vw);
+  max-height: min(450px, 75vh);
 }
 
 .ace-doc {
-  max-width: 350px;
-  padding: 8px;
+  max-width: 100%;
+  width: 100%;
+  max-height: min(450px, 75vh);
+  padding: 16px;
   background: white;
   font-family: var(--bento-font-family);
   font-size: 12px;
-  line-height: 1.4;
+  line-height: 1.6;
   color: var(--bento-text-body);
+  border: 2px solid var(--bento-bg-highlight);
+  border-radius: 10px;
+  box-sizing: border-box;
+  overflow-y: auto;
+  overflow-x: hidden;
+  word-wrap: break-word;
+  hyphens: auto;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+  /* Hide scrollbar */
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+}
+
+.ace-doc::-webkit-scrollbar {
+  width: 0px;
+  background: transparent; /* Chrome, Safari, Opera */
+}
+
+.ace-doc:hover {
+  background-color: #fef3f1;
+  border-color: var(--bento-text-highlight);
+}
+
+.ace-doc-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  gap: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border-radius: 8px;
+  padding: 4px;
+}
+
+.ace-doc-header:hover {
+  background-color: rgba(235, 135, 136, 0.05);
+  transform: translateY(-1px);
 }
 
 .ace-doc-signature {
   font-family: var(--bento-font-mono);
   font-size: 12px;
   color: var(--bento-text-heading);
-  margin-bottom: 12px;
-  padding: 8px;
+  padding: 10px 12px;
   background-color: var(--bento-bg-alt);
-  border-radius: 3px;
+  border-radius: 6px;
+  border: 1px solid rgba(235, 135, 136, 0.2);
+  flex: 1;
+  min-width: 0;
+  transition: all 0.2s ease;
+}
+
+.ace-doc-header:hover .ace-doc-signature {
+  border-color: var(--bento-text-highlight);
+  background-color: rgba(235, 135, 136, 0.1);
+}
+
+.ace-doc-link-indicator {
+  font-size: 16px;
+  color: var(--bento-text-highlight);
+  opacity: 0.7;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.ace-doc-header:hover .ace-doc-link-indicator {
+  opacity: 1;
+  transform: scale(1.1);
 }
 
 .ace-doc-description {
@@ -145,78 +289,42 @@
   margin-bottom: 6px;
 }
 
-.ace-doc-examples {
+/* Documentation Examples and Parameters */
+.ace-doc-examples,
+.ace-doc-parameters {
   margin-top: 8px;
   padding-top: 8px;
   border-top: 1px solid rgba(235, 135, 136, 0.2);
 }
 
-.ace-doc-examples strong {
+.ace-doc-examples strong,
+.ace-doc-parameters strong {
   color: var(--bento-text-heading);
   font-size: 11px;
   margin-bottom: 4px;
   display: block;
 }
 
-.ace-doc-examples code {
+.ace-doc-parameters strong {
+  margin-bottom: 6px;
+}
+
+.ace-doc-examples code,
+.ace-doc-param code {
   display: block;
   font-family: var(--bento-font-mono);
   font-size: 11px;
   background-color: var(--bento-bg-alt);
   padding: 2px 4px;
   border-radius: 2px;
-  margin: 2px 0;
   color: var(--bento-text-heading);
 }
 
-/* Status badges for functions and methods */
-.ace-status-stable {
-  background-color: var(--bento-success);
-  color: white;
-  font-size: 9px;
-  padding: 1px 4px;
-  border-radius: 2px;
-  margin-left: 6px;
-  font-weight: 600;
+.ace-doc-examples code {
+  margin: 2px 0;
 }
 
-.ace-status-beta {
-  background-color: #ff9800;
-  color: white;
-  font-size: 9px;
-  padding: 1px 4px;
-  border-radius: 2px;
-  margin-left: 6px;
-  font-weight: 600;
-}
-
-.ace-status-experimental {
-  background-color: #9c27b0;
-  color: white;
-  font-size: 9px;
-  padding: 1px 4px;
-  border-radius: 2px;
-  margin-left: 6px;
-  font-weight: 600;
-}
-
-.ace-status-deprecated {
-  background-color: var(--bento-error);
-  color: white;
-  font-size: 9px;
-  padding: 1px 4px;
-  border-radius: 2px;
-  margin-left: 6px;
-  font-weight: 600;
-}
-
-.ace-impure-badge {
-  background-color: #795548;
-  color: white;
-  font-size: 9px;
-  padding: 1px 4px;
-  border-radius: 2px;
-  margin-left: 6px;
+.ace-doc-param code {
   font-weight: 600;
 }
 
@@ -227,32 +335,141 @@
   margin: 4px 0 2px 0;
 }
 
-.ace-doc-parameters {
-  margin-top: 8px;
-  padding-top: 8px;
-  border-top: 1px solid rgba(235, 135, 136, 0.2);
-}
-
-.ace-doc-parameters strong {
-  color: var(--bento-text-heading);
-  font-size: 11px;
-  margin-bottom: 6px;
-  display: block;
-}
-
-.ace-doc-param code {
-  font-family: var(--bento-font-mono);
-  font-size: 11px;
-  background-color: var(--bento-bg-alt);
-  padding: 2px 4px;
-  border-radius: 2px;
-  color: var(--bento-text-heading);
-  font-weight: 600;
-}
-
 .ace-doc-param-desc {
   font-size: 11px;
   color: var(--bento-text-body);
   margin-left: 4px;
   line-height: 1.3;
+}
+
+.ace-doc a {
+  color: var(--bento-text-highlight);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--bento-text-highlight);
+}
+
+.ace-doc a:hover {
+  color: var(--bento-accent);
+  border-bottom-color: var(--bento-accent);
+}
+
+/* Status Badges */
+.ace-status-stable,
+.ace-status-beta,
+.ace-status-experimental,
+.ace-status-deprecated,
+.ace-impure-badge {
+  font-size: 9px;
+  padding: 1px 4px;
+  border-radius: 2px;
+  margin-left: 6px;
+  font-weight: 600;
+  color: white;
+}
+
+.ace-status-stable {
+  background-color: var(--bento-success);
+}
+
+.ace-status-beta {
+  background-color: #ff9800;
+}
+
+.ace-status-experimental {
+  background-color: #9c27b0;
+}
+
+.ace-status-deprecated {
+  background-color: var(--bento-error);
+}
+
+.ace-impure-badge {
+  background-color: #795548;
+}
+
+/* Dark Theme Documentation */
+[data-theme="dark"] .ace_tooltip {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] .ace-doc {
+  background: #4a3530;
+  color: #f0f0f0;
+  border: 1px solid #6a5a55;
+}
+
+[data-theme="dark"] .ace-doc-header:hover {
+  background-color: rgba(106, 90, 85, 0.1);
+}
+
+[data-theme="dark"] .ace-doc-signature {
+  background-color: #5a453f;
+  color: #ffffff;
+  border: 1px solid #6a5a55;
+}
+
+[data-theme="dark"] .ace-doc-header:hover .ace-doc-signature {
+  border-color: var(--bento-text-highlight);
+  background-color: rgba(106, 90, 85, 0.2);
+}
+
+[data-theme="dark"] .ace-doc-link-indicator {
+  color: var(--bento-text-highlight);
+}
+
+[data-theme="dark"] .ace-doc-examples code,
+[data-theme="dark"] .ace-doc-param code {
+  background-color: #5a453f;
+  color: #e0e0e0;
+  border: 1px solid #6a5a55;
+}
+
+[data-theme="dark"] .ace-doc-category {
+  color: #cccccc;
+}
+
+[data-theme="dark"] .ace-status-stable {
+  background-color: #4a7c59;
+}
+
+[data-theme="dark"] .ace-status-beta {
+  background-color: #cc7a00;
+}
+
+[data-theme="dark"] .ace-status-experimental {
+  background-color: #7a1f7a;
+}
+
+[data-theme="dark"] .ace-status-deprecated {
+  background-color: #cc4444;
+}
+
+[data-theme="dark"] .ace-impure-badge {
+  background-color: #6a4c42;
+}
+
+[data-theme="dark"] .ace-doc a {
+  color: var(--bento-text-highlight);
+  border-bottom-color: var(--bento-text-highlight);
+}
+
+[data-theme="dark"] .ace-doc a:hover {
+  color: #ff7777;
+  border-bottom-color: #ff7777;
+}
+
+/* Dark Theme Tooltip */
+[data-theme="dark"] .ace_tooltip {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .ace-doc {
+  background: #3f2d29;
+  color: #f0f0f0;
+  border: 1px solid #6a5a55;
+}
+
+[data-theme="dark"] .ace-doc:hover {
+  background: #2b1c18;
+  border-color: var(--bento-text-highlight);
 }

--- a/internal/cli/blobl/resources/playground/assets/css/theme.css
+++ b/internal/cli/blobl/resources/playground/assets/css/theme.css
@@ -11,6 +11,7 @@
   --bento-button-selected: #ffbcba;
   --bento-button-unselected: #fde5d8;
   --bento-button-text: #333333;
+  --bento-panel-header-bg: #ffbcba;
   --bento-success: #2e7d32;
   --bento-success-bg: #e8f5e8;
   --bento-error: #d32f2f;
@@ -26,6 +27,26 @@
   --bento-font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont,
     "Segoe UI", Roboto, sans-serif;
   --bento-font-mono: "Monaco", "IBM Plex Mono", "SF Mono", "Consolas", monospace;
+}
+
+/* Dark mode color palette */
+[data-theme="dark"] {
+  --bento-bg-main: #2a1a17;
+  --bento-accent: #ff5252;
+  --bento-bg-alt: #3a2623;
+  --bento-bg-highlight: #eb8788;
+  --bento-text-body: #fff4e9;
+  --bento-text-heading: #fff4e9;
+  --bento-text-highlight: #ff5252;
+  --bento-button-selected: #5a453f;
+  --bento-button-unselected: #3a2623;
+  --bento-button-text: #fff4e9;
+  --bento-panel-header-bg: #4a3530;
+  --bento-success: #a9dc76;
+  --bento-success-bg: #2a2b25;
+  --bento-error: #ff6188;
+  --bento-error-bg: #3d1b1b;
+  --bento-warning: #ffd866;
 }
 
 /* Reset & Base Styles */
@@ -153,6 +174,12 @@ body {
   resize: none;
   outline: none;
   tab-size: 2;
+}
+
+/* Dark mode editor styles */
+[data-theme="dark"] .editor {
+  background: var(--bento-bg-alt);
+  color: var(--bento-text-body);
 }
 
 .fallback-editor {

--- a/internal/cli/blobl/resources/playground/index.html
+++ b/internal/cli/blobl/resources/playground/index.html
@@ -24,7 +24,7 @@
       <div>Loading Bloblang Playground...</div>
     </div>
 
-    <!-- Floating Discreet Theme Toggle -->
+    <!-- Dark mode toggle -->
     <button
       class="floating-theme-toggle"
       id="themeToggle"

--- a/internal/cli/blobl/resources/playground/index.html
+++ b/internal/cli/blobl/resources/playground/index.html
@@ -24,6 +24,17 @@
       <div>Loading Bloblang Playground...</div>
     </div>
 
+    <!-- Floating Discreet Theme Toggle -->
+    <button
+      class="floating-theme-toggle"
+      id="themeToggle"
+      data-action="toggle-theme"
+      title="Toggle dark mode"
+      aria-label="Toggle dark mode"
+    >
+      <span class="theme-icon"></span>
+    </button>
+
     <main class="container" id="container">
       <!-- Input Panel -->
       <section class="panel input-panel" id="inputPanel">

--- a/internal/cli/blobl/resources/playground/js/editor.js
+++ b/internal/cli/blobl/resources/playground/js/editor.js
@@ -331,23 +331,26 @@ class EditorManager {
 
   processMarkdown(text) {
     if (typeof text !== "string") return text;
-    
+
     let processed = text;
-    
+
     // Process inline code (backticks)
-    processed = processed.replace(/`([^`]+)`/g, '<code>$1</code>');
-    
+    processed = processed.replace(/`([^`]+)`/g, "<code>$1</code>");
+
     // Process markdown links - handle docs links specially
-    processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, linkText, url) => {
-      // If it's a docs link, convert to full URL or strip if preferred
-      if (url.startsWith('/docs/')) {
-        const fullUrl = `https://warpstreamlabs.github.io/bento${url}`;
-        return `<a href="${fullUrl}" target="_blank" rel="noopener">${linkText}</a>`;
+    processed = processed.replace(
+      /\[([^\]]+)\]\(([^)]+)\)/g,
+      (match, linkText, url) => {
+        // If it's a docs link, convert to full URL
+        if (url.startsWith("/docs/")) {
+          const fullUrl = `https://warpstreamlabs.github.io/bento${url}`;
+          return `<a href="${fullUrl}" target="_blank" rel="noopener">${linkText}</a>`;
+        }
+        // For other links, use as-is
+        return `<a href="${url}" target="_blank" rel="noopener">${linkText}</a>`;
       }
-      // For other links, use as-is
-      return `<a href="${url}" target="_blank" rel="noopener">${linkText}</a>`;
-    });
-    
+    );
+
     return processed.trim();
   }
 
@@ -356,8 +359,8 @@ class EditorManager {
 
     const paramStrs = params.named.map((param) => {
       const type = param.type ? `: ${param.type}` : "";
-      
-      // Handle default values properly - only show if non-empty
+
+      // Handle default values properly
       let def = "";
       if (param.default !== undefined) {
         const defaultValue = String(param.default).trim();
@@ -365,7 +368,7 @@ class EditorManager {
           def = ` = ${defaultValue}`;
         }
       }
-      
+
       const token = `${param.name}${type}${def}`;
       return param.optional ? `[${token}]` : token;
     });
@@ -386,9 +389,9 @@ class EditorManager {
         : "";
 
     // Create specific docs URL with anchor
-    const docsSection = isMethod ? 'methods' : 'functions';
+    const docsSection = isMethod ? "methods" : "functions";
     const docsUrl = `https://warpstreamlabs.github.io/bento/docs/guides/bloblang/${docsSection}#${spec.name}`;
-    
+
     const strippedDesc = this.stripAdmonitions(spec.description);
     const processedDesc = this.processMarkdown(strippedDesc);
 
@@ -406,8 +409,8 @@ class EditorManager {
     if (spec.category) {
       html += `<div class="ace-doc-category">Category: ${spec.category}</div>`;
     }
-    
-    // Add version information if available
+
+    // Add version information
     if (spec.version) {
       html += `<div class="ace-doc-version">Since: v${spec.version}</div>`;
     }
@@ -424,13 +427,13 @@ class EditorManager {
           param.default !== undefined ? ` = ${param.default}` : "";
         const typeText = param.type ? ` [${param.type}]` : "";
 
-        const processedParamDesc = this.processMarkdown(param.description || "No description");
-        
+        const processedParamDesc = this.processMarkdown(
+          param.description || "No description"
+        );
+
         html += `
         <div class="ace-doc-param">
-          <code>${
-            param.name
-          }${typeText}${defaultText}${optionalText}</code><br/>
+          <code>${param.name}${typeText}${defaultText}${optionalText}</code><br/>
           <span class="ace-doc-param-desc">${processedParamDesc}</span>
         </div>`;
       }
@@ -449,37 +452,25 @@ class EditorManager {
       html += `</div>`;
     }
 
-    // Add walkthrough link if this is a commonly used function
-    const walkthroughFunctions = ['contains', 'split', 'join', 'map_each', 'filter', 'this', 'root', 'metadata'];
-    if (walkthroughFunctions.includes(spec.name)) {
-      html += `<div class="ace-doc-walkthrough">
-        <span class="ace-doc-walkthrough-icon">🎓</span>
-        <span>This function is featured in the <a href="https://warpstreamlabs.github.io/bento/docs/guides/bloblang/walkthrough" target="_blank">Bloblang Walkthrough</a></span>
-      </div>`;
-    }
-
     html += `</div>`;
     return html;
   }
 
   setupDocumentationClickHandlers() {
     // Make header and signature section clickable
-    document.addEventListener('click', (event) => {
-      // Check if clicked element is within ace-doc-header or ace-doc-signature
-      const clickedHeader = event.target.closest('.ace-doc-header');
-      const clickedSignature = event.target.closest('.ace-doc-signature');
-      
+    document.addEventListener("click", (event) => {
+      const clickedHeader = event.target.closest(".ace-doc-header");
+      const clickedSignature = event.target.closest(".ace-doc-signature");
+
       if (clickedHeader || clickedSignature) {
         event.preventDefault();
         event.stopPropagation();
-        
-        const aceDoc = event.target.closest('.ace-doc');
+
+        const aceDoc = event.target.closest(".ace-doc");
         const docsUrl = aceDoc?.dataset.docsUrl;
-        
-        console.log('Clicked on header/signature, URL:', docsUrl); // Debug log
-        
+
         if (docsUrl) {
-          window.open(docsUrl, '_blank', 'noopener,noreferrer');
+          window.open(docsUrl, "_blank", "noopener,noreferrer");
         }
       }
     });

--- a/internal/cli/blobl/resources/playground/js/playground.js
+++ b/internal/cli/blobl/resources/playground/js/playground.js
@@ -37,6 +37,7 @@ class BloblangPlayground {
         },
       });
       this.ui.init();
+      this.editor.setupDocumentationClickHandlers();
       this.updateLinters();
       this.execute();
       this.hideLoading();

--- a/internal/cli/blobl/resources/playground/js/ui.js
+++ b/internal/cli/blobl/resources/playground/js/ui.js
@@ -3,10 +3,71 @@ class UIManager {
     this.isResizing = false;
     this.container = document.getElementById("container");
     this.horizontalResizer = document.getElementById("horizontalResizer");
+    this.themeToggle = document.getElementById("themeToggle");
+    this.currentTheme = this.getInitialTheme();
   }
 
   init() {
     this.setupResizer();
+    this.setupTheme();
+  }
+
+  getStoredTheme() {
+    return localStorage.getItem("bloblang-theme");
+  }
+
+  getSystemTheme() {
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+
+  getUrlTheme() {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has('dark')) {
+      return 'dark';
+    }
+    if (urlParams.has('light')) {
+      return 'light';
+    }
+    return null;
+  }
+
+  getInitialTheme() {
+    // Priority: URL param > localStorage > system preference
+    return this.getUrlTheme() || this.getStoredTheme() || this.getSystemTheme();
+  }
+
+  setTheme(theme) {
+    this.currentTheme = theme;
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("bloblang-theme", theme);
+  }
+
+  toggleTheme() {
+    const newTheme = this.currentTheme === "dark" ? "light" : "dark";
+    this.setTheme(newTheme);
+  }
+
+  setupTheme() {
+    // Apply initial theme
+    this.setTheme(this.currentTheme);
+
+    // Setup theme toggle button
+    if (this.themeToggle) {
+      this.themeToggle.addEventListener("click", () => {
+        this.toggleTheme();
+      });
+    }
+
+    // Listen for system theme changes when no stored preference
+    if (!this.getStoredTheme()) {
+      window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+        if (!this.getStoredTheme()) {
+          this.setTheme(e.matches ? "dark" : "light");
+        }
+      });
+    }
   }
 
   setupResizer() {

--- a/internal/cli/blobl/resources/playground/js/ui.js
+++ b/internal/cli/blobl/resources/playground/js/ui.js
@@ -5,6 +5,7 @@ class UIManager {
     this.horizontalResizer = document.getElementById("horizontalResizer");
     this.themeToggle = document.getElementById("themeToggle");
     this.currentTheme = this.getInitialTheme();
+    this.rotationAngle = 0; // Track current rotation for smooth animations
   }
 
   init() {
@@ -17,25 +18,15 @@ class UIManager {
   }
 
   getSystemTheme() {
-    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+    return window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
       ? "dark"
       : "light";
   }
 
-  getUrlTheme() {
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.has('dark')) {
-      return 'dark';
-    }
-    if (urlParams.has('light')) {
-      return 'light';
-    }
-    return null;
-  }
-
   getInitialTheme() {
-    // Priority: URL param > localStorage > system preference
-    return this.getUrlTheme() || this.getStoredTheme() || this.getSystemTheme();
+    // Priority: localStorage > system preference
+    return this.getStoredTheme() || this.getSystemTheme();
   }
 
   setTheme(theme) {
@@ -45,6 +36,16 @@ class UIManager {
   }
 
   toggleTheme() {
+    // Smooth rotation using CSS transforms
+    if (this.themeToggle) {
+      const icon = this.themeToggle.querySelector(".theme-icon");
+
+      if (icon) {
+        this.rotationAngle += 360; // Add 360 degrees to current rotation
+        icon.style.transform = `rotate(${this.rotationAngle}deg)`;
+      }
+    }
+
     const newTheme = this.currentTheme === "dark" ? "light" : "dark";
     this.setTheme(newTheme);
   }
@@ -53,7 +54,7 @@ class UIManager {
     // Apply initial theme
     this.setTheme(this.currentTheme);
 
-    // Setup theme toggle button
+    // Setup dark mode toggle button
     if (this.themeToggle) {
       this.themeToggle.addEventListener("click", () => {
         this.toggleTheme();
@@ -62,11 +63,13 @@ class UIManager {
 
     // Listen for system theme changes when no stored preference
     if (!this.getStoredTheme()) {
-      window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
-        if (!this.getStoredTheme()) {
-          this.setTheme(e.matches ? "dark" : "light");
-        }
-      });
+      window
+        .matchMedia("(prefers-color-scheme: dark)")
+        .addEventListener("change", (e) => {
+          if (!this.getStoredTheme()) {
+            this.setTheme(e.matches ? "dark" : "light");
+          }
+        });
     }
   }
 


### PR DESCRIPTION
- **Dark Mode**: Adds a dark mode theme
- **Improved Tooltips**: Updates the tooltip documentation with better links, markdown stripping, and redirects
- **Improved Formatter**:  Improves Bloblang's code formatter

## Screenshots
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/a03daa7f-695b-40ec-80ce-a9b810b5d651" />
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/1e687f80-e469-4b38-b4f9-900233051bf7" />

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/60a435a1-65a2-494f-b7a3-e9d23733397b" />
<img width="1425" alt="image" src="https://github.com/user-attachments/assets/30e1b4fd-2af8-408e-bd16-e253f123ff4d" />

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/d92c199e-b0ea-482e-b2c7-20032bba8807" />
<img width="1428" alt="image" src="https://github.com/user-attachments/assets/c82de6f6-4337-4957-8f09-7dda7dc48ac5" />

References issue https://github.com/warpstreamlabs/bento/issues/370