### PR TITLE
feat: expose readiness from StreamBuilder API

### DIFF
--- a/public/service/stream.go
+++ b/public/service/stream.go
@@ -181,14 +181,13 @@ func (s *Stream) Stop(ctx context.Context) (err error) {
 }
 
 // IsReady returns a boolean indicating whether both the input and output layers
-// of the stream are connected. If the stream has not yet been run, an error is
-// returned.
-func (s *Stream) IsReady() (bool, error) {
+// of the stream are connected.
+func (s *Stream) IsReady() bool {
 	s.strmMut.Lock()
 	strm := s.strm
 	s.strmMut.Unlock()
 	if strm == nil {
-		return false, errors.New("stream has not been run yet")
+		return false
 	}
-	return strm.IsReady(), nil
+	return strm.IsReady()
 }

--- a/public/service/stream_builder_test.go
+++ b/public/service/stream_builder_test.go
@@ -62,15 +62,13 @@ generate:
 	strm, err := b.Build()
 	require.NoError(t, err)
 
-	ready, err := strm.IsReady()
-	require.ErrorContains(t, err, "stream has not been run yet")
+	ready := strm.IsReady()
 	require.False(t, ready)
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
 		require.Eventually(t, func() bool {
-			ready, err = strm.IsReady()
-			require.NoError(t, err)
+			ready = strm.IsReady()
 			return ready
 		}, time.Second*5, time.Millisecond*10)
 


### PR DESCRIPTION
Adds an `IsReady()` method to the public `Stream` interface. This allows callers using the Go `StreamBuilder` API to programmatically determine if the stream is active without needing to run the HTTP server.

Resolves #493 