### PR TITLE
feat(buffer_memory): spillover and active metrics

### DIFF
--- a/internal/impl/pure/buffer_memory.go
+++ b/internal/impl/pure/buffer_memory.go
@@ -44,13 +44,21 @@ This buffer intentionally weakens the delivery guarantees of the pipeline and th
 
 ## Batching
 
-It is possible to batch up messages sent from this buffer using a [batch policy](/docs/configuration/batching#batch-policy).`).
+It is possible to batch up messages sent from this buffer using a [batch policy](/docs/configuration/batching#batch-policy).
+
+## Metrics 
+
+- ` + "`buffer_active`" + ` Gauge metric tracking the current number of bytes in the buffer.
+- ` + "`buffer_spillover`" + ` Counter metric tracking the total number of bytes dropped because of spillover.
+
+`).
 		Field(service.NewIntField("limit").
 			Description(`The maximum buffer size (in bytes) to allow before applying backpressure upstream.`).
 			Default(524288000)).
 		Field(service.NewBoolField("spillover").
 			Description("Whether to drop incoming messages that will exceed the buffer limit.").
 			Advanced().
+			Version("1.13.0").
 			Default(false)).
 		Field(service.NewInternalField(bs))
 }

--- a/website/docs/components/buffers/memory.md
+++ b/website/docs/components/buffers/memory.md
@@ -73,6 +73,13 @@ This buffer intentionally weakens the delivery guarantees of the pipeline and th
 
 It is possible to batch up messages sent from this buffer using a [batch policy](/docs/configuration/batching#batch-policy).
 
+## Metrics 
+
+- `buffer_active` Gauge metric tracking the current number of bytes in the buffer.
+- `buffer_spillover` Counter metric tracking the total number of bytes dropped because of spillover.
+
+
+
 ## Fields
 
 ### `limit`
@@ -90,6 +97,7 @@ Whether to drop incoming messages that will exceed the buffer limit.
 
 Type: `bool`  
 Default: `false`  
+Requires version 1.13.0 or newer  
 
 ### `batch_policy`
 


### PR DESCRIPTION
Adds two new metrics to the `memory` buffer which track the active number of bytes in the buffer and number of bytes that have been spilled due to reaching maximum capacity.

Resolves #574 