### PR TITLE
fix(action): Use correct path for WASM in docsite job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,9 @@ docs: $(APPS) $(TOOLS)
 		"$(WEBSITE_DIR)/docs/**/*.md"
 	@$(PATHINSTBIN)/bento template lint "./config/template_examples/*.yaml"
 
+# TODO:(gregfurman): Change misc/wasm/wasm_exec.js => lib/wasm/wasm_exec.js when using Go 1.24
 playground:
 	@cp -r "internal/cli/blobl/playground" "$(WEBSITE_DIR)/static/playground"
 	@sed -i.bak '/<!-- BEGIN SERVER MODE -->/,/<!-- END SERVER MODE -->/d' "$(WEBSITE_DIR)/static/playground/index.html"
-	@mkdir -p "$(WEBSITE_DIR)/static/playground/js" && cp "$$(go env GOROOT)/lib/wasm/wasm_exec.js" "$(WEBSITE_DIR)/static/playground/js/wasm_exec.js"
+	@mkdir -p "$(WEBSITE_DIR)/static/playground/js" && cp "$$(go env GOROOT)/misc/wasm/wasm_exec.js" "$(WEBSITE_DIR)/static/playground/js/wasm_exec.js"
 	@GOOS=js GOARCH=wasm go build -o "$(WEBSITE_DIR)/static/playground/playground.wasm" "cmd/tools/playground/main.go"


### PR DESCRIPTION
The WASM javascript file we're looking for is in `misc/wasm` in Go 1.23 and below... let's change this for now until the next go version update to 1.24.

See [WebAssembly: Getting Started](https://go.dev/wiki/WebAssembly#getting-started)
> For Go 1.23 and earlier, the wasm support files needed in this article are located in misc/wasm, and the path should be replaced when performing operations with files such as lib/wasm/wasm_exec.js.