### PR TITLE
AsyncWriter - log errors when failing to write

### DIFF
--- a/internal/component/output/async_writer.go
+++ b/internal/component/output/async_writer.go
@@ -89,14 +89,13 @@ func (w *AsyncWriter) latencyMeasuringWrite(ctx context.Context, msg message.Bat
 func (w *AsyncWriter) loop() {
 	// Metrics paths
 	var (
-		mSent           = w.stats.GetCounter("output_sent")
-		mBatchSent      = w.stats.GetCounter("output_batch_sent")
-		mError          = w.stats.GetCounter("output_error")
-		mLatency        = w.stats.GetTimer("output_latency_ns")
-		mConn           = w.stats.GetCounter("output_connection_up")
-		mFailedConn     = w.stats.GetCounter("output_connection_failed")
-		mLostConn       = w.stats.GetCounter("output_connection_lost")
-		mReconnectError = w.stats.GetCounter("output_reconnect_error")
+		mSent       = w.stats.GetCounter("output_sent")
+		mBatchSent  = w.stats.GetCounter("output_batch_sent")
+		mError      = w.stats.GetCounter("output_error")
+		mLatency    = w.stats.GetTimer("output_latency_ns")
+		mConn       = w.stats.GetCounter("output_connection_up")
+		mFailedConn = w.stats.GetCounter("output_connection_failed")
+		mLostConn   = w.stats.GetCounter("output_connection_lost")
 
 		traceName = "output_" + w.typeStr
 	)
@@ -190,7 +189,6 @@ func (w *AsyncWriter) loop() {
 				mConn.Incr(1)
 				return
 			} else if err != nil {
-				mReconnectError.Incr(1)
 				mError.Incr(1)
 			}
 		}


### PR DESCRIPTION
Right now, the `AsyncWriter` loop calls `w.latencyMeasuringWrite(` in 3 different places but only emits one metric when there's an error: `mError.Incr(1)`.

This makes it hard to pinpoint exactly what went wrong, especially when debugging pipelines that are causing duplicate messages. I added some error logs and a metric for better observability.