### PR TITLE
Azure cloud credentials sql

### DIFF
--- a/internal/impl/sql/azure/azure.go
+++ b/internal/impl/sql/azure/azure.go
@@ -1,0 +1,106 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/warpstreamlabs/bento/internal/impl/sql"
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+func init() {
+	var noop sql.AzureDSNBuiler = func(dsn, driver string) (builtDSN string, err error) {
+		return dsn, nil
+	}
+
+	sql.AzureGetCredentialsGeneratorFn = func(pConf *service.ParsedConfig) (sql.AzureDSNBuiler, error) {
+		nsConf := pConf.Namespace("azure")
+		entraEnabled, err := nsConf.FieldBool("entra_enabled")
+		if err != nil {
+			return nil, err
+		}
+
+		if !entraEnabled {
+			return noop, nil
+		}
+
+		getTokenOptions := func() (tro policy.TokenRequestOptions, err error) {
+			return parseTokenOptions(pConf)
+		}
+
+		wrapDsnBuilder := func(dsn, driver string) (string, error) {
+			return BuildEntraDsn(dsn, driver, getTokenOptions)
+		}
+
+		return wrapDsnBuilder, nil
+	}
+}
+
+func BuildEntraDsn(dsn, driver string, getTokenOptions func() (policy.TokenRequestOptions, error)) (builtDsn string, err error) {
+	if driver != "postgres" {
+		return "", errors.New("entra auth currently only works for postgres DSNs")
+	}
+
+	parsedDSN, err := url.Parse(dsn)
+	if err != nil {
+		return "", fmt.Errorf("error parsing DSN URLS: %w", err)
+	}
+
+	username := parsedDSN.User.Username()
+	host := parsedDSN.Hostname()
+	path := parsedDSN.Path[1:]
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return "", err
+	}
+
+	tro, err := getTokenOptions()
+	if err != nil {
+		return "", err
+	}
+
+	token, err := cred.GetToken(context.TODO(), tro)
+	if err != nil {
+		return "", err
+	}
+
+	connectionString := fmt.Sprintf("host=%s user=%s password=%s dbname=%s sslmode=require", host, username, token.Token, path)
+
+	return connectionString, nil
+}
+
+func parseTokenOptions(pConf *service.ParsedConfig) (policy.TokenRequestOptions, error) {
+	nsConf := pConf.Namespace("azure", "token_request_options")
+
+	claims, err := nsConf.FieldString("claims")
+	if err != nil {
+		return policy.TokenRequestOptions{}, err
+	}
+
+	enableCAE, err := nsConf.FieldBool("enable_cae")
+	if err != nil {
+		return policy.TokenRequestOptions{}, err
+	}
+
+	scopes, err := nsConf.FieldStringList("scopes")
+	if err != nil {
+		return policy.TokenRequestOptions{}, err
+	}
+
+	tenantID, err := nsConf.FieldString("tenant_id")
+	if err != nil {
+		return policy.TokenRequestOptions{}, err
+	}
+
+	return policy.TokenRequestOptions{
+		Claims:    claims,
+		EnableCAE: enableCAE,
+		Scopes:    scopes,
+		TenantID:  tenantID,
+	}, nil
+}

--- a/internal/impl/sql/conn_aws.go
+++ b/internal/impl/sql/conn_aws.go
@@ -31,6 +31,6 @@ var AWSGetCredentialsGeneratorFn = func(c *service.ParsedConfig) (fn func(dsn, d
 	return
 }
 
-var BuildAwsDsn = func(dsn, driver string) (password string, err error) {
+var BuildAwsDsn = func(dsn, driver string) (newDsn string, err error) {
 	return dsn, nil
 }

--- a/internal/impl/sql/conn_azure.go
+++ b/internal/impl/sql/conn_azure.go
@@ -1,0 +1,24 @@
+package sql
+
+import (
+	"errors"
+
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+type AzureDSNBuiler func(dsn, driver string) (builtDSN string, err error)
+
+var AzureGetCredentialsGeneratorFn = func(pConf *service.ParsedConfig) (fn AzureDSNBuiler, err error) {
+	entraEnabled, err := pConf.FieldBool("azure", "entra_enabled")
+	if err != nil {
+		return nil, err
+	}
+	if entraEnabled {
+		return nil, errors.New("unable to configure Azure Entra authentication as this binary doesn't import components/azure")
+	}
+	return
+}
+
+var BuildAzureDsn = func(dsn, driver string) (builtDsn string, err error) {
+	return dsn, nil
+}

--- a/internal/impl/sql/conn_azure.go
+++ b/internal/impl/sql/conn_azure.go
@@ -6,9 +6,9 @@ import (
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
-type AzureDSNBuiler func(dsn, driver string) (builtDSN string, err error)
+type AzureDSNBuilder func(dsn, driver string) (builtDSN string, err error)
 
-var AzureGetCredentialsGeneratorFn = func(pConf *service.ParsedConfig) (fn AzureDSNBuiler, err error) {
+var AzureGetCredentialsGeneratorFn = func(pConf *service.ParsedConfig) (fn AzureDSNBuilder, err error) {
 	entraEnabled, err := pConf.FieldBool("azure", "entra_enabled")
 	if err != nil {
 		return nil, err

--- a/internal/impl/sql/conn_fields.go
+++ b/internal/impl/sql/conn_fields.go
@@ -115,6 +115,43 @@ CREATE TABLE IF NOT EXISTS some_table (
 			Default(false).
 			Version("1.8.0").
 			Advanced(),
+		service.NewObjectField("azure",
+			service.NewBoolField("entra_enabled").
+				Description("An optional field used to generate an entra token to connect to 'Azure Database for PostgreSQL flexible server', This will create a new connection string with the host, user and database from the DSN field - you may need to URL encode the dsn! The [Default Azure Credential Chain](https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/authentication-overview#defaultazurecredential) is used from the Azure SDK.").
+				Optional().
+				Default(false).
+				Version("1.10.0").
+				Advanced(),
+			service.NewObjectField("token_request_options",
+				service.NewStringField("claims").
+					Description("Set additional claims for the token.").
+					Optional().
+					Default("").
+					Version("1.10.0").
+					Advanced(),
+				service.NewBoolField("enable_cae").
+					Description("Indicates whether to enable Continuous Access Evaluation (CAE) for the requested token").
+					Optional().
+					Default(false).
+					Version("1.10.0").
+					Advanced(),
+				service.NewStringListField("scopes").
+					Description("Scopes contains the list of permission scopes required for the token.").
+					Optional().
+					Default([]string{"https://ossrdbms-aad.database.windows.net/.default"}).
+					Version("1.10.0").
+					Advanced(),
+				service.NewStringField("tenant_id").
+					Description("").
+					Optional().
+					Default("").
+					Version("1.10.0").
+					Advanced(),
+			)).
+			Description("Optional Fields that can be set to use Azure based authentication for Azure Postgres SQL").
+			Optional().
+			Version("1.10.0").
+			Advanced(),
 	}
 
 	connFields = append(connFields, config.SessionFields()...)
@@ -250,6 +287,12 @@ func connSettingsFromParsed(
 		}
 	}
 
+	if conf.Contains("azure", "entra_enabled") {
+		if BuildAzureDsn, err = AzureGetCredentialsGeneratorFn(conf); err != nil {
+			return
+		}
+	}
+
 	return
 }
 
@@ -302,6 +345,15 @@ func sqlOpenWithReworks(ctx context.Context, logger *service.Logger, driver, dsn
 
 	if updatedDSN != dsn {
 		logger.Info("Updated dsn with info from AWS")
+	}
+
+	updatedDSN, err = BuildAzureDsn(dsn, driver)
+	if err != nil {
+		return nil, err
+	}
+
+	if updatedDSN != dsn {
+		logger.Info("Updated dsn with info from Azure")
 	}
 
 	db, err := sql.Open(driver, updatedDSN)

--- a/internal/impl/sql/conn_fields.go
+++ b/internal/impl/sql/conn_fields.go
@@ -142,7 +142,7 @@ CREATE TABLE IF NOT EXISTS some_table (
 					Version("1.10.0").
 					Advanced(),
 				service.NewStringField("tenant_id").
-					Description("").
+					Description("tenant_id identifies the tenant from which to request the token. azure credentials authenticate in their configured default tenants when this field isn't set.").
 					Optional().
 					Default("").
 					Version("1.10.0").

--- a/public/components/sql/base/package.go
+++ b/public/components/sql/base/package.go
@@ -6,4 +6,5 @@ import (
 	// Bring in the internal plugin definitions.
 	_ "github.com/warpstreamlabs/bento/internal/impl/sql"
 	_ "github.com/warpstreamlabs/bento/internal/impl/sql/aws"
+	_ "github.com/warpstreamlabs/bento/internal/impl/sql/azure"
 )

--- a/website/docs/components/caches/sql.md
+++ b/website/docs/components/caches/sql.md
@@ -40,6 +40,8 @@ sql:
   key_column: foo # No default (required)
   value_column: bar # No default (required)
   set_suffix: ON DUPLICATE KEY UPDATE bar=VALUES(bar) # No default (optional)
+  azure:
+    token_request_options: {}
 ```
 
 </TabItem>
@@ -70,6 +72,13 @@ sql:
   conn_max_open: 0 # No default (optional)
   secret_name: "" # No default (optional)
   iam_enabled: false
+  azure:
+    entra_enabled: false
+    token_request_options:
+      claims: ""
+      enable_cae: false
+      scopes: []
+      tenant_id: ""
   region: ""
   endpoint: ""
   credentials:
@@ -317,6 +326,65 @@ An optional field used to generate an IAM authentication token to connect to an 
 Type: `bool`  
 Default: `false`  
 Requires version 1.8.0 or newer  
+
+### `azure`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.entra_enabled`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.token_request_options.claims`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.enable_cae`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.scopes`
+
+Sorry! This field is missing documentation.
+
+
+Type: `array`  
+Default: `[]`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.tenant_id`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
 
 ### `region`
 

--- a/website/docs/components/caches/sql.md
+++ b/website/docs/components/caches/sql.md
@@ -40,8 +40,6 @@ sql:
   key_column: foo # No default (required)
   value_column: bar # No default (required)
   set_suffix: ON DUPLICATE KEY UPDATE bar=VALUES(bar) # No default (optional)
-  azure:
-    token_request_options: {}
 ```
 
 </TabItem>
@@ -77,7 +75,8 @@ sql:
     token_request_options:
       claims: ""
       enable_cae: false
-      scopes: []
+      scopes:
+        - https://ossrdbms-aad.database.windows.net/.default
       tenant_id: ""
   region: ""
   endpoint: ""
@@ -329,14 +328,15 @@ Requires version 1.8.0 or newer
 
 ### `azure`
 
-Sorry! This field is missing documentation.
+Optional Fields that can be set to use Azure based authentication for Azure Postgres SQL
 
 
 Type: `object`  
+Requires version 1.10.0 or newer  
 
 ### `azure.entra_enabled`
 
-Sorry! This field is missing documentation.
+An optional field used to generate an entra token to connect to 'Azure Database for PostgreSQL flexible server', This will create a new connection string with the host, user and database from the DSN field - you may need to URL encode the dsn! The [Default Azure Credential Chain](https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/authentication-overview#defaultazurecredential) is used from the Azure SDK.
 
 
 Type: `bool`  
@@ -352,7 +352,7 @@ Type: `object`
 
 ### `azure.token_request_options.claims`
 
-Sorry! This field is missing documentation.
+Set additional claims for the token.
 
 
 Type: `string`  
@@ -361,7 +361,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.enable_cae`
 
-Sorry! This field is missing documentation.
+Indicates whether to enable Continuous Access Evaluation (CAE) for the requested token
 
 
 Type: `bool`  
@@ -370,11 +370,11 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.scopes`
 
-Sorry! This field is missing documentation.
+Scopes contains the list of permission scopes required for the token.
 
 
 Type: `array`  
-Default: `[]`  
+Default: `["https://ossrdbms-aad.database.windows.net/.default"]`  
 Requires version 1.10.0 or newer  
 
 ### `azure.token_request_options.tenant_id`

--- a/website/docs/components/caches/sql.md
+++ b/website/docs/components/caches/sql.md
@@ -379,7 +379,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.tenant_id`
 
-Sorry! This field is missing documentation.
+tenant_id identifies the tenant from which to request the token. azure credentials authenticate in their configured default tenants when this field isn't set.
 
 
 Type: `string`  

--- a/website/docs/components/inputs/sql_raw.md
+++ b/website/docs/components/inputs/sql_raw.md
@@ -377,7 +377,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.tenant_id`
 
-Sorry! This field is missing documentation.
+tenant_id identifies the tenant from which to request the token. azure credentials authenticate in their configured default tenants when this field isn't set.
 
 
 Type: `string`  

--- a/website/docs/components/inputs/sql_raw.md
+++ b/website/docs/components/inputs/sql_raw.md
@@ -40,6 +40,8 @@ input:
     query: SELECT * FROM footable WHERE user_id = $1; # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
     auto_replay_nacks: true
+    azure:
+      token_request_options: {}
 ```
 
 </TabItem>
@@ -70,6 +72,13 @@ input:
     conn_max_open: 0 # No default (optional)
     secret_name: "" # No default (optional)
     iam_enabled: false
+    azure:
+      entra_enabled: false
+      token_request_options:
+        claims: ""
+        enable_cae: false
+        scopes: []
+        tenant_id: ""
     region: ""
     endpoint: ""
     credentials:
@@ -315,6 +324,65 @@ An optional field used to generate an IAM authentication token to connect to an 
 Type: `bool`  
 Default: `false`  
 Requires version 1.8.0 or newer  
+
+### `azure`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.entra_enabled`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.token_request_options.claims`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.enable_cae`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.scopes`
+
+Sorry! This field is missing documentation.
+
+
+Type: `array`  
+Default: `[]`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.tenant_id`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
 
 ### `region`
 

--- a/website/docs/components/inputs/sql_raw.md
+++ b/website/docs/components/inputs/sql_raw.md
@@ -40,8 +40,6 @@ input:
     query: SELECT * FROM footable WHERE user_id = $1; # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
     auto_replay_nacks: true
-    azure:
-      token_request_options: {}
 ```
 
 </TabItem>
@@ -77,7 +75,8 @@ input:
       token_request_options:
         claims: ""
         enable_cae: false
-        scopes: []
+        scopes:
+          - https://ossrdbms-aad.database.windows.net/.default
         tenant_id: ""
     region: ""
     endpoint: ""
@@ -327,14 +326,15 @@ Requires version 1.8.0 or newer
 
 ### `azure`
 
-Sorry! This field is missing documentation.
+Optional Fields that can be set to use Azure based authentication for Azure Postgres SQL
 
 
 Type: `object`  
+Requires version 1.10.0 or newer  
 
 ### `azure.entra_enabled`
 
-Sorry! This field is missing documentation.
+An optional field used to generate an entra token to connect to 'Azure Database for PostgreSQL flexible server', This will create a new connection string with the host, user and database from the DSN field - you may need to URL encode the dsn! The [Default Azure Credential Chain](https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/authentication-overview#defaultazurecredential) is used from the Azure SDK.
 
 
 Type: `bool`  
@@ -350,7 +350,7 @@ Type: `object`
 
 ### `azure.token_request_options.claims`
 
-Sorry! This field is missing documentation.
+Set additional claims for the token.
 
 
 Type: `string`  
@@ -359,7 +359,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.enable_cae`
 
-Sorry! This field is missing documentation.
+Indicates whether to enable Continuous Access Evaluation (CAE) for the requested token
 
 
 Type: `bool`  
@@ -368,11 +368,11 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.scopes`
 
-Sorry! This field is missing documentation.
+Scopes contains the list of permission scopes required for the token.
 
 
 Type: `array`  
-Default: `[]`  
+Default: `["https://ossrdbms-aad.database.windows.net/.default"]`  
 Requires version 1.10.0 or newer  
 
 ### `azure.token_request_options.tenant_id`

--- a/website/docs/components/inputs/sql_select.md
+++ b/website/docs/components/inputs/sql_select.md
@@ -42,6 +42,8 @@ input:
     where: type = ? and created_at > ? # No default (optional)
     args_mapping: root = [ "article", now().ts_format("2006-01-02") ] # No default (optional)
     auto_replay_nacks: true
+    azure:
+      token_request_options: {}
 ```
 
 </TabItem>
@@ -76,6 +78,13 @@ input:
     conn_max_open: 0 # No default (optional)
     secret_name: "" # No default (optional)
     iam_enabled: false
+    azure:
+      entra_enabled: false
+      token_request_options:
+        claims: ""
+        enable_cae: false
+        scopes: []
+        tenant_id: ""
     region: ""
     endpoint: ""
     credentials:
@@ -356,6 +365,65 @@ An optional field used to generate an IAM authentication token to connect to an 
 Type: `bool`  
 Default: `false`  
 Requires version 1.8.0 or newer  
+
+### `azure`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.entra_enabled`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.token_request_options.claims`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.enable_cae`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.scopes`
+
+Sorry! This field is missing documentation.
+
+
+Type: `array`  
+Default: `[]`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.tenant_id`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
 
 ### `region`
 

--- a/website/docs/components/inputs/sql_select.md
+++ b/website/docs/components/inputs/sql_select.md
@@ -42,8 +42,6 @@ input:
     where: type = ? and created_at > ? # No default (optional)
     args_mapping: root = [ "article", now().ts_format("2006-01-02") ] # No default (optional)
     auto_replay_nacks: true
-    azure:
-      token_request_options: {}
 ```
 
 </TabItem>
@@ -83,7 +81,8 @@ input:
       token_request_options:
         claims: ""
         enable_cae: false
-        scopes: []
+        scopes:
+          - https://ossrdbms-aad.database.windows.net/.default
         tenant_id: ""
     region: ""
     endpoint: ""
@@ -368,14 +367,15 @@ Requires version 1.8.0 or newer
 
 ### `azure`
 
-Sorry! This field is missing documentation.
+Optional Fields that can be set to use Azure based authentication for Azure Postgres SQL
 
 
 Type: `object`  
+Requires version 1.10.0 or newer  
 
 ### `azure.entra_enabled`
 
-Sorry! This field is missing documentation.
+An optional field used to generate an entra token to connect to 'Azure Database for PostgreSQL flexible server', This will create a new connection string with the host, user and database from the DSN field - you may need to URL encode the dsn! The [Default Azure Credential Chain](https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/authentication-overview#defaultazurecredential) is used from the Azure SDK.
 
 
 Type: `bool`  
@@ -391,7 +391,7 @@ Type: `object`
 
 ### `azure.token_request_options.claims`
 
-Sorry! This field is missing documentation.
+Set additional claims for the token.
 
 
 Type: `string`  
@@ -400,7 +400,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.enable_cae`
 
-Sorry! This field is missing documentation.
+Indicates whether to enable Continuous Access Evaluation (CAE) for the requested token
 
 
 Type: `bool`  
@@ -409,11 +409,11 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.scopes`
 
-Sorry! This field is missing documentation.
+Scopes contains the list of permission scopes required for the token.
 
 
 Type: `array`  
-Default: `[]`  
+Default: `["https://ossrdbms-aad.database.windows.net/.default"]`  
 Requires version 1.10.0 or newer  
 
 ### `azure.token_request_options.tenant_id`

--- a/website/docs/components/inputs/sql_select.md
+++ b/website/docs/components/inputs/sql_select.md
@@ -418,7 +418,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.tenant_id`
 
-Sorry! This field is missing documentation.
+tenant_id identifies the tenant from which to request the token. azure credentials authenticate in their configured default tenants when this field isn't set.
 
 
 Type: `string`  

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -38,8 +38,6 @@ output:
     columns: [] # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
     max_in_flight: 64
-    azure:
-      token_request_options: {}
     batching:
       count: 0
       byte_size: 0
@@ -84,7 +82,8 @@ output:
       token_request_options:
         claims: ""
         enable_cae: false
-        scopes: []
+        scopes:
+          - https://ossrdbms-aad.database.windows.net/.default
         tenant_id: ""
     region: ""
     endpoint: ""
@@ -365,14 +364,15 @@ Requires version 1.8.0 or newer
 
 ### `azure`
 
-Sorry! This field is missing documentation.
+Optional Fields that can be set to use Azure based authentication for Azure Postgres SQL
 
 
 Type: `object`  
+Requires version 1.10.0 or newer  
 
 ### `azure.entra_enabled`
 
-Sorry! This field is missing documentation.
+An optional field used to generate an entra token to connect to 'Azure Database for PostgreSQL flexible server', This will create a new connection string with the host, user and database from the DSN field - you may need to URL encode the dsn! The [Default Azure Credential Chain](https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/authentication-overview#defaultazurecredential) is used from the Azure SDK.
 
 
 Type: `bool`  
@@ -388,7 +388,7 @@ Type: `object`
 
 ### `azure.token_request_options.claims`
 
-Sorry! This field is missing documentation.
+Set additional claims for the token.
 
 
 Type: `string`  
@@ -397,7 +397,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.enable_cae`
 
-Sorry! This field is missing documentation.
+Indicates whether to enable Continuous Access Evaluation (CAE) for the requested token
 
 
 Type: `bool`  
@@ -406,11 +406,11 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.scopes`
 
-Sorry! This field is missing documentation.
+Scopes contains the list of permission scopes required for the token.
 
 
 Type: `array`  
-Default: `[]`  
+Default: `["https://ossrdbms-aad.database.windows.net/.default"]`  
 Requires version 1.10.0 or newer  
 
 ### `azure.token_request_options.tenant_id`

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -415,7 +415,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.tenant_id`
 
-Sorry! This field is missing documentation.
+tenant_id identifies the tenant from which to request the token. azure credentials authenticate in their configured default tenants when this field isn't set.
 
 
 Type: `string`  

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -38,6 +38,8 @@ output:
     columns: [] # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
     max_in_flight: 64
+    azure:
+      token_request_options: {}
     batching:
       count: 0
       byte_size: 0
@@ -77,6 +79,13 @@ output:
     conn_max_open: 0 # No default (optional)
     secret_name: "" # No default (optional)
     iam_enabled: false
+    azure:
+      entra_enabled: false
+      token_request_options:
+        claims: ""
+        enable_cae: false
+        scopes: []
+        tenant_id: ""
     region: ""
     endpoint: ""
     credentials:
@@ -353,6 +362,65 @@ An optional field used to generate an IAM authentication token to connect to an 
 Type: `bool`  
 Default: `false`  
 Requires version 1.8.0 or newer  
+
+### `azure`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.entra_enabled`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.token_request_options.claims`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.enable_cae`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.scopes`
+
+Sorry! This field is missing documentation.
+
+
+Type: `array`  
+Default: `[]`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.tenant_id`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
 
 ### `region`
 

--- a/website/docs/components/outputs/sql_raw.md
+++ b/website/docs/components/outputs/sql_raw.md
@@ -396,7 +396,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.tenant_id`
 
-Sorry! This field is missing documentation.
+tenant_id identifies the tenant from which to request the token. azure credentials authenticate in their configured default tenants when this field isn't set.
 
 
 Type: `string`  

--- a/website/docs/components/outputs/sql_raw.md
+++ b/website/docs/components/outputs/sql_raw.md
@@ -37,8 +37,6 @@ output:
     query: INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?); # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
     max_in_flight: 64
-    azure:
-      token_request_options: {}
     batching:
       count: 0
       byte_size: 0
@@ -81,7 +79,8 @@ output:
       token_request_options:
         claims: ""
         enable_cae: false
-        scopes: []
+        scopes:
+          - https://ossrdbms-aad.database.windows.net/.default
         tenant_id: ""
     region: ""
     endpoint: ""
@@ -346,14 +345,15 @@ Requires version 1.8.0 or newer
 
 ### `azure`
 
-Sorry! This field is missing documentation.
+Optional Fields that can be set to use Azure based authentication for Azure Postgres SQL
 
 
 Type: `object`  
+Requires version 1.10.0 or newer  
 
 ### `azure.entra_enabled`
 
-Sorry! This field is missing documentation.
+An optional field used to generate an entra token to connect to 'Azure Database for PostgreSQL flexible server', This will create a new connection string with the host, user and database from the DSN field - you may need to URL encode the dsn! The [Default Azure Credential Chain](https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/authentication-overview#defaultazurecredential) is used from the Azure SDK.
 
 
 Type: `bool`  
@@ -369,7 +369,7 @@ Type: `object`
 
 ### `azure.token_request_options.claims`
 
-Sorry! This field is missing documentation.
+Set additional claims for the token.
 
 
 Type: `string`  
@@ -378,7 +378,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.enable_cae`
 
-Sorry! This field is missing documentation.
+Indicates whether to enable Continuous Access Evaluation (CAE) for the requested token
 
 
 Type: `bool`  
@@ -387,11 +387,11 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.scopes`
 
-Sorry! This field is missing documentation.
+Scopes contains the list of permission scopes required for the token.
 
 
 Type: `array`  
-Default: `[]`  
+Default: `["https://ossrdbms-aad.database.windows.net/.default"]`  
 Requires version 1.10.0 or newer  
 
 ### `azure.token_request_options.tenant_id`

--- a/website/docs/components/outputs/sql_raw.md
+++ b/website/docs/components/outputs/sql_raw.md
@@ -37,6 +37,8 @@ output:
     query: INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?); # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
     max_in_flight: 64
+    azure:
+      token_request_options: {}
     batching:
       count: 0
       byte_size: 0
@@ -74,6 +76,13 @@ output:
     conn_max_open: 0 # No default (optional)
     secret_name: "" # No default (optional)
     iam_enabled: false
+    azure:
+      entra_enabled: false
+      token_request_options:
+        claims: ""
+        enable_cae: false
+        scopes: []
+        tenant_id: ""
     region: ""
     endpoint: ""
     credentials:
@@ -334,6 +343,65 @@ An optional field used to generate an IAM authentication token to connect to an 
 Type: `bool`  
 Default: `false`  
 Requires version 1.8.0 or newer  
+
+### `azure`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.entra_enabled`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.token_request_options.claims`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.enable_cae`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.scopes`
+
+Sorry! This field is missing documentation.
+
+
+Type: `array`  
+Default: `[]`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.tenant_id`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
 
 ### `region`
 

--- a/website/docs/components/processors/sql_insert.md
+++ b/website/docs/components/processors/sql_insert.md
@@ -393,7 +393,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.tenant_id`
 
-Sorry! This field is missing documentation.
+tenant_id identifies the tenant from which to request the token. azure credentials authenticate in their configured default tenants when this field isn't set.
 
 
 Type: `string`  

--- a/website/docs/components/processors/sql_insert.md
+++ b/website/docs/components/processors/sql_insert.md
@@ -36,6 +36,8 @@ sql_insert:
   table: foo # No default (required)
   columns: [] # No default (required)
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
+  azure:
+    token_request_options: {}
 ```
 
 </TabItem>
@@ -67,6 +69,13 @@ sql_insert:
   conn_max_open: 0 # No default (optional)
   secret_name: "" # No default (optional)
   iam_enabled: false
+  azure:
+    entra_enabled: false
+    token_request_options:
+      claims: ""
+      enable_cae: false
+      scopes: []
+      tenant_id: ""
   region: ""
   endpoint: ""
   credentials:
@@ -331,6 +340,65 @@ An optional field used to generate an IAM authentication token to connect to an 
 Type: `bool`  
 Default: `false`  
 Requires version 1.8.0 or newer  
+
+### `azure`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.entra_enabled`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.token_request_options.claims`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.enable_cae`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.scopes`
+
+Sorry! This field is missing documentation.
+
+
+Type: `array`  
+Default: `[]`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.tenant_id`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
 
 ### `region`
 

--- a/website/docs/components/processors/sql_insert.md
+++ b/website/docs/components/processors/sql_insert.md
@@ -36,8 +36,6 @@ sql_insert:
   table: foo # No default (required)
   columns: [] # No default (required)
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
-  azure:
-    token_request_options: {}
 ```
 
 </TabItem>
@@ -74,7 +72,8 @@ sql_insert:
     token_request_options:
       claims: ""
       enable_cae: false
-      scopes: []
+      scopes:
+        - https://ossrdbms-aad.database.windows.net/.default
       tenant_id: ""
   region: ""
   endpoint: ""
@@ -343,14 +342,15 @@ Requires version 1.8.0 or newer
 
 ### `azure`
 
-Sorry! This field is missing documentation.
+Optional Fields that can be set to use Azure based authentication for Azure Postgres SQL
 
 
 Type: `object`  
+Requires version 1.10.0 or newer  
 
 ### `azure.entra_enabled`
 
-Sorry! This field is missing documentation.
+An optional field used to generate an entra token to connect to 'Azure Database for PostgreSQL flexible server', This will create a new connection string with the host, user and database from the DSN field - you may need to URL encode the dsn! The [Default Azure Credential Chain](https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/authentication-overview#defaultazurecredential) is used from the Azure SDK.
 
 
 Type: `bool`  
@@ -366,7 +366,7 @@ Type: `object`
 
 ### `azure.token_request_options.claims`
 
-Sorry! This field is missing documentation.
+Set additional claims for the token.
 
 
 Type: `string`  
@@ -375,7 +375,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.enable_cae`
 
-Sorry! This field is missing documentation.
+Indicates whether to enable Continuous Access Evaluation (CAE) for the requested token
 
 
 Type: `bool`  
@@ -384,11 +384,11 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.scopes`
 
-Sorry! This field is missing documentation.
+Scopes contains the list of permission scopes required for the token.
 
 
 Type: `array`  
-Default: `[]`  
+Default: `["https://ossrdbms-aad.database.windows.net/.default"]`  
 Requires version 1.10.0 or newer  
 
 ### `azure.token_request_options.tenant_id`

--- a/website/docs/components/processors/sql_raw.md
+++ b/website/docs/components/processors/sql_raw.md
@@ -36,6 +36,8 @@ sql_raw:
   query: INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?); # No default (required)
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
   exec_only: false
+  azure:
+    token_request_options: {}
 ```
 
 </TabItem>
@@ -66,6 +68,13 @@ sql_raw:
   conn_max_open: 0 # No default (optional)
   secret_name: "" # No default (optional)
   iam_enabled: false
+  azure:
+    entra_enabled: false
+    token_request_options:
+      claims: ""
+      enable_cae: false
+      scopes: []
+      tenant_id: ""
   region: ""
   endpoint: ""
   credentials:
@@ -338,6 +347,65 @@ An optional field used to generate an IAM authentication token to connect to an 
 Type: `bool`  
 Default: `false`  
 Requires version 1.8.0 or newer  
+
+### `azure`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.entra_enabled`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.token_request_options.claims`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.enable_cae`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.scopes`
+
+Sorry! This field is missing documentation.
+
+
+Type: `array`  
+Default: `[]`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.tenant_id`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
 
 ### `region`
 

--- a/website/docs/components/processors/sql_raw.md
+++ b/website/docs/components/processors/sql_raw.md
@@ -36,8 +36,6 @@ sql_raw:
   query: INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?); # No default (required)
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
   exec_only: false
-  azure:
-    token_request_options: {}
 ```
 
 </TabItem>
@@ -73,7 +71,8 @@ sql_raw:
     token_request_options:
       claims: ""
       enable_cae: false
-      scopes: []
+      scopes:
+        - https://ossrdbms-aad.database.windows.net/.default
       tenant_id: ""
   region: ""
   endpoint: ""
@@ -350,14 +349,15 @@ Requires version 1.8.0 or newer
 
 ### `azure`
 
-Sorry! This field is missing documentation.
+Optional Fields that can be set to use Azure based authentication for Azure Postgres SQL
 
 
 Type: `object`  
+Requires version 1.10.0 or newer  
 
 ### `azure.entra_enabled`
 
-Sorry! This field is missing documentation.
+An optional field used to generate an entra token to connect to 'Azure Database for PostgreSQL flexible server', This will create a new connection string with the host, user and database from the DSN field - you may need to URL encode the dsn! The [Default Azure Credential Chain](https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/authentication-overview#defaultazurecredential) is used from the Azure SDK.
 
 
 Type: `bool`  
@@ -373,7 +373,7 @@ Type: `object`
 
 ### `azure.token_request_options.claims`
 
-Sorry! This field is missing documentation.
+Set additional claims for the token.
 
 
 Type: `string`  
@@ -382,7 +382,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.enable_cae`
 
-Sorry! This field is missing documentation.
+Indicates whether to enable Continuous Access Evaluation (CAE) for the requested token
 
 
 Type: `bool`  
@@ -391,11 +391,11 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.scopes`
 
-Sorry! This field is missing documentation.
+Scopes contains the list of permission scopes required for the token.
 
 
 Type: `array`  
-Default: `[]`  
+Default: `["https://ossrdbms-aad.database.windows.net/.default"]`  
 Requires version 1.10.0 or newer  
 
 ### `azure.token_request_options.tenant_id`

--- a/website/docs/components/processors/sql_raw.md
+++ b/website/docs/components/processors/sql_raw.md
@@ -400,7 +400,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.tenant_id`
 
-Sorry! This field is missing documentation.
+tenant_id identifies the tenant from which to request the token. azure credentials authenticate in their configured default tenants when this field isn't set.
 
 
 Type: `string`  

--- a/website/docs/components/processors/sql_select.md
+++ b/website/docs/components/processors/sql_select.md
@@ -409,7 +409,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.tenant_id`
 
-Sorry! This field is missing documentation.
+tenant_id identifies the tenant from which to request the token. azure credentials authenticate in their configured default tenants when this field isn't set.
 
 
 Type: `string`  

--- a/website/docs/components/processors/sql_select.md
+++ b/website/docs/components/processors/sql_select.md
@@ -37,8 +37,6 @@ sql_select:
   columns: [] # No default (required)
   where: meow = ? and woof = ? # No default (optional)
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
-  azure:
-    token_request_options: {}
 ```
 
 </TabItem>
@@ -76,7 +74,8 @@ sql_select:
     token_request_options:
       claims: ""
       enable_cae: false
-      scopes: []
+      scopes:
+        - https://ossrdbms-aad.database.windows.net/.default
       tenant_id: ""
   region: ""
   endpoint: ""
@@ -359,14 +358,15 @@ Requires version 1.8.0 or newer
 
 ### `azure`
 
-Sorry! This field is missing documentation.
+Optional Fields that can be set to use Azure based authentication for Azure Postgres SQL
 
 
 Type: `object`  
+Requires version 1.10.0 or newer  
 
 ### `azure.entra_enabled`
 
-Sorry! This field is missing documentation.
+An optional field used to generate an entra token to connect to 'Azure Database for PostgreSQL flexible server', This will create a new connection string with the host, user and database from the DSN field - you may need to URL encode the dsn! The [Default Azure Credential Chain](https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/authentication-overview#defaultazurecredential) is used from the Azure SDK.
 
 
 Type: `bool`  
@@ -382,7 +382,7 @@ Type: `object`
 
 ### `azure.token_request_options.claims`
 
-Sorry! This field is missing documentation.
+Set additional claims for the token.
 
 
 Type: `string`  
@@ -391,7 +391,7 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.enable_cae`
 
-Sorry! This field is missing documentation.
+Indicates whether to enable Continuous Access Evaluation (CAE) for the requested token
 
 
 Type: `bool`  
@@ -400,11 +400,11 @@ Requires version 1.10.0 or newer
 
 ### `azure.token_request_options.scopes`
 
-Sorry! This field is missing documentation.
+Scopes contains the list of permission scopes required for the token.
 
 
 Type: `array`  
-Default: `[]`  
+Default: `["https://ossrdbms-aad.database.windows.net/.default"]`  
 Requires version 1.10.0 or newer  
 
 ### `azure.token_request_options.tenant_id`

--- a/website/docs/components/processors/sql_select.md
+++ b/website/docs/components/processors/sql_select.md
@@ -37,6 +37,8 @@ sql_select:
   columns: [] # No default (required)
   where: meow = ? and woof = ? # No default (optional)
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
+  azure:
+    token_request_options: {}
 ```
 
 </TabItem>
@@ -69,6 +71,13 @@ sql_select:
   conn_max_open: 0 # No default (optional)
   secret_name: "" # No default (optional)
   iam_enabled: false
+  azure:
+    entra_enabled: false
+    token_request_options:
+      claims: ""
+      enable_cae: false
+      scopes: []
+      tenant_id: ""
   region: ""
   endpoint: ""
   credentials:
@@ -347,6 +356,65 @@ An optional field used to generate an IAM authentication token to connect to an 
 Type: `bool`  
 Default: `false`  
 Requires version 1.8.0 or newer  
+
+### `azure`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.entra_enabled`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `azure.token_request_options.claims`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.enable_cae`
+
+Sorry! This field is missing documentation.
+
+
+Type: `bool`  
+Default: `false`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.scopes`
+
+Sorry! This field is missing documentation.
+
+
+Type: `array`  
+Default: `[]`  
+Requires version 1.10.0 or newer  
+
+### `azure.token_request_options.tenant_id`
+
+Sorry! This field is missing documentation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 1.10.0 or newer  
 
 ### `region`
 

--- a/website/docs/guides/cloud/azure.md
+++ b/website/docs/guides/cloud/azure.md
@@ -1,0 +1,7 @@
+---
+title: Microsoft Azure 
+description: Find out about authenticating with Azure in Bento.
+---
+
+There are many components within Bento which utilise Azure services.
+You will find that each of these components require valid credentials.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -116,6 +116,7 @@ module.exports = {
           items: [
             'guides/cloud/aws',
             'guides/cloud/gcp',
+            'guides/cloud/azure',
           ],
         },
         {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -116,7 +116,6 @@ module.exports = {
           items: [
             'guides/cloud/aws',
             'guides/cloud/gcp',
-            'guides/cloud/azure',
           ],
         },
         {


### PR DESCRIPTION
Adds `azure` fields to sql components (similar to the aws fields that enable iam auth) that enable auth to postgres running on azure with "entra auth". 


