### PR TITLE
test: Use `require.Eventually` to fix flaky `TestHealthCheck`

### DIFF
--- a/internal/stream/type_test.go
+++ b/internal/stream/type_test.go
@@ -229,5 +229,13 @@ output:
 
 	assert.NoError(t, strm.StopUnordered(stopCtx))
 
-	validateHealthCheckResponse(t, mockAPIReg.server.URL, "Stream terminated\n")
+	require.Eventually(t, func() bool {
+		res, err := http.Get(mockAPIReg.server.URL + "/ready")
+		require.NoError(t, err)
+		defer res.Body.Close()
+
+		data, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		return string(data) == "Stream terminated\n"
+	}, 5*time.Second, 100*time.Millisecond, "Expected stream to be terminated")
 }


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes [#403](https://github.com/warpstreamlabs/bento/issues/403)

### Problem

The TestHealthCheck test fails intermittently on CI due to a timing race condition.

The test's final assertion expects the stream's health check endpoint to return `Stream terminated\n` immediately after calling `strm.StopUnordered()`. However, `StopUnordered()` is an asynchronous operation, meaning the final status update may not complete instantly.

In CI, the test can assert the status while the stream is in an intermediate state (e.g., `input not connected\noutput not connected\n`), leading to a failure.

### Solution

This commit fixes the flakiness by using `require.Eventually` to assert the final state of the health check.
Instead of asserting immediately, the test now continuously polls the health check endpoint every 100 milliseconds for up to 5 seconds. This gives the asynchronous shutdown process enough time to complete and for the stream to transition to its final `Stream terminated\n` state.

### Verification

The test now correctly and consistently passes on my local machine after running it 100 times using a loop to simulate the flaky behavior.
```bash
for i in {1..100}; do go test -v ./internal/stream -run ^TestHealthCheck$; done 
```
I have also executed the following command before submitting the PR
```
make test
make lint
make fmt
```