### PR TITLE
feat(bigquery): Add direct protobuf support to BigQuery Write API sink

### DIFF
--- a/internal/impl/gcp/output_bigquery_storage_test.go
+++ b/internal/impl/gcp/output_bigquery_storage_test.go
@@ -289,9 +289,8 @@ table: test`,
 			config := gcpBigQueryWriteAPIConfFromYAML(t, tt.config)
 			require.Equal(t, tt.expectedFormat, config.messageFormat)
 
-			output, err := newBigQueryStorageOutput(config, nil)
+			_, err := newBigQueryStorageOutput(config, nil)
 			require.NoError(t, err)
-			require.NotNil(t, output.unmarshal)
 		})
 	}
 }

--- a/internal/impl/gcp/output_bigquery_storage_test.go
+++ b/internal/impl/gcp/output_bigquery_storage_test.go
@@ -9,6 +9,11 @@ import (
 	"cloud.google.com/go/bigquery"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
 
 	"github.com/warpstreamlabs/bento/public/service"
 )
@@ -243,5 +248,333 @@ endpoint:
 		require.NoError(t, json.Unmarshal(sampleJSONData[i], &expected))
 		require.Equal(t, expected, row)
 	}
+}
 
+func TestGCPBigQueryStorageOutputMessageFormatConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         string
+		expectedFormat string
+	}{
+		{
+			name: "json format",
+			config: `
+project: test
+dataset: test
+table: test
+message_format: json`,
+			expectedFormat: "json",
+		},
+		{
+			name: "protobuf format",
+			config: `
+project: test
+dataset: test
+table: test
+message_format: protobuf`,
+			expectedFormat: "protobuf",
+		},
+		{
+			name: "default format",
+			config: `
+project: test
+dataset: test
+table: test`,
+			expectedFormat: "json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := gcpBigQueryWriteAPIConfFromYAML(t, tt.config)
+			require.Equal(t, tt.expectedFormat, config.messageFormat)
+
+			output, err := newBigQueryStorageOutput(config, nil)
+			require.NoError(t, err)
+			require.NotNil(t, output.unmarshal)
+		})
+	}
+}
+
+func TestGCPBigQueryStorageOutputProtobufFormat(t *testing.T) {
+	type GithubRepo struct {
+		Type   string `bigquery:"type" json:"type"`
+		Public bool   `bigquery:"public" json:"public"`
+		Repo   struct {
+			ID   bigquery.NullInt64 `bigquery:"id" json:"id"`
+			Name string             `bigquery:"name" json:"name"`
+			URL  string             `bigquery:"url" json:"url"`
+		} `bigquery:"repo" json:"repo"`
+	}
+
+	schema, err := bigquery.InferSchema(GithubRepo{})
+	require.NoError(t, err)
+
+	fileDesc := createTestProtobufDescriptor(t)
+	msgDesc := fileDesc.Messages().ByName("TestMessage")
+	sampleProtobufData := createSampleProtobufMessages(t, msgDesc)
+
+	emulator := setupBigQueryEmulator(t, "project_meow", "dataset_meow", "table_meow", &schema)
+
+	config := gcpBigQueryWriteAPIConfFromYAML(t, fmt.Sprintf(`
+project: project_meow
+dataset: dataset_meow
+table: table_meow
+message_format: protobuf
+endpoint:
+  grpc: %s
+  http: %s
+`, emulator.grpcEndpoint, emulator.httpEndpoint))
+
+	output, err := newBigQueryStorageOutput(config, nil)
+	require.NoError(t, err)
+
+	err = output.Connect(context.Background())
+	defer output.Close(context.Background())
+	require.NoError(t, err)
+
+	batch := make(service.MessageBatch, len(sampleProtobufData))
+	for i, msgBytes := range sampleProtobufData {
+		batch[i] = service.NewMessage(msgBytes)
+	}
+
+	err = output.WriteBatch(context.Background(), batch)
+	require.NoError(t, err)
+
+	iter := emulator.client.Dataset("dataset_meow").Table("table_meow").Read(context.Background())
+	var rows []GithubRepo
+	for {
+		var row GithubRepo
+		if err := iter.Next(&row); err != nil {
+			if err == iterator.Done {
+				break
+			}
+			t.Fatal(err)
+		}
+		rows = append(rows, row)
+	}
+
+	require.Equal(t, len(sampleProtobufData), int(iter.TotalRows))
+
+	expectedValues := []GithubRepo{
+		{Type: "foo", Public: true, Repo: struct {
+			ID   bigquery.NullInt64 `bigquery:"id" json:"id"`
+			Name string             `bigquery:"name" json:"name"`
+			URL  string             `bigquery:"url" json:"url"`
+		}{ID: bigquery.NullInt64{Int64: 99, Valid: true}, Name: "repo_name_1", URL: "https://one.example.com"}},
+		{Type: "bar", Public: false, Repo: struct {
+			ID   bigquery.NullInt64 `bigquery:"id" json:"id"`
+			Name string             `bigquery:"name" json:"name"`
+			URL  string             `bigquery:"url" json:"url"`
+		}{ID: bigquery.NullInt64{Int64: 101, Valid: true}, Name: "repo_name_2", URL: "https://two.example.com"}},
+	}
+
+	for i, row := range rows {
+		if i < len(expectedValues) {
+			require.Equal(t, expectedValues[i].Type, row.Type)
+			require.Equal(t, expectedValues[i].Public, row.Public)
+			require.Equal(t, expectedValues[i].Repo.Name, row.Repo.Name)
+			require.Equal(t, expectedValues[i].Repo.URL, row.Repo.URL)
+			if expectedValues[i].Repo.ID.Valid {
+				require.Equal(t, expectedValues[i].Repo.ID.Int64, row.Repo.ID.Int64)
+			}
+		}
+	}
+}
+
+func TestGCPBigQueryStorageOutputProtobufUnmarshalError(t *testing.T) {
+	type SimpleRecord struct {
+		Name string `bigquery:"name" json:"name"`
+	}
+
+	schema, err := bigquery.InferSchema(SimpleRecord{})
+	require.NoError(t, err)
+
+	emulator := setupBigQueryEmulator(t, "project_test", "dataset_test", "table_test", &schema)
+
+	config := gcpBigQueryWriteAPIConfFromYAML(t, fmt.Sprintf(`
+project: project_test
+dataset: dataset_test
+table: table_test
+message_format: protobuf
+endpoint:
+  grpc: %s
+  http: %s
+`, emulator.grpcEndpoint, emulator.httpEndpoint))
+
+	output, err := newBigQueryStorageOutput(config, nil)
+	require.NoError(t, err)
+
+	err = output.Connect(context.Background())
+	defer output.Close(context.Background())
+	require.NoError(t, err)
+
+	invalidProtobufData := []byte("this is not valid protobuf data")
+	batch := service.MessageBatch{service.NewMessage(invalidProtobufData)}
+
+	err = output.WriteBatch(context.Background(), batch)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to Unmarshal message for item 0")
+}
+
+func createTestProtobufDescriptor(t *testing.T) protoreflect.FileDescriptor {
+	t.Helper()
+
+	fileDescProto := &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("test.proto"),
+		Package: proto.String("test"),
+		MessageType: []*descriptorpb.DescriptorProto{
+			{
+				Name: proto.String("TestMessage"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					{
+						Name:   proto.String("type"),
+						Number: proto.Int32(1),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+					},
+					{
+						Name:   proto.String("public"),
+						Number: proto.Int32(2),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_BOOL.Enum(),
+					},
+					{
+						Name:     proto.String("repo"),
+						Number:   proto.Int32(3),
+						Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+						TypeName: proto.String(".test.RepoMessage"),
+					},
+				},
+			},
+			{
+				Name: proto.String("RepoMessage"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					{
+						Name:   proto.String("id"),
+						Number: proto.Int32(1),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+					},
+					{
+						Name:   proto.String("name"),
+						Number: proto.Int32(2),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+					},
+					{
+						Name:   proto.String("url"),
+						Number: proto.Int32(3),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+					},
+				},
+			},
+		},
+	}
+
+	fileDesc, err := protodesc.NewFile(fileDescProto, nil)
+	require.NoError(t, err)
+	return fileDesc
+}
+
+func createSampleProtobufMessages(t *testing.T, msgDesc protoreflect.MessageDescriptor) [][]byte {
+	t.Helper()
+
+	var messages [][]byte
+
+	sampleData := []map[string]interface{}{
+		{
+			"type":   "foo",
+			"public": true,
+			"repo": map[string]interface{}{
+				"id":   int64(99),
+				"name": "repo_name_1",
+				"url":  "https://one.example.com",
+			},
+		},
+		{
+			"type":   "bar",
+			"public": false,
+			"repo": map[string]interface{}{
+				"id":   int64(101),
+				"name": "repo_name_2",
+				"url":  "https://two.example.com",
+			},
+		},
+	}
+
+	for _, data := range sampleData {
+		msg := dynamicpb.NewMessage(msgDesc)
+
+		msg.Set(msgDesc.Fields().ByName("type"), protoreflect.ValueOfString(data["type"].(string)))
+		msg.Set(msgDesc.Fields().ByName("public"), protoreflect.ValueOfBool(data["public"].(bool)))
+
+		repoDesc := msgDesc.Fields().ByName("repo").Message()
+		repoMsg := dynamicpb.NewMessage(repoDesc)
+		repoData := data["repo"].(map[string]interface{})
+
+		repoMsg.Set(repoDesc.Fields().ByName("id"), protoreflect.ValueOfInt64(repoData["id"].(int64)))
+		repoMsg.Set(repoDesc.Fields().ByName("name"), protoreflect.ValueOfString(repoData["name"].(string)))
+		repoMsg.Set(repoDesc.Fields().ByName("url"), protoreflect.ValueOfString(repoData["url"].(string)))
+
+		msg.Set(msgDesc.Fields().ByName("repo"), protoreflect.ValueOfMessage(repoMsg))
+
+		msgBytes, err := proto.Marshal(msg)
+		require.NoError(t, err)
+
+		messages = append(messages, msgBytes)
+	}
+
+	return messages
+}
+
+func TestGCPBigQueryStorageProtobufIntegrationDemo(t *testing.T) {
+	fileDesc := createTestProtobufDescriptor(t)
+	msgDesc := fileDesc.Messages().ByName("TestMessage")
+
+	testJSON := []string{
+		`{"type": "demo", "public": true, "repo": {"id": 123, "name": "test-repo", "url": "https://example.com"}}`,
+	}
+
+	var protobufMessages [][]byte
+	for _, jsonData := range testJSON {
+		protobufData := createProtobufMessageFromJSON(t, msgDesc, jsonData)
+		protobufMessages = append(protobufMessages, protobufData)
+	}
+
+	protoMessage := dynamicpb.NewMessage(msgDesc)
+	err := proto.Unmarshal(protobufMessages[0], protoMessage)
+	require.NoError(t, err)
+
+	typeField := protoMessage.Get(msgDesc.Fields().ByName("type")).String()
+	publicField := protoMessage.Get(msgDesc.Fields().ByName("public")).Bool()
+	repoField := protoMessage.Get(msgDesc.Fields().ByName("repo")).Message()
+
+	require.Equal(t, "demo", typeField)
+	require.Equal(t, true, publicField)
+	require.NotNil(t, repoField)
+}
+
+func createProtobufMessageFromJSON(t *testing.T, msgDesc protoreflect.MessageDescriptor, jsonData string) []byte {
+	t.Helper()
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(jsonData), &data)
+	require.NoError(t, err)
+
+	msg := dynamicpb.NewMessage(msgDesc)
+
+	msg.Set(msgDesc.Fields().ByName("type"), protoreflect.ValueOfString(data["type"].(string)))
+	msg.Set(msgDesc.Fields().ByName("public"), protoreflect.ValueOfBool(data["public"].(bool)))
+
+	repoDesc := msgDesc.Fields().ByName("repo").Message()
+	repoMsg := dynamicpb.NewMessage(repoDesc)
+	repoData := data["repo"].(map[string]interface{})
+
+	repoMsg.Set(repoDesc.Fields().ByName("id"), protoreflect.ValueOfInt64(int64(repoData["id"].(float64))))
+	repoMsg.Set(repoDesc.Fields().ByName("name"), protoreflect.ValueOfString(repoData["name"].(string)))
+	repoMsg.Set(repoDesc.Fields().ByName("url"), protoreflect.ValueOfString(repoData["url"].(string)))
+
+	msg.Set(msgDesc.Fields().ByName("repo"), protoreflect.ValueOfMessage(repoMsg))
+
+	msgBytes, err := proto.Marshal(msg)
+	require.NoError(t, err)
+
+	return msgBytes
 }

--- a/website/docs/components/outputs/gcp_bigquery_write_api.md
+++ b/website/docs/components/outputs/gcp_bigquery_write_api.md
@@ -38,6 +38,7 @@ output:
     project: ""
     dataset: "" # No default (required)
     table: "" # No default (required)
+    message_format: json
 ```
 
 </TabItem>
@@ -55,6 +56,7 @@ output:
       http: ""
       grpc: ""
     stream_type: DEFAULT
+    message_format: json
     batching:
       count: 0
       byte_size: 0
@@ -141,6 +143,20 @@ Default: `"DEFAULT"`
 | Option | Summary |
 |---|---|
 | `DEFAULT` | DefaultStream most closely mimics the legacy bigquery tabledata.insertAll semantics. Successful inserts are committed immediately, and there's no tracking offsets as all writes go into a `default` stream that always exists for a table. |
+
+
+### `message_format`
+
+Format of incoming messages
+
+
+Type: `string`  
+Default: `"json"`  
+
+| Option | Summary |
+|---|---|
+| `json` | Messages are in JSON format (default) |
+| `protobuf` | Messages are in protobuf format |
 
 
 ### `batching`


### PR DESCRIPTION
## Changes

- Adds a new `message_format` field to `gcp_bigquery_write_api` that allows a user specify the format of incoming messages.