### PR TITLE
refactor(sql/conn): Rework SQL connection builder for AWS and Azure

### DIFF
--- a/internal/impl/sql/aws/aws.go
+++ b/internal/impl/sql/aws/aws.go
@@ -21,7 +21,7 @@ func init() {
 		return "", nil
 	}
 
-	sql.AWSGetCredentialsGeneratorFn = func(conf *service.ParsedConfig) (func(dsn, driver string) (password string, err error), error) {
+	fn := func(conf *service.ParsedConfig) (sql.DSNBuilder, error) {
 
 		awsEnabled, err := sql.IsAWSEnabled(conf)
 		if err != nil {
@@ -78,6 +78,8 @@ func init() {
 
 		return noop, nil
 	}
+
+	sql.SetAWSGetCredentialsGeneratorFn(fn)
 }
 
 //------------------------------------------------------------------------------

--- a/internal/impl/sql/azure/azure.go
+++ b/internal/impl/sql/azure/azure.go
@@ -14,11 +14,11 @@ import (
 )
 
 func init() {
-	var noop sql.AzureDSNBuilder = func(dsn, driver string) (builtDSN string, err error) {
+	noop := func(dsn, driver string) (builtDSN string, err error) {
 		return dsn, nil
 	}
 
-	sql.AzureGetCredentialsGeneratorFn = func(pConf *service.ParsedConfig) (sql.AzureDSNBuilder, error) {
+	fn := func(pConf *service.ParsedConfig) (sql.DSNBuilder, error) {
 		nsConf := pConf.Namespace("azure")
 		entraEnabled, err := nsConf.FieldBool("entra_enabled")
 		if err != nil {
@@ -39,6 +39,8 @@ func init() {
 
 		return wrapDsnBuilder, nil
 	}
+
+	sql.SetAzureGetCredentialsGeneratorFn(fn)
 }
 
 func BuildEntraDsn(dsn, driver string, getTokenOptions func() (policy.TokenRequestOptions, error)) (builtDsn string, err error) {

--- a/internal/impl/sql/conn_aws.go
+++ b/internal/impl/sql/conn_aws.go
@@ -2,12 +2,17 @@ package sql
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
 const (
 	SQLConnLintRule = `root = match {this.iam_enabled && this.exists("secret_name") => "both iam_enabled and secret_name cannot be set"}`
+)
+
+var (
+	awsGetCredentialsGeneratorFn func(*service.ParsedConfig) (DSNBuilder, error)
 )
 
 func IsAWSEnabled(c *service.ParsedConfig) (enabled bool, err error) {
@@ -19,8 +24,30 @@ func IsAWSEnabled(c *service.ParsedConfig) (enabled bool, err error) {
 	return false, nil
 }
 
-// AWSGetCredentialsGeneratorFn is populated with the child `aws` package when imported.
-var AWSGetCredentialsGeneratorFn = func(c *service.ParsedConfig) (fn func(dsn, driver string) (password string, err error), err error) {
+var (
+	getAWSCredentials = sync.OnceValues(initAWSCredentials)
+)
+
+func initAWSCredentials() (func(*service.ParsedConfig) (DSNBuilder, error), error) {
+	if awsGetCredentialsGeneratorFn != nil {
+		return awsGetCredentialsGeneratorFn, nil
+	}
+	return defaultAWSGetCredentialsGenerator, nil
+}
+
+func AWSGetCredentialsGeneratorFn(c *service.ParsedConfig) (DSNBuilder, error) {
+	genFn, err := getAWSCredentials()
+	if err != nil {
+		return nil, err
+	}
+	return genFn(c)
+}
+
+func SetAWSGetCredentialsGeneratorFn(fn func(*service.ParsedConfig) (DSNBuilder, error)) {
+	awsGetCredentialsGeneratorFn = fn
+}
+
+func defaultAWSGetCredentialsGenerator(c *service.ParsedConfig) (DSNBuilder, error) {
 	awsEnabled, err := IsAWSEnabled(c)
 	if err != nil {
 		return nil, err
@@ -28,9 +55,7 @@ var AWSGetCredentialsGeneratorFn = func(c *service.ParsedConfig) (fn func(dsn, d
 	if awsEnabled {
 		return nil, errors.New("unable to configure AWS authentication as this binary does not import components/aws")
 	}
-	return
-}
-
-var BuildAwsDsn = func(dsn, driver string) (newDsn string, err error) {
-	return dsn, nil
+	return func(dsn, driver string) (string, error) {
+		return dsn, nil
+	}, nil
 }

--- a/internal/impl/sql/conn_fields.go
+++ b/internal/impl/sql/conn_fields.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -12,6 +13,8 @@ import (
 	"github.com/warpstreamlabs/bento/internal/impl/aws/config"
 	"github.com/warpstreamlabs/bento/public/service"
 )
+
+type DSNBuilder func(dsn, driver string) (builtDSN string, err error)
 
 var driverField = service.NewStringEnumField("driver", "mysql", "postgres", "clickhouse", "mssql", "sqlite", "oracle", "snowflake", "trino", "gocosmos", "spanner").
 	Description("A database [driver](#drivers) to use.")
@@ -189,6 +192,8 @@ type connSettings struct {
 	initFileStatements [][2]string // (path,statement)
 	initStatement      string
 	initVerifyConn     bool
+
+	getCredentials func(string, string) (string, error)
 }
 
 func (c *connSettings) apply(ctx context.Context, db *sql.DB, log *service.Logger) {
@@ -212,7 +217,31 @@ func (c *connSettings) apply(ctx context.Context, db *sql.DB, log *service.Logge
 				log.Debug("Successfully ran init_statement")
 			}
 		}
+
 	})
+}
+
+func getDsnBuilder(conf *service.ParsedConfig) (DSNBuilder, error) {
+	awsEnabled, err := IsAWSEnabled(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	azureEnabled, err := IsAzureEnabled(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case awsEnabled && azureEnabled:
+		return nil, errors.New("cannot enable both AWS and Azure authentication")
+	case awsEnabled:
+		return AWSGetCredentialsGeneratorFn(conf)
+	case azureEnabled:
+		return AzureGetCredentialsGeneratorFn(conf)
+	default:
+		return func(dsn, driver string) (string, error) { return dsn, nil }, nil
+	}
 }
 
 func connSettingsFromParsed(
@@ -277,20 +306,8 @@ func connSettingsFromParsed(
 		}
 	}
 
-	awsEnabled, err := IsAWSEnabled(conf)
-	if err != nil {
+	if c.getCredentials, err = getDsnBuilder(conf); err != nil {
 		return
-	}
-	if awsEnabled {
-		if BuildAwsDsn, err = AWSGetCredentialsGeneratorFn(conf); err != nil {
-			return
-		}
-	}
-
-	if conf.Contains("azure", "entra_enabled") {
-		if BuildAzureDsn, err = AzureGetCredentialsGeneratorFn(conf); err != nil {
-			return
-		}
 	}
 
 	return
@@ -338,22 +355,13 @@ func sqlOpenWithReworks(ctx context.Context, logger *service.Logger, driver, dsn
 		logger.Warnf("Detected old-style Clickhouse Data Source Name: '%v', replacing with new style: '%v'", dsn, updatedDSN)
 	}
 
-	updatedDSN, err = BuildAwsDsn(dsn, driver)
+	updatedDSN, err = connSettings.getCredentials(dsn, driver)
 	if err != nil {
 		return nil, err
 	}
 
 	if updatedDSN != dsn {
 		logger.Info("Updated dsn with info from AWS")
-	}
-
-	updatedDSN, err = BuildAzureDsn(dsn, driver)
-	if err != nil {
-		return nil, err
-	}
-
-	if updatedDSN != dsn {
-		logger.Info("Updated dsn with info from Azure")
 	}
 
 	db, err := sql.Open(driver, updatedDSN)


### PR DESCRIPTION
## Motivation

There is a race condition when initialising multiple sql components as the global `var AWSGetCredentialsGeneratorFn` can be called from multiple goroutines on connect.

## Changes

- Rework the `sql/azure` and `sql/aws` subpackages to instead use `sync.Values` and no longer make unsafe-references a global variable.