### PR TITLE
fix(ci): bump go version with GitHub action for WASM build

### DIFF
--- a/.github/workflows/deploy-docsite.yml
+++ b/.github/workflows/deploy-docsite.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.25"
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Motivation

- Aligns the WASM build GH action with Bento Golang version, allowing docsite to deploy.