### PR TITLE
feat(service/batch): Reduce allocations when interpolating across MessageBatch

### DIFF
--- a/public/service/message.go
+++ b/public/service/message.go
@@ -573,11 +573,7 @@ func (b MessageBatch) BloblangMutate(index int, blobl *bloblang.Executor) (*Mess
 // member of a batch individually, you should instead use an
 // InterpolationExecutor.
 func (b MessageBatch) TryInterpolatedString(index int, i *InterpolatedString) (string, error) {
-	msg := make(message.Batch, len(b))
-	for i, m := range b {
-		msg[i] = m.part
-	}
-	return i.expr.String(index, msg)
+	return i.TryString(b[index])
 }
 
 // TryInterpolatedBytes resolves an interpolated string expression on a message
@@ -591,11 +587,7 @@ func (b MessageBatch) TryInterpolatedString(index int, i *InterpolatedString) (s
 // member of a batch individually, you should instead use an
 // InterpolationExecutor.
 func (b MessageBatch) TryInterpolatedBytes(index int, i *InterpolatedString) ([]byte, error) {
-	msg := make(message.Batch, len(b))
-	for i, m := range b {
-		msg[i] = m.part
-	}
-	return i.expr.Bytes(index, msg)
+	return i.TryBytes(b[index])
 }
 
 // InterpolatedString resolves an interpolated string expression on a message


### PR DESCRIPTION

Removes the unnecessary slice allocation when doing a `TryInterpolatedString` 

Machine info:
```
goos: darwin
goarch: arm64
pkg: github.com/warpstreamlabs/bento/public/service
cpu: Apple M3 Pro
```

Old benchmarks:
```
BenchmarkMessageBatchTryInterpolatedString/Simple-12               59151             20234 ns/op            8304 B/op          5 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Simple-12               57394             21064 ns/op            8304 B/op          5 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Simple-12               63255             19215 ns/op            8304 B/op          5 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Simple-12               63088             18932 ns/op            8304 B/op          5 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Simple-12               64581             18803 ns/op            8304 B/op          5 allocs/op
BenchmarkMessageBatchTryInterpolatedString/WithMeta-12             59874             20100 ns/op            8448 B/op         10 allocs/op
BenchmarkMessageBatchTryInterpolatedString/WithMeta-12             59454             20124 ns/op            8448 B/op         10 allocs/op
BenchmarkMessageBatchTryInterpolatedString/WithMeta-12             60351             20084 ns/op            8448 B/op         10 allocs/op
BenchmarkMessageBatchTryInterpolatedString/WithMeta-12             59650             20134 ns/op            8448 B/op         10 allocs/op
BenchmarkMessageBatchTryInterpolatedString/WithMeta-12             59336             20138 ns/op            8448 B/op         10 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Complex-12              59719             20221 ns/op            8552 B/op         14 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Complex-12              60336             20270 ns/op            8552 B/op         14 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Complex-12              59388             20285 ns/op            8552 B/op         14 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Complex-12              59032             20285 ns/op            8552 B/op         14 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Complex-12              59266             20176 ns/op            8552 B/op         14 allocs/op
```

New benchmarks:

```
BenchmarkMessageBatchTryInterpolatedString/Simple-12             2283337               522.0 ns/op            88 B/op          3 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Simple-12             2286046               520.8 ns/op            88 B/op          3 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Simple-12             2290999               524.9 ns/op            88 B/op          3 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Simple-12             2293249               521.6 ns/op            88 B/op          3 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Simple-12             2296100               521.9 ns/op            88 B/op          3 allocs/op
BenchmarkMessageBatchTryInterpolatedString/WithMeta-12            753454              1578 ns/op             232 B/op          8 allocs/op
BenchmarkMessageBatchTryInterpolatedString/WithMeta-12            764316              1566 ns/op             232 B/op          8 allocs/op
BenchmarkMessageBatchTryInterpolatedString/WithMeta-12            765740              1555 ns/op             232 B/op          8 allocs/op
BenchmarkMessageBatchTryInterpolatedString/WithMeta-12            774807              1552 ns/op             232 B/op          8 allocs/op
BenchmarkMessageBatchTryInterpolatedString/WithMeta-12            771722              1569 ns/op             232 B/op          8 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Complex-12             686871              1760 ns/op             336 B/op         12 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Complex-12             676851              1758 ns/op             336 B/op         12 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Complex-12             695480              1756 ns/op             336 B/op         12 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Complex-12             629857              1775 ns/op             336 B/op         12 allocs/op
BenchmarkMessageBatchTryInterpolatedString/Complex-12             694459              1757 ns/op             336 B/op         12 allocs/op
```