### PR TITLE
add ping to sql output components

### DIFF
--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -232,6 +232,13 @@ func (s *sqlInsertOutput) WriteBatch(ctx context.Context, batch service.MessageB
 	s.dbMut.RLock()
 	defer s.dbMut.RUnlock()
 
+	if s.driver != "trino" {
+		if err := s.db.PingContext(ctx); err != nil {
+			s.db = nil
+			return service.ErrNotConnected
+		}
+	}
+
 	insertBuilder := s.builder
 
 	var tx *sql.Tx

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -208,6 +208,13 @@ func (s *sqlRawOutput) WriteBatch(ctx context.Context, batch service.MessageBatc
 	s.dbMut.RLock()
 	defer s.dbMut.RUnlock()
 
+	if s.driver != "trino" {
+		if err := s.db.PingContext(ctx); err != nil {
+			s.db = nil
+			return service.ErrNotConnected
+		}
+	}
+
 	var executor *service.MessageBatchBloblangExecutor
 	if s.argsMapping != nil {
 		executor = batch.BloblangExecutor(s.argsMapping)


### PR DESCRIPTION
PR adds a 'Ping' check to the WriteBatch function of the sql output components - so if a connection cannot be established we return a service.ErrNotConnected. Bento will then go into a retry loop exec'ing the Connect function, it's necessary to use the Connect func because we might need to rebuild the DSN (i.e. RDS IAM etc.) 