### PR TITLE
fix(sql/output): Race condition on reconnect

### DIFF
--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -3,6 +3,8 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -220,8 +222,12 @@ func (s *sqlInsertOutput) Connect(ctx context.Context) error {
 		<-s.shutSig.HardStopChan()
 
 		s.dbMut.Lock()
-		_ = s.db.Close()
-		s.dbMut.Unlock()
+		defer s.dbMut.Unlock()
+
+		if s.db != nil {
+			_ = s.db.Close()
+			s.db = nil
+		}
 
 		s.shutSig.TriggerHasStopped()
 	}()
@@ -229,14 +235,27 @@ func (s *sqlInsertOutput) Connect(ctx context.Context) error {
 }
 
 func (s *sqlInsertOutput) WriteBatch(ctx context.Context, batch service.MessageBatch) error {
+	err := s.writeBatch(ctx, batch)
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, driver.ErrBadConn) {
+		s.dbMut.Lock()
+		s.db = nil
+		s.dbMut.Unlock()
+		return service.ErrNotConnected
+	}
+
+	return err
+}
+
+func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageBatch) error {
 	s.dbMut.RLock()
 	defer s.dbMut.RUnlock()
 
-	if s.driver != "trino" {
-		if err := s.db.PingContext(ctx); err != nil {
-			s.db = nil
-			return service.ErrNotConnected
-		}
+	if s.db == nil {
+		return service.ErrNotConnected
 	}
 
 	insertBuilder := s.builder


### PR DESCRIPTION
## Motivation

Fixes a race condition where `PingContext` failing sets sets the stores `*sql.DB` to `nil` without proper checks. This approach replaces the `PingContext` approach to instead rely on the `driver.ErrBadConn` as a signal that the component's connection to the upstream DB is failing.

## Changes

- Adds a `writeBatch` function for both `sql_insert` and `sql_raw` output components -- allowing us to easily check whether an error response should trigger a failure.
- Includes test from @jem-davies original fix for this in https://github.com/warpstreamlabs/bento/pull/541