### PR TITLE
docs fix tabs spacing issue

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -882,6 +882,17 @@ input.cookbookSearch {
   padding: 0.75rem 1rem !important;
 }
 
+.tabs {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  width: 100% !important;
+  overflow-x: auto !important;
+  overflow-y: clip !important;
+  box-sizing: border-box !important;
+  row-gap: 0.75rem !important; 
+}
+
+
 [class*="tabs__item"]:hover {
   background-color: #FFD0CE !important;
   transform: translateY(-1px);


### PR DESCRIPTION
Current: 

<img width="786" height="943" alt="image" src="https://github.com/user-attachments/assets/b2519858-51c4-4150-9c62-e8a901870ea7" />

PR: 

<img width="762" height="1001" alt="image" src="https://github.com/user-attachments/assets/d42d24a0-1033-426d-9d31-60ad022d729a" />

Important - 

I am not really a frontend dev - so writing CSS is very difficult for me - It seems to be ok though... 