### PR TITLE
docs(output/broker): Include example usage

### DIFF
--- a/internal/impl/pure/output_broker.go
+++ b/internal/impl/pure/output_broker.go
@@ -24,7 +24,7 @@ func brokerOutputSpec() *service.ConfigSpec {
 		Categories("Utility").
 		Summary(`Allows you to route messages to multiple child outputs using a range of brokering [patterns](#patterns).`).
 		Description(`
-Outputs can be defined inline with their full configuration or referenced by name. Both methods can be mixed:
+Outputs can be defined inline with their full configuration or referenced by resource name. Both methods can be mixed:
 
 `+"```yaml"+`
 output:
@@ -58,48 +58,7 @@ output:
   # Processors applied to messages sent to all brokered outputs.
   processors:
     - resource: general_processor
-`+"```"+`
-
-## Common Use Cases
-
-### Send to Multiple Destinations
-
-Send the same data to multiple outputs simultaneously:
-
-`+"```yaml"+`
-output:
-  broker:
-    pattern: fan_out
-    outputs:
-      - gcp_bigquery:
-          project: my-project
-          dataset: raw_data
-          table: events
-      - gcp_bigquery:
-          project: my-project
-          dataset: analytics
-          table: events_aggregated
-      - file:
-          path: /backup/events.jsonl
-          codec: lines
-`+"```"+`
-
-### Load Balance Across Endpoints
-
-Distribute messages across multiple targets:
-
-`+"```yaml"+`
-output:
-  broker:
-    pattern: round_robin
-    outputs:
-      - http_client:
-          url: http://api1.example.com/data
-      - http_client:
-          url: http://api2.example.com/data
-      - http_client:
-          url: http://api3.example.com/data
-`+"```"+``).
+`+"```").
 		Footnotes(`
 ## Patterns
 
@@ -146,7 +105,41 @@ The greedy pattern results in higher output throughput at the cost of potentiall
 			service.NewOutputListField(boFieldOutputs).
 				Description("A list of child outputs to broker. Each item can be either a complete inline output configuration or a reference to an output resource."),
 			service.NewBatchPolicyField(boFieldBatching),
-		)
+		).Example(
+		"Send to Multiple Destinations",
+		"Send the same data to multiple outputs simultaneously.",
+		`
+output:
+  broker:
+    pattern: fan_out
+    outputs:
+      - gcp_bigquery:
+          project: my-project
+          dataset: raw_data
+          table: events
+      - gcp_bigquery:
+          project: my-project
+          dataset: analytics
+          table: events_aggregated
+      - file:
+          path: /backup/events.jsonl
+          codec: lines
+`,
+	).Example(
+		"Load Balance Across Endpoints", "Distribute messages across multiple targets.",
+		`
+output:
+  broker:
+    pattern: round_robin
+    outputs:
+      - http_client:
+          url: http://api1.example.com/data
+      - http_client:
+          url: http://api2.example.com/data
+      - http_client:
+          url: http://api3.example.com/data
+`,
+	)
 }
 
 // ErrBrokerNoOutputs is returned when creating a Broker type with zero

--- a/website/docs/components/outputs/broker.md
+++ b/website/docs/components/outputs/broker.md
@@ -63,7 +63,7 @@ output:
 </TabItem>
 </Tabs>
 
-Outputs can be defined inline with their full configuration or referenced by name. Both methods can be mixed:
+Outputs can be defined inline with their full configuration or referenced by resource name. Both methods can be mixed:
 
 ```yaml
 output:
@@ -99,11 +99,16 @@ output:
     - resource: general_processor
 ```
 
-## Common Use Cases
+## Examples
 
-### Send to Multiple Destinations
+<Tabs defaultValue="Send to Multiple Destinations" values={[
+{ label: 'Send to Multiple Destinations', value: 'Send to Multiple Destinations', },
+{ label: 'Load Balance Across Endpoints', value: 'Load Balance Across Endpoints', },
+]}>
 
-Send the same data to multiple outputs simultaneously:
+<TabItem value="Send to Multiple Destinations">
+
+Send the same data to multiple outputs simultaneously.
 
 ```yaml
 output:
@@ -123,9 +128,10 @@ output:
           codec: lines
 ```
 
-### Load Balance Across Endpoints
+</TabItem>
+<TabItem value="Load Balance Across Endpoints">
 
-Distribute messages across multiple targets:
+Distribute messages across multiple targets.
 
 ```yaml
 output:
@@ -139,6 +145,9 @@ output:
       - http_client:
           url: http://api3.example.com/data
 ```
+
+</TabItem>
+</Tabs>
 
 ## Fields
 


### PR DESCRIPTION
Instead of adding inline examples to description, let's rather leverage `Example()` types.