### PR TITLE
Added --allow-experimental and --allow-beta CLI flags #426

### DIFF
--- a/internal/bundle/buffers.go
+++ b/internal/bundle/buffers.go
@@ -24,7 +24,16 @@ func (e *Environment) BufferAdd(constructor BufferConstructor, spec docs.Compone
 
 // BufferInit attempts to initialise a buffer from a config.
 func (e *Environment) BufferInit(conf buffer.Config, mgr NewManagement) (buffer.Streamed, error) {
-	return e.buffers.Init(conf, mgr)
+	spec, exists := e.buffers.specs[conf.Type]
+	if !exists {
+		return nil, component.ErrInvalidType("buffer", conf.Type)
+	}
+	if err := e.allowStatus(spec.spec); err != nil {
+		return nil, wrapComponentErr(mgr, "buffer", err)
+	}
+	c, err := spec.constructor(conf, mgr)
+	err = wrapComponentErr(mgr, "buffer", err)
+	return c, err
 }
 
 // BufferDocs returns a slice of buffer specs, which document each method.

--- a/internal/bundle/caches.go
+++ b/internal/bundle/caches.go
@@ -24,7 +24,16 @@ func (e *Environment) CacheAdd(constructor CacheConstructor, spec docs.Component
 
 // CacheInit attempts to initialise a cache from a config.
 func (e *Environment) CacheInit(conf cache.Config, mgr NewManagement) (cache.V1, error) {
-	return e.caches.Init(conf, mgr)
+	spec, exists := e.caches.specs[conf.Type]
+	if !exists {
+		return nil, component.ErrInvalidType("cache", conf.Type)
+	}
+	if err := e.allowStatus(spec.spec); err != nil {
+		return nil, wrapComponentErr(mgr, "cache", err)
+	}
+	c, err := spec.constructor(conf, mgr)
+	err = wrapComponentErr(mgr, "cache", err)
+	return c, err
 }
 
 // CacheDocs returns a slice of cache specs, which document each method.

--- a/internal/bundle/inputs.go
+++ b/internal/bundle/inputs.go
@@ -24,7 +24,16 @@ func (e *Environment) InputAdd(constructor InputConstructor, spec docs.Component
 
 // InputInit attempts to initialise an input from a config.
 func (e *Environment) InputInit(conf input.Config, mgr NewManagement) (input.Streamed, error) {
-	return e.inputs.Init(conf, mgr)
+	spec, exists := e.inputs.specs[conf.Type]
+	if !exists {
+		return nil, component.ErrInvalidType("input", conf.Type)
+	}
+	if err := e.allowStatus(spec.spec); err != nil {
+		return nil, wrapComponentErr(mgr, "input", err)
+	}
+	c, err := spec.constructor(conf, mgr)
+	err = wrapComponentErr(mgr, "input", err)
+	return c, err
 }
 
 // InputDocs returns a slice of input specs, which document each method.

--- a/internal/bundle/outputs.go
+++ b/internal/bundle/outputs.go
@@ -29,7 +29,16 @@ func (e *Environment) OutputInit(
 	mgr NewManagement,
 	pipelines ...processor.PipelineConstructorFunc,
 ) (output.Streamed, error) {
-	return e.outputs.Init(conf, mgr, pipelines...)
+	spec, exists := e.outputs.specs[conf.Type]
+	if !exists {
+		return nil, component.ErrInvalidType("output", conf.Type)
+	}
+	if err := e.allowStatus(spec.spec); err != nil {
+		return nil, wrapComponentErr(mgr, "output", err)
+	}
+	c, err := spec.constructor(conf, mgr, pipelines...)
+	err = wrapComponentErr(mgr, "output", err)
+	return c, err
 }
 
 // OutputDocs returns a slice of output specs, which document each method.

--- a/internal/bundle/processors.go
+++ b/internal/bundle/processors.go
@@ -25,7 +25,16 @@ func (e *Environment) ProcessorAdd(constructor ProcessorConstructor, spec docs.C
 
 // ProcessorInit attempts to initialise a processor from a config.
 func (e *Environment) ProcessorInit(conf processor.Config, mgr NewManagement) (processor.V1, error) {
-	return e.processors.Init(conf, mgr)
+	spec, exists := e.processors.specs[conf.Type]
+	if !exists {
+		return nil, component.ErrInvalidType("processor", conf.Type)
+	}
+	if err := e.allowStatus(spec.spec); err != nil {
+		return nil, wrapComponentErr(mgr, "processor", err)
+	}
+	c, err := spec.constructor(conf, mgr)
+	err = wrapComponentErr(mgr, "processor", err)
+	return c, err
 }
 
 // ProcessorDocs returns a slice of processor specs, which document each method.

--- a/internal/bundle/scanners.go
+++ b/internal/bundle/scanners.go
@@ -24,7 +24,14 @@ func (e *Environment) ScannerAdd(constructor ScannerConstructor, spec docs.Compo
 
 // ScannerInit attempts to initialise a scanner creator from a config.
 func (e *Environment) ScannerInit(conf scanner.Config, nm NewManagement) (scanner.Creator, error) {
-	return e.scanners.Init(conf, nm)
+	spec, exists := e.scanners.specs[conf.Type]
+	if !exists {
+		return nil, component.ErrInvalidType("scanner", conf.Type)
+	}
+	if err := e.allowStatus(spec.spec); err != nil {
+		return nil, wrapComponentErr(nm, "scanner", err)
+	}
+	return spec.constructor(conf, nm)
 }
 
 // ScannerDocs returns a slice of scanner specs.

--- a/internal/bundle/test_allow_experimental_test.go
+++ b/internal/bundle/test_allow_experimental_test.go
@@ -1,0 +1,6 @@
+package bundle
+
+func init() {
+	GlobalEnvironment.AllowExperimental()
+	GlobalEnvironment.AllowBeta()
+}

--- a/internal/bundle/tracers.go
+++ b/internal/bundle/tracers.go
@@ -26,7 +26,14 @@ func (e *Environment) TracersAdd(constructor TracerConstructor, spec docs.Compon
 
 // TracersInit attempts to initialise a tracers exporter from a config.
 func (e *Environment) TracersInit(conf tracer.Config, nm NewManagement) (trace.TracerProvider, error) {
-	return e.tracers.Init(conf, nm)
+	spec, exists := e.tracers.specs[conf.Type]
+	if !exists {
+		return nil, component.ErrInvalidType("tracer", conf.Type)
+	}
+	if err := e.allowStatus(spec.spec); err != nil {
+		return nil, wrapComponentErr(nm, "tracer", err)
+	}
+	return spec.constructor(conf, nm)
 }
 
 // TracersDocs returns a slice of tracers exporter specs.

--- a/internal/cli/common/manager.go
+++ b/internal/cli/common/manager.go
@@ -62,13 +62,13 @@ func CreateManager(
 	tmpMgr.Version = cliOpts.Version
 
 	// Create our metrics type.
-	if stats, err = bundle.AllMetrics.Init(conf.Metrics, tmpMgr); err != nil {
+	if stats, err = bundle.GlobalEnvironment.MetricsInit(conf.Metrics, tmpMgr); err != nil {
 		err = fmt.Errorf("failed to connect to metrics aggregator: %w", err)
 		return
 	}
 
 	// Create our tracer type.
-	if trac, err = bundle.AllTracers.Init(conf.Tracer, tmpMgr); err != nil {
+	if trac, err = bundle.GlobalEnvironment.TracersInit(conf.Tracer, tmpMgr); err != nil {
 		err = fmt.Errorf("failed to initialise tracer: %w", err)
 		return
 	}

--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/warpstreamlabs/bento/internal/bundle"
 	"github.com/warpstreamlabs/bento/internal/config"
 	"github.com/warpstreamlabs/bento/internal/manager"
 	"github.com/warpstreamlabs/bento/internal/stream"
@@ -21,6 +22,12 @@ import (
 // RunService runs a service command (either the default or the streams
 // subcommand).
 func RunService(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) int {
+	if c.Bool("allow-experimental") {
+		bundle.GlobalEnvironment.AllowExperimental()
+	}
+	if c.Bool("allow-beta") {
+		bundle.GlobalEnvironment.AllowBeta()
+	}
 	mainPath, inferredMainPath, confReader := ReadConfig(c, cliOpts, streamsMode)
 
 	conf, pConf, lints, lintWarns, err := confReader.Read()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -133,6 +133,16 @@ func runFlags(opts *common.CLIOpts) []cli.Flag {
 			Aliases: []string{"t"},
 			Usage:   opts.ExecTemplate("EXPERIMENTAL: import {{.ProductName}} templates, supports glob patterns (requires quotes)"),
 		},
+		&cli.BoolFlag{
+			Name:  "allow-experimental",
+			Value: false,
+			Usage: "allow use of experimental components",
+		},
+		&cli.BoolFlag{
+			Name:  "allow-beta",
+			Value: false,
+			Usage: "allow use of beta components",
+		},
 	}
 }
 

--- a/internal/impl/cypher/allow_experimental_test.go
+++ b/internal/impl/cypher/allow_experimental_test.go
@@ -1,0 +1,8 @@
+package cypher
+
+import "github.com/warpstreamlabs/bento/internal/bundle"
+
+func init() {
+	bundle.GlobalEnvironment.AllowExperimental()
+	bundle.GlobalEnvironment.AllowBeta()
+}

--- a/internal/impl/jaeger/tracer_jaeger.go
+++ b/internal/impl/jaeger/tracer_jaeger.go
@@ -113,7 +113,7 @@ func NewJaeger(config jaegerConfig) (trace.TracerProvider, error) {
 		case "const":
 			sampler = tracesdk.TraceIDRatioBased(config.SamplerParam)
 		case "probabilistic":
-			return nil, errors.New("probabalistic sampling is no longer available")
+			return nil, errors.New("probabilistic sampling is no longer available")
 		case "ratelimiting":
 			return nil, errors.New("rate limited sampling is no longer available")
 		case "remote":

--- a/internal/impl/pure/allow_experimental_test.go
+++ b/internal/impl/pure/allow_experimental_test.go
@@ -1,0 +1,8 @@
+package pure_test
+
+import "github.com/warpstreamlabs/bento/internal/bundle"
+
+func init() {
+	bundle.GlobalEnvironment.AllowExperimental()
+	bundle.GlobalEnvironment.AllowBeta()
+}

--- a/internal/impl/pure/processor_jsonschema_test.go
+++ b/internal/impl/pure/processor_jsonschema_test.go
@@ -39,21 +39,23 @@ func TestJSONSchemaExternalSchemaRelativePath(t *testing.T) {
   }
 }`
 
-	tmpDir := t.TempDir()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	tmpDir, err := os.MkdirTemp(cwd, "jschema")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
 
 	sFileName := filepath.Join(tmpDir, "foo")
 	require.NoError(t, os.WriteFile(sFileName, []byte(schema), 0o777))
 
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-
-	sFileName, err = filepath.Rel(cwd, sFileName)
+	relPath, err := filepath.Rel(cwd, sFileName)
 	require.NoError(t, err)
 
 	conf, err := testutil.ProcessorFromYAML(fmt.Sprintf(`
 json_schema:
   schema_path: file://%v
-`, sFileName))
+`, relPath))
 	require.NoError(t, err)
 
 	c, err := mock.NewManager().NewProcessor(conf)

--- a/internal/impl/sql/allow_experimental_test.go
+++ b/internal/impl/sql/allow_experimental_test.go
@@ -1,0 +1,8 @@
+package sql_test
+
+import "github.com/warpstreamlabs/bento/internal/bundle"
+
+func init() {
+	bundle.GlobalEnvironment.AllowExperimental()
+	bundle.GlobalEnvironment.AllowBeta()
+}

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -99,11 +99,21 @@ func (e *Environment) UseFS(fs *FS) {
 	})
 }
 
+// AllowExperimental enables experimental components within this environment.
+func (e *Environment) AllowExperimental() {
+	e.internal.AllowExperimental()
+}
+
+// AllowBeta enables beta components within this environment.
+func (e *Environment) AllowBeta() {
+	e.internal.AllowBeta()
+}
+
 // NewStreamBuilder creates a new StreamBuilder upon the defined environment,
 // only components known to this environment will be available to the stream
 // builder.
-func (e *Environment) NewStreamBuilder() *StreamBuilder {
-	sb := NewStreamBuilder()
+func (e *Environment) NewStreamBuilder(opts ...StreamBuilderOpt) *StreamBuilder {
+	sb := NewStreamBuilder(opts...)
 	sb.env = e
 	return sb
 }

--- a/public/service/example_output_batched_plugin_test.go
+++ b/public/service/example_output_batched_plugin_test.go
@@ -66,7 +66,7 @@ func Example_outputBatchedPlugin() {
 
 	// Use the stream builder API to create a Bento stream that uses our new
 	// output type.
-	builder := service.NewStreamBuilder()
+	builder := service.NewStreamBuilder(service.OptAllowExperimental())
 
 	// Set the full Bento configuration of the stream.
 	err = builder.SetYAML(`

--- a/public/service/plugins_test.go
+++ b/public/service/plugins_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
+func init() {
+	service.GlobalEnvironment().AllowExperimental()
+}
+
 func testSanitConf() docs.SanitiseConfig {
 	sanitConf := docs.NewSanitiseConfig(bundle.GlobalEnvironment)
 	sanitConf.RemoveTypeField = true

--- a/public/service/tracing_test.go
+++ b/public/service/tracing_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestOtelTracingPlugin(t *testing.T) {
 	env := service.NewEnvironment()
+	env.AllowExperimental()
 	confSpec := service.NewConfigSpec().Field(service.NewStringField("foo"))
 
 	var testValue string


### PR DESCRIPTION
- Added --allow-experimental and --allow-beta CLI flags and wired them into service startup so unstable components are only loaded when explicitly requested
- Introduced gating in the component environment to block beta/experimental plugins unless they are enabled, with opt-ins available via AllowExperimental/AllowBeta and stream-builder options for programmatic control
- Updated manager creation to respect the environment gating by constructing metrics and tracers through the global environment
- Closes : https://github.com/warpstreamlabs/bento/issues/426