### PR TITLE
fix(parquet): Fallback to randomly generated valid field names

### DIFF
--- a/internal/impl/parquet/schema.go
+++ b/internal/impl/parquet/schema.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"unicode"
 
 	"github.com/warpstreamlabs/bento/public/service"
 )
@@ -43,6 +44,11 @@ func generateStructTypeFromFields(
 			exportedName = strings.ToUpper(name[:1]) + name[1:]
 			components   = []string{name}
 		)
+
+		if !unicode.IsUpper(rune(exportedName[0])) {
+			// HACK(gregfurman): 1/26^15 chance of collision. Should be fine ¯\_(ツ)_/¯
+			exportedName = randomFieldName(15)
+		}
 
 		if field.Contains("type") {
 			typeStr, err := field.FieldString("type")

--- a/internal/impl/parquet/schema_test.go
+++ b/internal/impl/parquet/schema_test.go
@@ -1,13 +1,21 @@
 package parquet
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateStructTypeAsPtrs(t *testing.T) {
+	randSource = rand.New(rand.NewSource(42))
+	t.Cleanup(func() {
+		// Resets after test complete
+		rand.New(rand.NewSource(time.Now().UnixNano()))
+	})
+
 	tests := []struct {
 		name       string
 		yaml       string
@@ -81,6 +89,20 @@ schema:
 				"Req": {reflect.TypeOf(int64(0)), `parquet:"req" json:"req"`},
 				"Opt": {reflect.PointerTo(reflect.TypeOf(int64(0))), `parquet:"opt" json:"opt"`},
 				"Arr": {reflect.SliceOf(reflect.TypeOf(float32(0))), `parquet:"arr" json:"arr"`},
+			},
+		},
+		{
+			name: "whacky naming",
+			yaml: `
+schema:
+  - { name: _timestamp, type: UTF8 }
+`,
+			wantFields: map[string]struct {
+				fieldType reflect.Type
+				tag       string
+			}{
+				// deterministic random field name
+				"HRUKPTTUEZPTNEU": {reflect.TypeOf(""), `parquet:"_timestamp" json:"_timestamp"`},
 			},
 		},
 		{

--- a/internal/impl/parquet/util.go
+++ b/internal/impl/parquet/util.go
@@ -1,6 +1,11 @@
 package parquet
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"math/rand"
+	"strings"
+	"time"
+)
 
 func scrubJSONNumbers(v any) any {
 	switch t := v.(type) {
@@ -32,4 +37,16 @@ func scrubJSONNumbersArr(arr []any) {
 	for i, v := range arr {
 		arr[i] = scrubJSONNumbers(v)
 	}
+}
+
+// HACK(gregfurman): use an rng to make this approach testable
+var randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func randomFieldName(length int) string {
+	var builder strings.Builder
+	for i := 0; i < length; i++ {
+		builder.WriteRune(rune(randSource.Intn(26) + 'A'))
+	}
+
+	return builder.String()
 }


### PR DESCRIPTION
## Motivation

When a dynamically generated stuct is created with a field name that is unexportable, `reflect.StructOf()` panics. 

For example, the field `_timestamp` will panic with:

```
reflect.StructOf: field "<invalid field>" is unexported but missing PkgPath
```

## Changes

- Creates a random field name generator that is used as a fallback if the struct field name is invalid.

