### PR TITLE
test: add `time.sleep()` to resolve race condition in `TestRetryParallel`

### DIFF
--- a/internal/impl/pure/output_retry_test.go
+++ b/internal/impl/pure/output_retry_test.go
@@ -302,7 +302,7 @@ retry:
 
 	sendForRetry("second", tChan, resChan2, t)
 	expectFromRetry(component.ErrFailedSend, mOut.TChan, t, "first", "second")
-
+	time.Sleep(50 * time.Millisecond)
 	select {
 	case tChan <- message.NewTransaction(nil, nil):
 		t.Fatal("Accepted transaction during retry loop")


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes [#375](https://github.com/warpstreamlabs/bento/issues/375)

### Problem
The root cause is a race condition between the `loop()` goroutine (from `output_retry.go`) and the background handler goroutines that increment the `errLooped` counter when they receive an error.

The `TestRetryParallel` function in `output_retry_test.go` is designed to verify that the input channel blocks new messages when a retry is in progress. The flakiness occurs because the `loop()` goroutine can execute its `errLooped > 0` check before the handler goroutine has had time to increment `errLooped` after receiving a mock failure.

### Solution
To resolve the problem, this solution adds a 50-millisecond delay (`time.Sleep`) before the test asserts that the input channel is blocked.
This delay provides a sufficient window for the entire sequence of events to complete:
1. The background handler goroutines in `output_retry.go` have time to run and increment the `errLooped` counter after receiving the mock failures.
2. the loop() goroutine in `output_retry.go` has time to observe the updated counter and change its behavior to block the input channel.

In this way, when `TestRetryParallel` checks the input channel (`tChan`), it is correctly blocked, which resolves the race condition and stabilizes the test.

### Verification
The test now correctly and consistently passes on my local machine after running it 100 times using a loop to simulate the flaky behavior. In addition, after running 100 times, the TestRetryParallel test took an average of 1.55 seconds to finish, which is only 0.05 seconds longer on average than without the time.Sleep().
```bash
go test -v -race ./internal/impl/pure -run ^TestRetryParallel$ -count=100
```
I have also executed the following command before submitting the PR
```
make test
make lint
make fmt
```

### Misc
I did not choose `require.Eventually` to fix this issue because this approach would pollute the channel every time a new message is successfully sent during a polling interval.