### PR TITLE
feat(docs): Add Bloblang Playground to navbar and homepage

### DIFF
--- a/website/docs/guides/bloblang/playground.md
+++ b/website/docs/guides/bloblang/playground.md
@@ -155,7 +155,7 @@ root.finalPrice = this.product.price - root.discount
 Want to run the playground locally? Use the Bento CLI:
 
 ```bash
-bento blobl server
+bento blobl playground
 ```
 
 This starts a local server with the full playground interface, perfect for development and testing.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -54,6 +54,7 @@ module.exports = {
       items: [
         {to: 'docs/about', label: 'Docs', position: 'left'},
         {to: 'cookbooks', label: 'Cookbooks', position: 'left'},
+        {to: 'docs/guides/bloblang/playground', label: 'Playground', position: 'left'},
         {
           type: 'html',
           position: 'right',

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -284,7 +284,7 @@ function Home() {
                 <p className={styles.writtenInGo}>
                   Written in Go, deployed as a static binary, declarative configuration. <a href="https://github.com/warpstreamlabs/bento" target="_blank" rel="noopener noreferrer" aria-label="View Bento source code on GitHub">Open source</a> and cloud native as utter heck.
                 </p>
-                <div style={{ display: 'flex', gap: '1rem' }}>
+                <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
                   <Link
                     className={classnames('button button--outline button--primary', styles.learnMoreButton)}
                     to={useBaseUrl('docs/guides/getting_started')}>
@@ -295,6 +295,12 @@ function Home() {
                     style={{ backgroundColor: 'rgba(255, 255, 255, 0.1)' }}
                     to={useBaseUrl('cookbooks')}>
                     Explore Cookbooks
+                  </Link>
+                  <Link
+                    className={classnames('button button--outline button--primary', styles.learnMoreButton)}
+                    style={{ backgroundColor: 'rgba(255, 255, 255, 0.1)' }}
+                    to={useBaseUrl('docs/guides/bloblang/playground')}>
+                    Try Playground
                   </Link>
                 </div>
               </div>


### PR DESCRIPTION
## Improves discoverability of the Bloblang Playground

- Add "Playground" link to navbar next to "Docs" and "Cookbooks"
- Add "Try Playground" button to homepage alongside "Get Started" and "Explore Cookbooks"

<img width="1430" height="780" alt="image" src="https://github.com/user-attachments/assets/bf0e3983-1079-4106-8341-4a0988739caf" />

Fixes https://github.com/warpstreamlabs/bento/issues/596

Signed-off-by: Ramtin Mesgari <26694963+iamramtin@users.noreply.github.com>
