### PR TITLE
fix: remove client.Disconnect from mongodb output

### DIFF
--- a/internal/impl/mongodb/output.go
+++ b/internal/impl/mongodb/output.go
@@ -107,7 +107,6 @@ func (m *outputWriter) Connect(ctx context.Context) error {
 	defer m.mu.Unlock()
 
 	if err := m.client.Ping(ctx, nil); err != nil {
-		_ = m.client.Disconnect(ctx)
 		return fmt.Errorf("ping failed: %v", err)
 	}
 	return nil


### PR DESCRIPTION
Fixes #576 .

Please review my change carefully, because its my first contact with the bento code at all.

What and Why:  

So bento currently keeps looping in "ping failed: client is disconnected" if client.Ping once throws an error. Bento will never recover from this by its own. Even if the ping works again.

What I figured out is, that if client.Ping throws an error we do a m.client.Disconnect. That's fatal because after that, a reconnect needs to be done, but in this loop there is nothing like this.
The disconnect should not be done at all. Just return the ping error and let the retry loop try again.

I tested the code and now even the errormessage is more appropriate on whats going on and why ping is failing.

I am not sure if the mongodb input is also affected by this error. Probably not because there is no disconnect if the ping fails.


Greetings,
Dominik