### PR TITLE
fix(kafka_franz): Validate non-zero seed_brokers attribute

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -22,6 +22,8 @@ import (
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
+var errInvalidSeedBrokerCount = errors.New("you must provide at least one address in 'seed_brokers'")
+
 func franzKafkaInputConfig() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Beta().
@@ -291,6 +293,10 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 	}
 	for _, b := range brokerList {
 		f.seedBrokers = append(f.seedBrokers, strings.Split(b, ",")...)
+	}
+
+	if len(f.seedBrokers) == 0 {
+		return nil, errInvalidSeedBrokerCount
 	}
 
 	if f.autoOffsetReset, err = getOffsetReset(conf); err != nil {

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -22,7 +22,10 @@ import (
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
-var errInvalidSeedBrokerCount = errors.New("you must provide at least one address in 'seed_brokers'")
+var (
+	errInvalidSeedBrokerCount = errors.New("you must provide at least one address in 'seed_brokers'")
+	errInvalidSeedBrokerValue = errors.New("seed broker address cannot be empty")
+)
 
 func franzKafkaInputConfig() *service.ConfigSpec {
 	return service.NewConfigSpec().
@@ -293,6 +296,12 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 	}
 	for _, b := range brokerList {
 		f.seedBrokers = append(f.seedBrokers, strings.Split(b, ",")...)
+	}
+
+	for _, b := range f.seedBrokers {
+		if b == "" {
+			return nil, errInvalidSeedBrokerValue
+		}
 	}
 
 	if len(f.seedBrokers) == 0 {

--- a/internal/impl/kafka/input_kafka_franz_test.go
+++ b/internal/impl/kafka/input_kafka_franz_test.go
@@ -20,6 +20,64 @@ import (
 	"github.com/warpstreamlabs/bento/public/service/integration"
 )
 
+func TestInputKafkaFranzConfig(t *testing.T) {
+	testCases := []struct {
+		name        string
+		conf        string
+		errContains string
+	}{
+		{
+			name: "single broker",
+			conf: `
+seed_brokers: [ broker_1 ]
+topics: [ test ]
+consumer_group: test
+`,
+		},
+		{
+			name: "multiple brokers",
+			conf: `
+seed_brokers: [ broker_1, broker_2 ]
+topics: [ test ]
+consumer_group: test
+`,
+		},
+		{
+			name: "multiple nested brokers",
+			conf: `
+seed_brokers: [ "broker_1,broker_2", "broker_3" ]
+topics: [ test ]
+consumer_group: test
+`,
+		},
+		{
+			name: "fail no brokers",
+			conf: `
+seed_brokers: [ ]
+topics: [ test ]
+consumer_group: test
+`,
+			errContains: "you must provide at least one address in 'seed_brokers'",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			conf, err := franzKafkaInputConfig().ParseYAML(test.conf, nil)
+			require.NoError(t, err)
+
+			_, err = newFranzKafkaReaderFromConfig(conf, service.MockResources())
+			if test.errContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+			}
+		})
+	}
+}
+
 func TestInputKafkaFranzRetriableError(t *testing.T) {
 	conf, err := franzKafkaInputConfig().ParseYAML(`
 seed_brokers: [ localhost:9092 ]

--- a/internal/impl/kafka/input_kafka_franz_test.go
+++ b/internal/impl/kafka/input_kafka_franz_test.go
@@ -59,6 +59,14 @@ consumer_group: test
 `,
 			errContains: "you must provide at least one address in 'seed_brokers'",
 		},
+		{
+			name: "no seed broker should be empty string",
+			conf: `
+seed_brokers: [ "", "broker_1" ]
+topic: foo
+`,
+			errContains: "seed broker address cannot be empty",
+		},
 	}
 
 	for _, test := range testCases {

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -175,6 +175,10 @@ func newFranzKafkaWriterFromConfig(conf *service.ParsedConfig, log *service.Logg
 		f.seedBrokers = append(f.seedBrokers, strings.Split(b, ",")...)
 	}
 
+	if len(f.seedBrokers) == 0 {
+		return nil, errInvalidSeedBrokerCount
+	}
+
 	if f.topic, err = conf.FieldInterpolatedString("topic"); err != nil {
 		return nil, err
 	}

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -175,6 +175,12 @@ func newFranzKafkaWriterFromConfig(conf *service.ParsedConfig, log *service.Logg
 		f.seedBrokers = append(f.seedBrokers, strings.Split(b, ",")...)
 	}
 
+	for _, b := range f.seedBrokers {
+		if b == "" {
+			return nil, errInvalidSeedBrokerValue
+		}
+	}
+
 	if len(f.seedBrokers) == 0 {
 		return nil, errInvalidSeedBrokerCount
 	}

--- a/internal/impl/kafka/output_kafka_franz_test.go
+++ b/internal/impl/kafka/output_kafka_franz_test.go
@@ -83,6 +83,14 @@ topic: foo
 `,
 			errContains: "you must provide at least one address in 'seed_brokers'",
 		},
+		{
+			name: "no seed broker should be empty string",
+			conf: `
+seed_brokers: [ "", "broker_1" ]
+topic: foo
+`,
+			errContains: "seed broker address cannot be empty",
+		},
 	}
 
 	for _, test := range testCases {

--- a/internal/impl/kafka/output_kafka_franz_test.go
+++ b/internal/impl/kafka/output_kafka_franz_test.go
@@ -68,3 +68,36 @@ kafka_franz:
 		})
 	}
 }
+
+func TestOutputKafkaFranzConfig(t *testing.T) {
+	testCases := []struct {
+		name        string
+		conf        string
+		errContains string
+	}{
+		{
+			name: "at least one seed broker should be defined",
+			conf: `
+seed_brokers: [ ]
+topic: foo
+`,
+			errContains: "you must provide at least one address in 'seed_brokers'",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			conf, err := franzKafkaOutputConfig().ParseYAML(test.conf, nil)
+			require.NoError(t, err)
+
+			_, err = newFranzKafkaWriterFromConfig(conf, service.MockResources().Logger())
+			if test.errContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Handles the edge-case where no `seed_brokers` are set in the Bento config. 

In addition, since the franz-go library allows a new client to be initialised without any `seed_brokers`, the client ends up not connecting to any broker -- resulting in a no reads or writes taking place silently.

## Changes
- Returns an error in the `input/kafka_franz` and `output/kafka_franz` components when no seed brokers are defined.