### PR TITLE
adds support for binding metrics from multiple StreamBuilders into one shared metrics instance

### DIFF
--- a/public/service/shared_metrics.go
+++ b/public/service/shared_metrics.go
@@ -1,0 +1,201 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/warpstreamlabs/bento/internal/api"
+	"github.com/warpstreamlabs/bento/internal/component/metrics"
+	"github.com/warpstreamlabs/bento/internal/config"
+	"github.com/warpstreamlabs/bento/internal/docs"
+	"github.com/warpstreamlabs/bento/internal/log"
+	"github.com/warpstreamlabs/bento/internal/manager"
+)
+
+// SharedMetricsSetup provides a way to create shared metrics that can be used
+// across multiple StreamBuilders, allowing them to aggregate metrics to the
+// same destination and expose a single HTTP endpoint.
+//
+// This solves the common problem when building multiple streams programmatically
+// with StreamBuilder APIs: each stream creates its own metrics registry and
+// HTTP server, leading to port conflicts. With SharedMetricsSetup, all streams
+// can share the same metrics registry and expose metrics via a single endpoint.
+//
+// Example usage:
+//
+//	// Create shared metrics setup
+//	sharedMetrics, err := service.NewSharedMetricsSetup(`
+//	prometheus:
+//	  use_histogram_timing: false
+//	`, 9090)
+//	if err != nil {
+//	  log.Fatal(err)
+//	}
+//	defer sharedMetrics.Shutdown(context.Background())
+//
+//	// Start the shared metrics server
+//	go sharedMetrics.ListenAndServe()
+//
+//	// Create multiple streams that share the same metrics with distinct labels
+//	streamNames := []string{"orders-processor", "user-events", "notifications"}
+//	for _, streamName := range streamNames {
+//	  builder := service.NewStreamBuilder()
+//	  builder.SetStreamName(streamName)  // This adds stream="orders-processor" labels
+//	  sharedMetrics.ConfigureStreamBuilder(builder)
+//	  // ... configure your stream normally
+//	  stream, err := builder.Build()
+//	  // ... run your stream
+//	}
+//
+//	// All streams now report to the same Prometheus registry on port 9090
+//	// Metrics are labeled with stream names for easy identification:
+//	// - input_received{stream="orders-processor",...}
+//	// - input_received{stream="user-events",...}
+//	// - input_received{stream="notifications",...}
+type SharedMetricsSetup struct {
+	metrics     *metrics.Namespaced
+	api         *api.Type
+	httpAddress string
+}
+
+// NewSharedMetricsSetup creates a shared metrics setup from a YAML configuration.
+// This allows multiple StreamBuilders to aggregate their metrics to the same
+// destination (e.g., shared Prometheus registry) and expose them via a single
+// HTTP server.
+func NewSharedMetricsSetup(metricsYAML string, httpPort int) (*SharedMetricsSetup, error) {
+	return NewSharedMetricsSetupWithEnvironment(metricsYAML, httpPort, GlobalEnvironment())
+}
+
+// NewSharedMetricsSetupWithEnvironment creates a shared metrics setup from a YAML
+// configuration using a custom environment. This is useful for testing with
+// custom metrics exporters.
+func NewSharedMetricsSetupWithEnvironment(metricsYAML string, httpPort int, env *Environment) (*SharedMetricsSetup, error) {
+	// Create a temporary manager for initializing metrics
+	tmpMgr, err := manager.New(
+		manager.NewResourceConfig(),
+		manager.OptSetLogger(log.Noop()),
+		manager.OptSetEnvironment(env.internal),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary manager: %w", err)
+	}
+
+	// Parse YAML string into yaml.Node
+	yamlBytes := []byte(metricsYAML)
+	if yamlBytes, err = config.ReplaceEnvVariables(yamlBytes, os.LookupEnv); err != nil {
+		return nil, fmt.Errorf("failed to replace environment variables: %w", err)
+	}
+
+	yamlNode, err := docs.UnmarshalYAML(yamlBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	// Parse metrics configuration from YAML node
+	metricsConf, err := metrics.FromAny(env.internal, yamlNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse metrics YAML: %w", err)
+	}
+
+	// Initialize metrics
+	stats, err := env.internal.MetricsInit(metricsConf, tmpMgr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics: %w", err)
+	}
+
+	// Create HTTP API server for metrics endpoint
+	httpConf := api.NewConfig()
+	httpAddress := fmt.Sprintf("0.0.0.0:%d", httpPort)
+	httpConf.Address = httpAddress
+	httpConf.Enabled = true
+
+	apiServer, err := api.New("", "", httpConf, nil, log.Noop(), stats)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API server: %w", err)
+	}
+
+	return &SharedMetricsSetup{
+		metrics:     stats,
+		api:         apiServer,
+		httpAddress: httpAddress,
+	}, nil
+}
+
+// ConfigureStreamBuilder configures a StreamBuilder to use the shared metrics
+// and disables its individual HTTP server to prevent port conflicts.
+//
+// If the StreamBuilder has a stream name set (via SetStreamName), all metrics
+// will be labeled with "stream": streamName, similar to how Bento's streams
+// mode works. This allows you to distinguish metrics from different streams
+// in the shared registry. If no stream name is set, metrics will be emitted
+// without stream labels (backward compatible).
+//
+// After calling this method, the StreamBuilder will:
+//   - Send all its metrics to the shared metrics registry with optional stream labels
+//   - Have its individual HTTP server disabled to avoid port conflicts
+//   - Still function normally in all other respects
+//
+// Example with stream labeling:
+//
+//	builder.SetStreamName("orders-processor")
+//	sharedMetrics.ConfigureStreamBuilder(builder)
+//	// All metrics will have label "stream": "orders-processor"
+//
+// Example without stream labeling (backward compatible):
+//
+//	sharedMetrics.ConfigureStreamBuilder(builder)
+//	// Metrics emitted without stream labels
+func (s *SharedMetricsSetup) ConfigureStreamBuilder(builder *StreamBuilder) {
+	sharedMetrics := s.metrics
+	if builder.streamName != "" {
+		sharedMetrics = s.metrics.WithLabels("stream", builder.streamName)
+	}
+	builder.SetSharedMetrics(sharedMetrics)
+	// Disable HTTP server on individual streams since we have a shared one
+	builder.http.Enabled = false
+}
+
+// ListenAndServe starts the HTTP server for the shared metrics endpoint.
+// This is a blocking call that should typically be run in a goroutine.
+//
+// The server will expose metrics at the standard endpoints:
+//   - /metrics - Prometheus format metrics
+//   - /stats - Same metrics in the configured format
+func (s *SharedMetricsSetup) ListenAndServe() error {
+	return s.api.ListenAndServe()
+}
+
+// Shutdown gracefully shuts down the shared metrics HTTP server and closes
+// the metrics registry. This should be called when you're done with the
+// shared metrics setup to clean up resources.
+func (s *SharedMetricsSetup) Shutdown(ctx context.Context) error {
+	if s.api != nil {
+		if err := s.api.Shutdown(ctx); err != nil {
+			return err
+		}
+	}
+	if s.metrics != nil {
+		return s.metrics.Close()
+	}
+	return nil
+}
+
+// GetMetrics returns the shared metrics instance. This can be useful for
+// advanced use cases where you need direct access to the metrics registry.
+func (s *SharedMetricsSetup) GetMetrics() *metrics.Namespaced {
+	return s.metrics
+}
+
+// GetHTTPAddress returns the address the HTTP server is configured to listen on.
+// This is useful for logging or constructing full URLs to the metrics endpoint.
+func (s *SharedMetricsSetup) GetHTTPAddress() string {
+	return s.httpAddress
+}
+
+// SetMetricsForTesting is a helper method for testing that allows setting
+// the metrics instance directly without going through the full setup process.
+// This should only be used in tests.
+func (s *SharedMetricsSetup) SetMetricsForTesting(metrics *metrics.Namespaced) {
+	s.metrics = metrics
+}

--- a/public/service/shared_metrics_test.go
+++ b/public/service/shared_metrics_test.go
@@ -1,0 +1,311 @@
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/warpstreamlabs/bento/internal/component/metrics"
+	"github.com/warpstreamlabs/bento/public/service"
+
+	_ "github.com/warpstreamlabs/bento/public/components/io"
+	_ "github.com/warpstreamlabs/bento/public/components/pure"
+)
+
+func TestSharedMetricsBasic(t *testing.T) {
+	sharedMetrics, err := service.NewSharedMetricsSetup(`none: {}`, 0)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	require.NoError(t, sharedMetrics.Shutdown(ctx))
+}
+
+func TestSharedMetricsWithStreamBuilder(t *testing.T) {
+	sharedMetrics, err := service.NewSharedMetricsSetup(`none: {}`, 0)
+	require.NoError(t, err)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+		_ = sharedMetrics.Shutdown(ctx)
+	}()
+
+	builder := service.NewStreamBuilder()
+
+	// Test handler is nil before setting shared metrics
+	require.Nil(t, builder.GetMetricsHandler())
+
+	// Configure with shared metrics
+	sharedMetrics.ConfigureStreamBuilder(builder)
+
+	err = builder.SetYAML(`
+input:
+  generate:
+    count: 2
+    mapping: 'root = "test"'
+output:
+  drop: {}
+logger:
+  level: OFF
+`)
+	require.NoError(t, err)
+
+	stream, err := builder.Build()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	err = stream.Run(ctx)
+	// Context timeout is expected for generate input
+	require.NotEqual(t, err, context.DeadlineExceeded, "Stream should complete before timeout")
+}
+
+func TestSharedMetricsEmission(t *testing.T) {
+	localMetrics := metrics.NewLocal()
+	namespacedMetrics := metrics.NewNamespaced(localMetrics)
+
+	// Create two streams with shared local metrics directly
+	var streams []*service.Stream
+	for i := 0; i < 2; i++ {
+		builder := service.NewStreamBuilder()
+		builder.SetStreamName(fmt.Sprintf("stream-%d", i))
+		builder.SetSharedMetrics(namespacedMetrics)
+
+		err := builder.SetYAML(`
+input:
+  generate:
+    count: 2
+    mapping: 'root = "test"'
+output:
+  drop: {}
+logger:
+  level: OFF
+`)
+		require.NoError(t, err)
+
+		stream, err := builder.Build()
+		require.NoError(t, err)
+		streams = append(streams, stream)
+	}
+
+	// Run both streams
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	for _, stream := range streams {
+		wg.Add(1)
+		go func(s *service.Stream) {
+			defer wg.Done()
+			_ = s.Run(ctx)
+		}(stream)
+	}
+
+	wg.Wait()
+	time.Sleep(time.Millisecond * 100)
+
+	// Verify metrics were emitted and aggregated
+	counters := localMetrics.GetCounters()
+
+	var totalReceived int64
+	hasInputReceived := false
+	for metricName, value := range counters {
+		if strings.Contains(metricName, "input_received") {
+			hasInputReceived = true
+			totalReceived += value
+		}
+	}
+
+	require.True(t, hasInputReceived, "Should have input_received metrics")
+	require.Equal(t, int64(4), totalReceived, "Should have processed 4 messages total")
+
+	// Verify timings exist
+	timings := localMetrics.GetTimings()
+	require.NotEmpty(t, timings, "Should have timing metrics")
+}
+
+func TestSharedMetricsExplicitNaming(t *testing.T) {
+	localMetrics := metrics.NewLocal()
+	namespacedMetrics := metrics.NewNamespaced(localMetrics)
+
+	// Test multiple streams with explicit component names for distinct metrics
+	streamConfigs := []struct {
+		name  string
+		count int
+	}{
+		{"orders", 2},
+		{"users", 3},
+	}
+
+	var streams []*service.Stream
+	for _, config := range streamConfigs {
+		builder := service.NewStreamBuilder()
+		builder.SetSharedMetrics(namespacedMetrics)
+
+		yamlConfig := fmt.Sprintf(`
+input:
+  label: "%s_input"
+  generate:
+    count: %d
+    mapping: 'root = {"source": "%s"}'
+output:
+  label: "%s_output"
+  drop: {}
+logger:
+  level: OFF
+`, config.name, config.count, config.name, config.name)
+
+		err := builder.SetYAML(yamlConfig)
+		require.NoError(t, err)
+
+		stream, err := builder.Build()
+		require.NoError(t, err)
+		streams = append(streams, stream)
+	}
+
+	// Run all streams
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	for _, stream := range streams {
+		wg.Add(1)
+		go func(s *service.Stream) {
+			defer wg.Done()
+			_ = s.Run(ctx)
+		}(stream)
+	}
+
+	wg.Wait()
+	time.Sleep(time.Millisecond * 100)
+
+	// Verify distinct metrics for each stream
+	counters := localMetrics.GetCounters()
+	streamMetrics := make(map[string]int64)
+
+	for metricName, value := range counters {
+		if strings.Contains(metricName, "input_received") {
+			if strings.Contains(metricName, "orders_input") {
+				streamMetrics["orders"] += value
+			} else if strings.Contains(metricName, "users_input") {
+				streamMetrics["users"] += value
+			}
+		}
+	}
+
+	require.Equal(t, int64(2), streamMetrics["orders"], "Orders stream should process 2 messages")
+	require.Equal(t, int64(3), streamMetrics["users"], "Users stream should process 3 messages")
+
+	totalMessages := streamMetrics["orders"] + streamMetrics["users"]
+	require.Equal(t, int64(5), totalMessages, "Total should be 5 messages across streams")
+}
+
+func TestSharedMetricsWithStreamLabeling(t *testing.T) {
+	localMetrics := metrics.NewLocal()
+	namespacedMetrics := metrics.NewNamespaced(localMetrics)
+	sharedSetup := &service.SharedMetricsSetup{}
+	sharedSetup.SetMetricsForTesting(namespacedMetrics)
+
+	// Create multiple streams with different stream names
+	streamNames := []string{"orders-stream", "users-stream", "notifications-stream"}
+	var streams []*service.Stream
+
+	for _, streamName := range streamNames {
+		builder := service.NewStreamBuilder()
+		builder.SetStreamName(streamName)
+		sharedSetup.ConfigureStreamBuilder(builder)
+
+		yamlConfig := `
+input:
+  generate:
+    count: 1
+    mapping: 'root = {"stream": "` + streamName + `"}'
+output:
+  drop: {}
+logger:
+  level: OFF
+`
+		err := builder.SetYAML(yamlConfig)
+		require.NoError(t, err)
+
+		stream, err := builder.Build()
+		require.NoError(t, err)
+		streams = append(streams, stream)
+	}
+
+	// Run all streams
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	for _, stream := range streams {
+		wg.Add(1)
+		go func(s *service.Stream) {
+			defer wg.Done()
+			_ = s.Run(ctx)
+		}(stream)
+	}
+
+	wg.Wait()
+	time.Sleep(time.Millisecond * 100)
+
+	// Verify metrics are properly labeled by stream
+	counters := localMetrics.GetCounters()
+	streamMetrics := make(map[string]int64)
+
+	for metricName, value := range counters {
+		if strings.Contains(metricName, "input_received") {
+			for _, streamName := range streamNames {
+				// Look for stream label in metric name like: input_received{stream="orders-stream",path="root.input"}
+				expectedLabel := fmt.Sprintf(`stream="%s"`, streamName)
+				if strings.Contains(metricName, expectedLabel) {
+					streamMetrics[streamName] += value
+				}
+			}
+		}
+	}
+
+	// Each stream should have processed exactly 1 message
+	for _, streamName := range streamNames {
+		require.Equal(t, int64(1), streamMetrics[streamName],
+			fmt.Sprintf("Stream %s should have processed 1 message", streamName))
+	}
+
+	// Total should be 3 messages (1 per stream)
+	totalMessages := int64(0)
+	for _, count := range streamMetrics {
+		totalMessages += count
+	}
+	require.Equal(t, int64(3), totalMessages, "Should have 3 messages total across all streams")
+}
+
+func TestStreamLabelingSimple(t *testing.T) {
+	localMetrics := metrics.NewLocal()
+
+	// Test basic labeling functionality
+	baseMetrics := metrics.NewNamespaced(localMetrics)
+	streamMetrics := baseMetrics.WithLabels("stream", "test-stream")
+
+	// Emit a simple counter
+	counter := streamMetrics.GetCounter("test_counter")
+	counter.Incr(1)
+
+	// Check what was emitted
+	counters := localMetrics.GetCounters()
+
+	// Should see counter with stream label
+	found := false
+	for metricName := range counters {
+		if strings.Contains(metricName, "stream=") && strings.Contains(metricName, "test-stream") {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "Should find metric with stream label")
+}

--- a/public/service/shared_metrics_test.go
+++ b/public/service/shared_metrics_test.go
@@ -62,8 +62,7 @@ logger:
 	defer cancel()
 
 	err = stream.Run(ctx)
-	// Context timeout is expected for generate input
-	require.NotEqual(t, err, context.DeadlineExceeded, "Stream should complete before timeout")
+	require.NoError(t, err)
 }
 
 func TestSharedMetricsEmission(t *testing.T) {


### PR DESCRIPTION
This has been a source of frustration for us: when using StreamBuilder to create multiple streams, each stream creates its own metrics registry and HTTP server, which means exposing one port per stream if you want metrics from all of them. We wanted a way to have metrics from multiple StreamBuilder-built streams report into one prometheus registry.

This PR introduces a `SharedMetrics` abstraction that can be associated with any given `StreamBuilder`. Stream names can be used to automatically label metrics, similar to how Bento's streams mode works, making it easy to distinguish metrics from different streams in the shared registry.

## Basic Usage
```go
// Create shared metrics setup
sharedMetrics, err := service.NewSharedMetricsSetup(`
prometheus:
  use_histogram_timing: false
`, 9090)

// Start shared metrics server
go sharedMetrics.ListenAndServe()

// Create multiple streams
for i := 0; i < 5; i++ {
    builder := service.NewStreamBuilder()
    sharedMetrics.ConfigureStreamBuilder(builder)
    // ... configure stream normally
    stream, _ := builder.Build()
    go stream.Run(context.Background())
}
// All streams report to single Prometheus endpoint on port 9090
```

## Stream Labeling
Similar to Bento's streams mode, each stream can be given a name that appears in all metrics:

```go
// Create streams with distinct names
streamNames := []string{"orders-processor", "user-events", "notifications"}
for _, name := range streamNames {
    builder := service.NewStreamBuilder()
    builder.SetStreamName(name)  // Add stream labels automatically
    sharedMetrics.ConfigureStreamBuilder(builder)
    // ... configure normally
}
```

**Results in labeled metrics:**
```
input_received{stream="orders-processor",path="root.input"} 5
input_received{stream="user-events",path="root.input"} 12  
input_received{stream="notifications",path="root.input"} 3
```