### PR TITLE
docs(example): change inject_tracing_map config example

### DIFF
--- a/public/service/config_inject_tracing.go
+++ b/public/service/config_inject_tracing.go
@@ -18,7 +18,7 @@ func NewInjectTracingSpanMappingField() *ConfigField {
 	return NewBloblangField(itsField).
 		Description("EXPERIMENTAL: A [Bloblang mapping](/docs/guides/bloblang/about) used to inject an object containing tracing propagation information into outbound messages. The specification of the injected fields will match the format used by the service wide tracer.").
 		Examples(
-			`meta = @.merge(this)`,
+			`meta = @.assign(this)`,
 			`root.meta.span = this`,
 		).
 		Version("1.0.0").

--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -97,7 +97,7 @@ output:
     static_headers: {} # No default (optional)
     metadata:
       exclude_prefixes: []
-    inject_tracing_map: meta = @.merge(this) # No default (optional)
+    inject_tracing_map: meta = @.assign(this) # No default (optional)
     max_in_flight: 64
     idempotent_write: false
     ack_replicas: false
@@ -629,7 +629,7 @@ Requires version 1.0.0 or newer
 ```yml
 # Examples
 
-inject_tracing_map: meta = @.merge(this)
+inject_tracing_map: meta = @.assign(this)
 
 inject_tracing_map: root.meta.span = this
 ```

--- a/website/docs/components/outputs/nats.md
+++ b/website/docs/components/outputs/nats.md
@@ -66,7 +66,7 @@ output:
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
-    inject_tracing_map: meta = @.merge(this) # No default (optional)
+    inject_tracing_map: meta = @.assign(this) # No default (optional)
 ```
 
 </TabItem>
@@ -421,7 +421,7 @@ Requires version 4.23.0 or newer
 ```yml
 # Examples
 
-inject_tracing_map: meta = @.merge(this)
+inject_tracing_map: meta = @.assign(this)
 
 inject_tracing_map: root.meta.span = this
 ```

--- a/website/docs/components/outputs/nats_jetstream.md
+++ b/website/docs/components/outputs/nats_jetstream.md
@@ -68,7 +68,7 @@ output:
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
-    inject_tracing_map: meta = @.merge(this) # No default (optional)
+    inject_tracing_map: meta = @.assign(this) # No default (optional)
 ```
 
 </TabItem>
@@ -426,7 +426,7 @@ Requires version 4.23.0 or newer
 ```yml
 # Examples
 
-inject_tracing_map: meta = @.merge(this)
+inject_tracing_map: meta = @.assign(this)
 
 inject_tracing_map: root.meta.span = this
 ```

--- a/website/docs/components/outputs/nats_stream.md
+++ b/website/docs/components/outputs/nats_stream.md
@@ -62,7 +62,7 @@ output:
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
-    inject_tracing_map: meta = @.merge(this) # No default (optional)
+    inject_tracing_map: meta = @.assign(this) # No default (optional)
 ```
 
 </TabItem>
@@ -359,7 +359,7 @@ Requires version 4.23.0 or newer
 ```yml
 # Examples
 
-inject_tracing_map: meta = @.merge(this)
+inject_tracing_map: meta = @.assign(this)
 
 inject_tracing_map: root.meta.span = this
 ```


### PR DESCRIPTION
### 📝 Description
This PR corrects the documentation example for propagating tracing spans with **Kafka** or **NATS**.

---

#### Problem
The current example shows:
```bloblang
meta = @.merge(this)
```

According to the Bloblang specification, the `merge` method **merges objects when a target already exists**.  
This can cause problems when `traceparent` is already present in the metadata.

For example, suppose the metadata already contains:
```json
{
  "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
}
```

After applying `@.merge(this)` with a new context:
```json
{
  "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dddddddddddddddd-01"
}
```

The result becomes:
```json
{
  "traceparent": [
    "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
    "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dddddddddddddddd-01"
  ]
}
```

This is unintended—`traceparent` should be a single value, not an array.

---

#### Fix
Updated the example to use:
```bloblang
meta = @.assign(this)
```

With `assign`, the new context correctly overwrites the old one:
```json
{
  "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dddddddddddddddd-01"
}
```

---

#### Impact
- **Documentation only** (documents are generated with `make docs`).  
- Prevents confusion and incorrect usage when propagating tracing spans.  
