### PR TITLE
feat(bloblang): Add support for square bracket syntax

### DIFF
--- a/internal/bloblang/parser/query_function_parser.go
+++ b/internal/bloblang/parser/query_function_parser.go
@@ -76,6 +76,128 @@ func parseMapExpression(fn query.Function, pCtx Context) Func[query.Function] {
 	}
 }
 
+func parseBracketExpression(fn query.Function, pCtx Context) Func[query.Function] {
+	return func(input []rune) Result[query.Function] {
+		openRes := charSquareOpen(input)
+		if openRes.Err != nil {
+			return Fail[query.Function](openRes.Err, input)
+		}
+
+		remaining := DiscardedWhitespaceNewlineComments(openRes.Remaining).Remaining
+
+		return OneOf(
+			parseSliceExpression(fn, pCtx), // [start:end:step]
+			parseIndexExpression(fn, pCtx), // [i] (single number)
+		)(remaining)
+	}
+}
+
+func parseIndexExpression(fn query.Function, pCtx Context) Func[query.Function] {
+	return func(input []rune) Result[query.Function] {
+		remaining := input
+		indexRes := queryParser(pCtx)(remaining)
+		if indexRes.Err != nil {
+			return Fail[query.Function](indexRes.Err, input)
+		}
+
+		indexExpr := indexRes.Payload
+		remaining = indexRes.Remaining
+
+		wsRes := DiscardedWhitespaceNewlineComments(remaining)
+		remaining = wsRes.Remaining
+
+		colonRes := charColon(remaining)
+		if colonRes.Err == nil {
+			return Fail[query.Function](NewError(input, "slice syntax should use parseSliceExpression"), input)
+		}
+
+		closeRes := Expect(charSquareClose, "closing bracket")(remaining)
+		if closeRes.Err != nil {
+			return Fail[query.Function](closeRes.Err, input)
+		}
+
+		method, err := query.NewIndexMethod(fn, indexExpr)
+		if err != nil {
+			return Fail[query.Function](NewFatalError(input, err), input)
+		}
+
+		return Success(method, closeRes.Remaining)
+	}
+}
+
+func parseSliceExpression(fn query.Function, pCtx Context) Func[query.Function] {
+	return func(input []rune) Result[query.Function] {
+		remaining := input
+
+		// Parse start bound
+		var startBound query.Function
+		colonRes := charColon(remaining)
+		if colonRes.Err != nil {
+			// Not colon -> parse start expression
+			startRes := queryParser(pCtx)(remaining)
+			if startRes.Err != nil {
+				return Fail[query.Function](startRes.Err, input)
+			}
+
+			startBound = startRes.Payload
+			remaining = DiscardedWhitespaceNewlineComments(startRes.Remaining).Remaining
+
+			colonRes = charColon(remaining)
+			if colonRes.Err != nil {
+				// Must have colon after start bound, otherwise it's an index
+				return Fail[query.Function](colonRes.Err, input)
+			}
+		}
+
+		remaining = DiscardedWhitespaceNewlineComments(colonRes.Remaining).Remaining
+
+		// Parse end bound
+		var endBound query.Function
+		colonRes2 := charColon(remaining)
+		closeRes := charSquareClose(remaining)
+		if colonRes2.Err != nil && closeRes.Err != nil {
+			// Not colon or close bracket -> parse end expression
+			endRes := queryParser(pCtx)(remaining)
+			if endRes.Err != nil {
+				return Fail[query.Function](endRes.Err, input)
+			}
+
+			endBound = endRes.Payload
+			remaining = DiscardedWhitespaceNewlineComments(endRes.Remaining).Remaining
+		}
+
+		// Parse step bound
+		var stepBound query.Function
+		colonRes3 := charColon(remaining)
+		if colonRes3.Err == nil {
+			remaining = DiscardedWhitespaceNewlineComments(colonRes3.Remaining).Remaining
+
+			closeRes2 := charSquareClose(remaining)
+			if closeRes2.Err != nil {
+				// Not close bracket -> parse step expression
+				stepRes := queryParser(pCtx)(remaining)
+				if stepRes.Err != nil {
+					return Fail[query.Function](stepRes.Err, input)
+				}
+
+				stepBound = stepRes.Payload
+				remaining = DiscardedWhitespaceNewlineComments(stepRes.Remaining).Remaining
+			}
+		}
+
+		closeRes = Expect(charSquareClose, "closing bracket")(remaining)
+		if closeRes.Err != nil {
+			return Fail[query.Function](closeRes.Err, input)
+		}
+
+		method, err := query.NewSliceMethod(fn, startBound, endBound, stepBound)
+		if err != nil {
+			return Fail[query.Function](NewFatalError(input, err), input)
+		}
+		return Success(method, closeRes.Remaining)
+	}
+}
+
 func parseFunctionTail(fn query.Function, pCtx Context) Func[query.Function] {
 	return OneOf(
 		// foo.(bar | baz)
@@ -115,6 +237,14 @@ func parseWithTails(fnParser Func[query.Function], pCtx Context) Func[query.Func
 		isNot := seq[0].(string) == "!"
 		fn := seq[1].(query.Function)
 		for {
+			// Parse bracket expressions: foo[*] -> i.e. foo[0, 1]
+			if res := parseBracketExpression(fn, pCtx)(remaining); res.Err == nil {
+				fn = res.Payload
+				remaining = res.Remaining
+				continue
+			}
+
+			// Parse dot-delimited expressions: foo.* -> i.e. foo.bar()
 			if res := delimPattern(remaining); res.Err != nil {
 				if isNot {
 					fn = query.Not(fn)

--- a/internal/bloblang/parser/query_parser_test.go
+++ b/internal/bloblang/parser/query_parser_test.go
@@ -230,6 +230,22 @@ not this`,
 	5 and also this`,
 			remaining: " and also this",
 		},
+		"bracket slice with single param": {
+			input:     `this.value[4]`,
+			remaining: ``,
+		},
+		"bracket slice with two params": {
+			input:     `this.value[0:2]`,
+			remaining: ``,
+		},
+		"bracket slice chained": {
+			input:     `this.value[0:5][1:3]`,
+			remaining: ``,
+		},
+		"bracket slice with method": {
+			input:     `this.value[0:2].length()`,
+			remaining: ``,
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/bloblang/query/methods.go
+++ b/internal/bloblang/query/methods.go
@@ -364,6 +364,235 @@ func mapMethod(target Function, args *ParsedParams) (Function, error) {
 
 //------------------------------------------------------------------------------
 
+// NewIndexMethod creates a new index method for single element access.
+func NewIndexMethod(target, indexExpr Function) (Function, error) {
+	return ClosureFunction("index", func(ctx FunctionContext) (any, error) {
+		targetVal, err := target.Exec(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		indexVal, err := indexExpr.Exec(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		index, err := value.IGetInt(indexVal)
+		if err != nil {
+			return nil, fmt.Errorf("index: %w", err)
+		}
+
+		var length int64
+		switch t := targetVal.(type) {
+		case string:
+			length = int64(len(t))
+		case []byte:
+			length = int64(len(t))
+		case []any:
+			length = int64(len(t))
+		default:
+			return nil, value.NewTypeError(targetVal, value.TArray, value.TString)
+		}
+
+		if index < 0 {
+			index += length
+		}
+
+		if index < 0 || index >= length {
+			return nil, fmt.Errorf("index %v out of bounds for length %v", index, length)
+		}
+
+		switch t := targetVal.(type) {
+		case string:
+			return string(t[index]), nil
+		case []byte:
+			return t[index], nil
+		case []any:
+			return t[index], nil
+		}
+
+		return nil, nil
+
+	}, func(ctx TargetsContext) (TargetsContext, []TargetPath) {
+		targetCtx, targets := target.QueryTargets(ctx)
+		indexCtx, indexTargets := indexExpr.QueryTargets(targetCtx)
+
+		allTargets := append(targets, indexTargets...)
+		return indexCtx, allTargets
+	}), nil
+}
+
+//------------------------------------------------------------------------------
+
+// NewSliceMethod creates a new slice method with optional step support.
+func NewSliceMethod(target, startBound, endBound, stepBound Function) (Function, error) {
+	execFunc := func(ctx FunctionContext) (any, error) {
+		targetVal, err := target.Exec(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		var start, end, step *int64
+
+		if startBound != nil {
+			startVal, err := startBound.Exec(ctx)
+			if err != nil {
+				return nil, err
+			}
+			startInt, err := value.IGetInt(startVal)
+			if err != nil {
+				return nil, fmt.Errorf("slice start bound: %w", err)
+			}
+			start = &startInt
+		}
+
+		if endBound != nil {
+			endVal, err := endBound.Exec(ctx)
+			if err != nil {
+				return nil, err
+			}
+			endInt, err := value.IGetInt(endVal)
+			if err != nil {
+				return nil, fmt.Errorf("slice end bound: %w", err)
+			}
+			end = &endInt
+		}
+
+		if stepBound != nil {
+			stepVal, err := stepBound.Exec(ctx)
+			if err != nil {
+				return nil, err
+			}
+			stepInt, err := value.IGetInt(stepVal)
+			if err != nil {
+				return nil, fmt.Errorf("slice step: %w", err)
+			}
+			if stepInt == 0 {
+				return nil, errors.New("slice step cannot be zero")
+			}
+			step = &stepInt
+		}
+
+		switch t := targetVal.(type) {
+		case string:
+			return sliceString(t, start, end, step)
+		case []byte:
+			return sliceBytes(t, start, end, step)
+		case []any:
+			return sliceArray(t, start, end, step)
+		default:
+			return nil, value.NewTypeError(targetVal, value.TArray, value.TString)
+		}
+	}
+	queryFunc := func(ctx TargetsContext) (TargetsContext, []TargetPath) {
+		var allTargets []TargetPath
+		currentCtx := ctx
+
+		for _, fn := range []Function{target, startBound, endBound, stepBound} {
+			if fn == nil {
+				continue
+			}
+			var targets []TargetPath
+			currentCtx, targets = fn.QueryTargets(currentCtx)
+			allTargets = append(allTargets, targets...)
+		}
+
+		return currentCtx, allTargets
+	}
+
+	return ClosureFunction("slice", execFunc, queryFunc), nil
+}
+
+// slice slices any slice-like input (string, []byte, []any).
+func slice[T any](data []T, start, end, step *int64) ([]T, error) {
+	length := int64(len(data))
+	startIdx, endIdx, stepVal := normalizeSliceBounds(length, start, end, step)
+
+	if stepVal == 1 {
+		return data[startIdx:endIdx], nil
+	}
+
+	// Out of range
+	if (stepVal > 0 && startIdx >= endIdx) || (stepVal < 0 && startIdx <= endIdx) {
+		return nil, nil
+	}
+
+	var result []T
+	if stepVal > 0 {
+		for i := startIdx; i < endIdx; i += stepVal {
+			result = append(result, data[i])
+		}
+	} else {
+		for i := startIdx; i > endIdx; i += stepVal {
+			result = append(result, data[i])
+		}
+	}
+	return result, nil
+}
+
+// sliceString slices any string input.
+func sliceString(s string, start, end, step *int64) (string, error) {
+	runes := []rune(s)
+	result, err := slice(runes, start, end, step)
+	if err != nil {
+		return "", err
+	}
+	return string(result), nil
+}
+
+// sliceString slices any byte array input.
+func sliceBytes(b []byte, start, end, step *int64) ([]byte, error) {
+	return slice(b, start, end, step)
+}
+
+// sliceString slices any array input.
+func sliceArray(arr []any, start, end, step *int64) ([]any, error) {
+	return slice(arr, start, end, step)
+}
+
+func normalizeSliceBounds(length int64, start, end, step *int64) (startIdx, endIdx, stepVal int64) {
+	stepVal = 1 // default
+	if step != nil {
+		stepVal = *step
+	}
+
+	if start == nil {
+		if stepVal > 0 {
+			startIdx = 0
+		} else {
+			startIdx = length - 1
+		}
+	} else {
+		startIdx = *start
+		if startIdx < 0 {
+			startIdx = max(length+startIdx, 0)
+		}
+		if stepVal > 0 {
+			startIdx = min(startIdx, length)
+		}
+	}
+
+	if end == nil {
+		if stepVal > 0 {
+			endIdx = length
+		} else {
+			endIdx = -1
+		}
+	} else {
+		endIdx = *end
+		if endIdx < 0 {
+			endIdx = max(length+endIdx, -1)
+		}
+		if stepVal > 0 {
+			endIdx = min(endIdx, length)
+		}
+	}
+
+	return startIdx, endIdx, stepVal
+}
+
+//------------------------------------------------------------------------------
+
 var _ = registerMethod(NewHiddenMethodSpec("not"), notMethodCtor)
 
 type notMethod struct {

--- a/internal/bloblang/query/methods_structured.go
+++ b/internal/bloblang/query/methods_structured.go
@@ -1391,36 +1391,56 @@ func sortByMethod(target Function, args *ParsedParams) (Function, error) {
 //------------------------------------------------------------------------------
 
 var _ = registerSimpleMethod(
-	NewMethodSpec(
-		"slice", "",
+	NewDeprecatedMethodSpec(
+		"slice", "use square bracket syntax instead: this.value[0:2] instead of this.value.slice(0, 2)",
 	).InCategory(
 		MethodCategoryStrings,
-		"Extract a slice from a string by specifying two indices, a low and high bound, which selects a half-open range that includes the first character, but excludes the last one. If the second index is omitted then it defaults to the length of the input sequence.",
+		"Extract a slice from a string by specifying two indices, a low and high bound, which selects a half-open range that includes the first character, but excludes the last one. If the second index is omitted then it defaults to the length of the input sequence. **This method is deprecated, use bracket syntax instead: `this.value[0:2]` instead of `this.value.slice(0, 2)`.**",
 		NewExampleSpec("",
-			`root.beginning = this.value.slice(0, 2)
-root.end = this.value.slice(4)`,
+			`# Deprecated - use bracket syntax instead
+root.beginning = this.value.slice(0, 2)
+root.end = this.value.slice(4)
+
+# New bracket syntax (recommended)
+root.beginning = this.value[0:2]  
+root.end = this.value[4:]`,
 			`{"value":"foo bar"}`,
 			`{"beginning":"fo","end":"bar"}`,
 		),
-		NewExampleSpec(`A negative low index can be used, indicating an offset from the end of the sequence. If the low index is greater than the length of the sequence then an empty result is returned.`,
-			`root.last_chunk = this.value.slice(-4)
-root.the_rest = this.value.slice(0, -4)`,
+		NewExampleSpec("A negative low index can be used, indicating an offset from the end of the sequence. If the low index is greater than the length of the sequence then an empty result is returned. **Use bracket syntax instead: `this.value[-4:]` instead of `this.value.slice(-4)`.**",
+			`# Deprecated - use bracket syntax instead
+root.last_chunk = this.value.slice(-4)
+root.the_rest = this.value.slice(0, -4)
+
+# New bracket syntax (recommended)
+root.last_chunk = this.value[-4:]
+root.the_rest = this.value[:-4]`,
 			`{"value":"foo bar"}`,
 			`{"last_chunk":" bar","the_rest":"foo"}`,
 		),
 	).InCategory(
 		MethodCategoryObjectAndArray,
-		"Extract a slice from an array by specifying two indices, a low and high bound, which selects a half-open range that includes the first element, but excludes the last one. If the second index is omitted then it defaults to the length of the input sequence.",
+		"Extract a slice from an array by specifying two indices, a low and high bound, which selects a half-open range that includes the first element, but excludes the last one. If the second index is omitted then it defaults to the length of the input sequence. **This method is deprecated, use bracket syntax instead: `this.value[0:2]` instead of `this.value.slice(0, 2)`.**",
 		NewExampleSpec("",
-			`root.beginning = this.value.slice(0, 2)
-root.end = this.value.slice(4)`,
+			`# Deprecated - use bracket syntax instead
+root.beginning = this.value.slice(0, 2)
+root.end = this.value.slice(4)
+
+# New bracket syntax (recommended)
+root.beginning = this.value[0:2]
+root.end = this.value[4:]`,
 			`{"value":["foo","bar","baz","buz","bev"]}`,
 			`{"beginning":["foo","bar"],"end":["bev"]}`,
 		),
 		NewExampleSpec(
-			`A negative low index can be used, indicating an offset from the end of the sequence. If the low index is greater than the length of the sequence then an empty result is returned.`,
-			`root.last_chunk = this.value.slice(-2)
-root.the_rest = this.value.slice(0, -2)`,
+			"A negative low index can be used, indicating an offset from the end of the sequence. If the low index is greater than the length of the sequence then an empty result is returned. **Use bracket syntax instead: `this.value[-2:]` instead of `this.value.slice(-2)`.**",
+			`# Deprecated - use bracket syntax instead
+root.last_chunk = this.value.slice(-2)
+root.the_rest = this.value.slice(0, -2)
+
+# New bracket syntax (recommended)
+root.last_chunk = this.value[-2:]
+root.the_rest = this.value[:-2]`,
 			`{"value":["foo","bar","baz","buz","bev"]}`,
 			`{"last_chunk":["buz","bev"],"the_rest":["foo","bar","baz"]}`,
 		),

--- a/internal/bloblang/query/methods_test.go
+++ b/internal/bloblang/query/methods_test.go
@@ -2210,3 +2210,437 @@ func TestMethodNoArgsTargets(t *testing.T) {
 		assert.Contains(t, targets, exp, "method: %v", k)
 	}
 }
+
+func TestNewIndexMethod(t *testing.T) {
+	literalFn := func(val any) Function {
+		return NewLiteralFunction("", val)
+	}
+
+	tests := []struct {
+		name     string
+		target   any
+		index    any
+		expected any
+		wantErr  bool
+		errMsg   string
+	}{
+		// String indexing
+		{
+			name:     "string positive index",
+			target:   "hello",
+			index:    1,
+			expected: "e",
+		},
+		{
+			name:     "string negative index",
+			target:   "hello",
+			index:    -1,
+			expected: "o",
+		},
+		{
+			name:     "string negative index middle",
+			target:   "hello",
+			index:    -3,
+			expected: "l",
+		},
+		{
+			name:    "string index out of bounds positive",
+			target:  "hello",
+			index:   10,
+			wantErr: true,
+			errMsg:  "index 10 out of bounds for length 5",
+		},
+		{
+			name:    "string index out of bounds negative",
+			target:  "hello",
+			index:   -10,
+			wantErr: true,
+			errMsg:  "index -5 out of bounds for length 5",
+		},
+
+		// Array indexing
+		{
+			name:     "array positive index",
+			target:   []any{"a", "b", "c"},
+			index:    0,
+			expected: "a",
+		},
+		{
+			name:     "array negative index",
+			target:   []any{"a", "b", "c"},
+			index:    -1,
+			expected: "c",
+		},
+		{
+			name:    "array index out of bounds",
+			target:  []any{"a", "b", "c"},
+			index:   5,
+			wantErr: true,
+			errMsg:  "index 5 out of bounds for length 3",
+		},
+
+		// Byte array indexing
+		{
+			name:     "byte array positive index",
+			target:   []byte("hello"),
+			index:    1,
+			expected: byte('e'),
+		},
+		{
+			name:     "byte array negative index",
+			target:   []byte("hello"),
+			index:    -1,
+			expected: byte('o'),
+		},
+
+		// Error cases
+		{
+			name:    "invalid target type",
+			target:  42,
+			index:   0,
+			wantErr: true,
+			errMsg:  "expected array or string value, got number",
+		},
+		{
+			name:    "invalid index type",
+			target:  "hello",
+			index:   "not a number",
+			wantErr: true,
+			errMsg:  "index:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetFn := literalFn(tt.target)
+			indexFn := literalFn(tt.index)
+
+			method, err := NewIndexMethod(targetFn, indexFn)
+			require.NoError(t, err)
+
+			ctx := FunctionContext{}
+			result, err := method.Exec(ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewSliceMethod(t *testing.T) {
+	literalFn := func(val any) Function {
+		return NewLiteralFunction("", val)
+	}
+
+	tests := []struct {
+		name     string
+		target   any
+		start    any
+		end      any
+		step     any
+		expected any
+		wantErr  bool
+		errMsg   string
+	}{
+		// String slicing
+		{
+			name:     "string basic slice",
+			target:   "hello world",
+			start:    1,
+			end:      5,
+			step:     nil,
+			expected: "ello",
+		},
+		{
+			name:     "string slice with step",
+			target:   "hello world",
+			start:    0,
+			end:      10,
+			step:     2,
+			expected: "hlowr",
+		},
+		{
+			name:     "string slice start only",
+			target:   "hello world",
+			start:    6,
+			end:      nil,
+			step:     nil,
+			expected: "world",
+		},
+		{
+			name:     "string slice end only",
+			target:   "hello world",
+			start:    nil,
+			end:      5,
+			step:     nil,
+			expected: "hello",
+		},
+		{
+			name:     "string slice step only",
+			target:   "hello world",
+			start:    nil,
+			end:      nil,
+			step:     2,
+			expected: "hlowrd",
+		},
+		{
+			name:     "string negative start",
+			target:   "hello world",
+			start:    -5,
+			end:      nil,
+			step:     nil,
+			expected: "world",
+		},
+		{
+			name:     "string negative end",
+			target:   "hello world",
+			start:    nil,
+			end:      -6,
+			step:     nil,
+			expected: "hello",
+		},
+		{
+			name:     "string negative step",
+			target:   "hello",
+			start:    nil,
+			end:      nil,
+			step:     -1,
+			expected: "olleh",
+		},
+
+		// Array slicing
+		{
+			name:     "array basic slice",
+			target:   []any{"a", "b", "c", "d", "e"},
+			start:    1,
+			end:      4,
+			step:     nil,
+			expected: []any{"b", "c", "d"},
+		},
+		{
+			name:     "array with step",
+			target:   []any{"a", "b", "c", "d", "e"},
+			start:    0,
+			end:      nil,
+			step:     2,
+			expected: []any{"a", "c", "e"},
+		},
+		{
+			name:     "array negative indices",
+			target:   []any{"a", "b", "c", "d", "e"},
+			start:    -3,
+			end:      -1,
+			step:     nil,
+			expected: []any{"c", "d"},
+		},
+
+		// Byte array slicing
+		{
+			name:     "bytes basic slice",
+			target:   []byte("hello"),
+			start:    1,
+			end:      4,
+			step:     nil,
+			expected: []byte("ell"),
+		},
+		{
+			name:     "bytes with step",
+			target:   []byte("hello"),
+			start:    0,
+			end:      nil,
+			step:     2,
+			expected: []byte("hlo"),
+		},
+
+		// Edge cases
+		{
+			name:     "empty slice",
+			target:   "hello",
+			start:    2,
+			end:      2,
+			step:     nil,
+			expected: "",
+		},
+		{
+			name:     "full slice",
+			target:   "hello",
+			start:    nil,
+			end:      nil,
+			step:     nil,
+			expected: "hello",
+		},
+
+		// Error cases
+		{
+			name:    "invalid target type",
+			target:  42,
+			start:   0,
+			end:     2,
+			step:    nil,
+			wantErr: true,
+			errMsg:  "expected array or string value, got number",
+		},
+		{
+			name:    "zero step",
+			target:  "hello",
+			start:   0,
+			end:     2,
+			step:    0,
+			wantErr: true,
+			errMsg:  "slice step cannot be zero",
+		},
+		{
+			name:    "invalid start type",
+			target:  "hello",
+			start:   "not a number",
+			end:     2,
+			step:    nil,
+			wantErr: true,
+			errMsg:  "slice start bound:",
+		},
+		{
+			name:    "invalid end type",
+			target:  "hello",
+			start:   0,
+			end:     "not a number",
+			step:    nil,
+			wantErr: true,
+			errMsg:  "slice end bound:",
+		},
+		{
+			name:    "invalid step type",
+			target:  "hello",
+			start:   0,
+			end:     2,
+			step:    "not a number",
+			wantErr: true,
+			errMsg:  "slice step:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetFn := literalFn(tt.target)
+
+			var startFn, endFn, stepFn Function
+			if tt.start != nil {
+				startFn = literalFn(tt.start)
+			}
+			if tt.end != nil {
+				endFn = literalFn(tt.end)
+			}
+			if tt.step != nil {
+				stepFn = literalFn(tt.step)
+			}
+
+			method, err := NewSliceMethod(targetFn, startFn, endFn, stepFn)
+			require.NoError(t, err)
+
+			ctx := FunctionContext{}
+			result, err := method.Exec(ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSliceHelperFunctions(t *testing.T) {
+	t.Run("normalizeSliceBounds", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			length    int64
+			start     *int64
+			end       *int64
+			step      *int64
+			wantStart int64
+			wantEnd   int64
+			wantStep  int64
+		}{
+			{
+				name:      "default values",
+				length:    10,
+				start:     nil,
+				end:       nil,
+				step:      nil,
+				wantStart: 0,
+				wantEnd:   10,
+				wantStep:  1,
+			},
+			{
+				name:      "negative step defaults",
+				length:    10,
+				start:     nil,
+				end:       nil,
+				step:      ptr(int64(-1)),
+				wantStart: 9,
+				wantEnd:   -1,
+				wantStep:  -1,
+			},
+			{
+				name:      "negative indices",
+				length:    10,
+				start:     ptr(int64(-3)),
+				end:       ptr(int64(-1)),
+				step:      nil,
+				wantStart: 7,
+				wantEnd:   9,
+				wantStep:  1,
+			},
+			{
+				name:      "out of bounds clamping",
+				length:    5,
+				start:     ptr(int64(-10)),
+				end:       ptr(int64(10)),
+				step:      nil,
+				wantStart: 0,
+				wantEnd:   5,
+				wantStep:  1,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gotStart, gotEnd, gotStep := normalizeSliceBounds(tt.length, tt.start, tt.end, tt.step)
+				assert.Equal(t, tt.wantStart, gotStart)
+				assert.Equal(t, tt.wantEnd, gotEnd)
+				assert.Equal(t, tt.wantStep, gotStep)
+			})
+		}
+	})
+
+	t.Run("sliceString", func(t *testing.T) {
+		result, err := sliceString("hello world", ptr(int64(0)), ptr(int64(5)), ptr(int64(2)))
+		require.NoError(t, err)
+		assert.Equal(t, "hlo", result)
+	})
+
+	t.Run("sliceBytes", func(t *testing.T) {
+		result, err := sliceBytes([]byte("hello"), ptr(int64(1)), ptr(int64(4)), nil)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("ell"), result)
+	})
+
+	t.Run("sliceArray", func(t *testing.T) {
+		result, err := sliceArray([]any{"a", "b", "c", "d"}, ptr(int64(1)), ptr(int64(3)), nil)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"b", "c"}, result)
+	})
+}
+
+// Helper function to create pointers to int64 values
+func ptr(i int64) *int64 {
+	return &i
+}

--- a/website/docs/guides/bloblang/about.md
+++ b/website/docs/guides/bloblang/about.md
@@ -144,6 +144,50 @@ root.new_doc.type = this.thing.(article | comment | this).type
 
 Opening brackets on a field begins a query where the context of `this` changes to value of the path it is opened upon, therefore in the above example `this` within the brackets refers to the contents of `this.thing`.
 
+## Array and String Slicing
+
+Bloblang supports Python-style bracket notation for accessing array elements and string characters, as well as slicing with optional start, end, and step parameters:
+
+### Single Element Access
+
+Access individual elements using bracket notation with an index:
+
+```coffee
+root.first_char = this.message[0]
+root.last_char = this.message[-1]
+root.first_item = this.items[0]
+root.third_item = this.items[2]
+
+# In:  {"message":"hello","items":["a","b","c","d"]}
+# Out: {"first_char":"h","last_char":"o","first_item":"a","third_item":"c"}
+```
+
+### Slice Syntax
+
+Extract slices using the colon syntax `[start:end:step]`. All parameters are optional:
+
+```coffee
+# Basic slicing with start and end
+root.substring = this.message[1:4]
+root.subarray = this.items[1:3]
+
+# Slicing from start or to end
+root.from_start = this.message[:3]
+root.to_end = this.message[2:]
+
+# Step slicing
+root.every_second = this.message[::2]
+root.reverse = this.message[::-1]
+
+# Complex slicing with all parameters
+root.complex_slice = this.items[1:5:2]
+
+# In:  {"message":"hello world","items":["a","b","c","d","e","f"]}
+# Out: {"substring":"ell","subarray":["b","c"],"from_start":"hel","to_end":"llo world","every_second":"hlowrd","reverse":"dlrow olleh","complex_slice":["b","d"]}
+```
+
+This bracket syntax works with strings, byte arrays, and regular arrays, and supports negative indexing like Python.
+
 ## Literals
 
 Bloblang supports number, boolean, string, null, array and object literals:
@@ -407,7 +451,7 @@ It's possible to execute unit tests for your Bloblang mappings using the standar
 
 1. I'm seeing `unable to reference message as structured (with 'this')` when I try to run mappings with `bento blobl`.
 
-That particular error message means the mapping is failing to parse what's being fed in as a JSON document. Make sure that the data you are feeding in is valid JSON, and also that the documents *do not* contain line breaks as `bento blobl` will parse each line individually.
+That particular error message means the mapping is failing to parse what's being fed in as a JSON document. Make sure that the data you are feeding in is valid JSON, and also that the documents _do not_ contain line breaks as `bento blobl` will parse each line individually.
 
 Why? That's a good question. Bloblang supports non-JSON formats too, so it can't delimit documents with a streaming JSON parser like tools such as `jq`, so instead it uses line breaks to determine the boundaries of each message.
 

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -526,36 +526,6 @@ root = content().reverse()
 # Out: }"sdrawkcab":"gniht"{
 ```
 
-### `slice`
-
-Extract a slice from a string by specifying two indices, a low and high bound, which selects a half-open range that includes the first character, but excludes the last one. If the second index is omitted then it defaults to the length of the input sequence.
-
-#### Parameters
-
-**`low`** &lt;integer&gt; The low bound, which is the first element of the selection, or if negative selects from the end.  
-**`high`** &lt;(optional) integer&gt; An optional high bound.  
-
-#### Examples
-
-
-```coffee
-root.beginning = this.value.slice(0, 2)
-root.end = this.value.slice(4)
-
-# In:  {"value":"foo bar"}
-# Out: {"beginning":"fo","end":"bar"}
-```
-
-A negative low index can be used, indicating an offset from the end of the sequence. If the low index is greater than the length of the sequence then an empty result is returned.
-
-```coffee
-root.last_chunk = this.value.slice(-4)
-root.the_rest = this.value.slice(0, -4)
-
-# In:  {"value":"foo bar"}
-# Out: {"last_chunk":" bar","the_rest":"foo"}
-```
-
 ### `slug`
 
 :::caution BETA
@@ -2620,36 +2590,6 @@ Introduced in version 1.0.0.
 
 **`changelog`** &lt;unknown&gt; The changelog to apply.  
 
-### `slice`
-
-Extract a slice from an array by specifying two indices, a low and high bound, which selects a half-open range that includes the first element, but excludes the last one. If the second index is omitted then it defaults to the length of the input sequence.
-
-#### Parameters
-
-**`low`** &lt;integer&gt; The low bound, which is the first element of the selection, or if negative selects from the end.  
-**`high`** &lt;(optional) integer&gt; An optional high bound.  
-
-#### Examples
-
-
-```coffee
-root.beginning = this.value.slice(0, 2)
-root.end = this.value.slice(4)
-
-# In:  {"value":["foo","bar","baz","buz","bev"]}
-# Out: {"beginning":["foo","bar"],"end":["bev"]}
-```
-
-A negative low index can be used, indicating an offset from the end of the sequence. If the low index is greater than the length of the sequence then an empty result is returned.
-
-```coffee
-root.last_chunk = this.value.slice(-2)
-root.the_rest = this.value.slice(0, -2)
-
-# In:  {"value":["foo","bar","baz","buz","bev"]}
-# Out: {"last_chunk":["buz","bev"],"the_rest":["foo","bar","baz"]}
-```
-
 ### `sort`
 
 Attempts to sort the values of an array in increasing order. The type of all values must match in order for the ordering to succeed. Supports string and number values.
@@ -3973,6 +3913,46 @@ Attempts to parse a string as a timestamp following a specified strptime-compati
 #### Parameters
 
 **`format`** &lt;string&gt; The format of the target string.  
+
+### `slice`
+
+Extract a slice from a string by specifying two indices, a low and high bound, which selects a half-open range that includes the first character, but excludes the last one. If the second index is omitted then it defaults to the length of the input sequence. **This method is deprecated, use bracket syntax instead: `this.value[0:2]` instead of `this.value.slice(0, 2)`.**
+
+#### Parameters
+
+**`low`** &lt;integer&gt; The low bound, which is the first element of the selection, or if negative selects from the end.  
+**`high`** &lt;(optional) integer&gt; An optional high bound.  
+
+#### Examples
+
+
+```coffee
+# Deprecated - use bracket syntax instead
+root.beginning = this.value.slice(0, 2)
+root.end = this.value.slice(4)
+
+# New bracket syntax (recommended)
+root.beginning = this.value[0:2]  
+root.end = this.value[4:]
+
+# In:  {"value":"foo bar"}
+# Out: {"beginning":"fo","end":"bar"}
+```
+
+A negative low index can be used, indicating an offset from the end of the sequence. If the low index is greater than the length of the sequence then an empty result is returned. **Use bracket syntax instead: `this.value[-4:]` instead of `this.value.slice(-4)`.**
+
+```coffee
+# Deprecated - use bracket syntax instead
+root.last_chunk = this.value.slice(-4)
+root.the_rest = this.value.slice(0, -4)
+
+# New bracket syntax (recommended)
+root.last_chunk = this.value[-4:]
+root.the_rest = this.value[:-4]
+
+# In:  {"value":"foo bar"}
+# Out: {"last_chunk":" bar","the_rest":"foo"}
+```
 
 [field_paths]: /docs/configuration/field_paths
 [methods.encode]: #encode


### PR DESCRIPTION
## Add support for Python-style bracket notation for array/string slicing and indexing:
  - Support single element access: `this.value[i]`
  - Support full slice syntax: `this.value[start:end:step]`
  - Deprecate existing `.slice()` method with migration guidance
  - Documentation updated with examples and deprecation warnings
  - New bracket syntax tests added for index and slice methods
 
### Examples

#### Single Element Access
```coffee
root.first_char = this.message[0]      # "h" from "hello"
root.last_char = this.message[-1]      # "o" from "hello"
root.third_item = this.items[2]        # "c" from ["a","b","c","d"]
```

Basic Slicing
```coffee

root.substring = this.message[1:4]     # "ell" from "hello"
root.subarray = this.items[1:3]        # ["b","c"] from ["a","b","c","d"]
```

#### Flexible Slice Syntax
```coffee
# From start or to end
root.prefix = this.message[:3]         # "hel" from "hello"
root.suffix = this.message[2:]         # "llo" from "hello"

# Step slicing
root.every_second = this.message[::2]  # "hlo" from "hello"
root.reverse = this.message[::-1]      # "olleh" from "hello"

# Complex slicing with all parameters
root.stepped = this.items[1:5:2]       # ["b","d"] from ["a","b","c","d","e"]
```

#### Migration from Deprecated .slice() Method

```coffee
# Old (deprecated)
root.old_way = this.value.slice(0, 3)

# New (recommended)  
root.new_way = this.value[0:3]
```

References issue [#429](https://github.com/warpstreamlabs/bento/issues/429)