### PR TITLE
feat(metrics): use default Prometheus registry

### DIFF
--- a/website/docs/components/metrics/prometheus.md
+++ b/website/docs/components/metrics/prometheus.md
@@ -56,6 +56,7 @@ metrics:
       username: ""
       password: ""
     file_output_path: ""
+    use_default_registry: false
   mapping: ""
 ```
 
@@ -190,6 +191,14 @@ An optional file path to write all prometheus metrics on service shutdown.
 
 Type: `string`  
 Default: `""`  
+
+### `use_default_registry`
+
+Whether to use the same Prometheus registry as the main process or create a new one. Most useful when using the StreamBuilder API and you want the stream metrics to be scraped from the same port as the metrics of the parent process.
+
+
+Type: `bool`  
+Default: `false`  
 
 ## Push Gateway
 


### PR DESCRIPTION
Adds a `use_default_registry` field to the Prometheus metrics config.

This solves a problem when using the StreamBuilder API, where the parent Go application exposes metrics on one port, but the Bento stream exposes its metrics on a different port. To simplify monitoring setup by only needing to scrape a single port, setting this field to true will cause Bento to use the default Prometheus registry rather than creating its own.

Resolves #486 