### PR TITLE
couchbase: add ttl (expiry) support

### DIFF
--- a/internal/impl/couchbase/couchbase.go
+++ b/internal/impl/couchbase/couchbase.go
@@ -2,6 +2,7 @@ package couchbase
 
 import (
 	"errors"
+	"time"
 
 	"github.com/couchbase/gocb/v2"
 )
@@ -40,38 +41,56 @@ func valueFromOp(op gocb.BulkOp) (out any, cas gocb.Cas, err error) {
 	return nil, gocb.Cas(0), errors.New("type not supported")
 }
 
-func get(key string, _ []byte, _ gocb.Cas) gocb.BulkOp {
+func get(key string, _ []byte, _ gocb.Cas, _ *time.Duration) gocb.BulkOp {
 	return &gocb.GetOp{
 		ID: key,
 	}
 }
 
-func insert(key string, data []byte, _ gocb.Cas) gocb.BulkOp {
-	return &gocb.InsertOp{
+func insert(key string, data []byte, _ gocb.Cas, ttl *time.Duration) gocb.BulkOp {
+	op := &gocb.InsertOp{
 		ID:    key,
 		Value: data,
 	}
+
+	if ttl != nil {
+		op.Expiry = *ttl
+	}
+
+	return op
 }
 
-func remove(key string, _ []byte, cas gocb.Cas) gocb.BulkOp {
+func remove(key string, _ []byte, cas gocb.Cas, _ *time.Duration) gocb.BulkOp {
 	return &gocb.RemoveOp{
 		ID:  key,
 		Cas: cas,
 	}
 }
 
-func replace(key string, data []byte, cas gocb.Cas) gocb.BulkOp {
-	return &gocb.ReplaceOp{
+func replace(key string, data []byte, cas gocb.Cas, ttl *time.Duration) gocb.BulkOp {
+	op := &gocb.ReplaceOp{
 		ID:    key,
 		Value: data,
 		Cas:   cas,
 	}
+
+	if ttl != nil {
+		op.Expiry = *ttl
+	}
+
+	return op
 }
 
-func upsert(key string, data []byte, cas gocb.Cas) gocb.BulkOp {
-	return &gocb.UpsertOp{
+func upsert(key string, data []byte, cas gocb.Cas, ttl *time.Duration) gocb.BulkOp {
+	op := &gocb.UpsertOp{
 		ID:    key,
 		Value: data,
 		Cas:   cas,
 	}
+
+	if ttl != nil {
+		op.Expiry = *ttl
+	}
+
+	return op
 }

--- a/internal/impl/couchbase/integration_test.go
+++ b/internal/impl/couchbase/integration_test.go
@@ -128,7 +128,7 @@ func TestIntegrationCouchbaseProcessor(t *testing.T) {
 	payload := fmt.Sprintf(`{"id": %q, "data": %q}`, uid, faker.Sentence())
 
 	t.Run("Insert", func(t *testing.T) {
-		testCouchbaseProcessorInsert(uid, payload, bucket, servicePort, t)
+		testCouchbaseProcessorInsert(payload, bucket, servicePort, t)
 	})
 	t.Run("Get", func(t *testing.T) {
 		testCouchbaseProcessorGet(uid, payload, bucket, servicePort, t)
@@ -142,7 +142,7 @@ func TestIntegrationCouchbaseProcessor(t *testing.T) {
 
 	payload = fmt.Sprintf(`{"id": %q, "data": %q}`, uid, faker.Sentence())
 	t.Run("Upsert", func(t *testing.T) {
-		testCouchbaseProcessorUpsert(uid, payload, bucket, servicePort, t)
+		testCouchbaseProcessorUpsert(payload, bucket, servicePort, t)
 	})
 	t.Run("Get", func(t *testing.T) {
 		testCouchbaseProcessorGet(uid, payload, bucket, servicePort, t)
@@ -150,10 +150,16 @@ func TestIntegrationCouchbaseProcessor(t *testing.T) {
 
 	payload = fmt.Sprintf(`{"id": %q, "data": %q}`, uid, faker.Sentence())
 	t.Run("Replace", func(t *testing.T) {
-		testCouchbaseProcessorReplace(uid, payload, bucket, servicePort, t)
+		testCouchbaseProcessorReplace(payload, bucket, servicePort, t)
 	})
 	t.Run("Get", func(t *testing.T) {
 		testCouchbaseProcessorGet(uid, payload, bucket, servicePort, t)
+	})
+	t.Run("TTL", func(t *testing.T) {
+		testCouchbaseProcessorUpsertTTL(payload, bucket, servicePort, t)
+		testCouchbaseProcessorGet(uid, payload, bucket, servicePort, t)
+		time.Sleep(5 * time.Second)
+		testCouchbaseProcessorGetMissing(uid, bucket, servicePort, t)
 	})
 }
 

--- a/website/docs/components/processors/couchbase.md
+++ b/website/docs/components/processors/couchbase.md
@@ -60,6 +60,7 @@ couchbase:
   timeout: 15s
   id: ${! json("id") } # No default (required)
   content: "" # No default (optional)
+  ttl: "" # No default (optional)
   operation: get
   cas_enabled: true
 ```
@@ -161,6 +162,13 @@ id: ${! json("id") }
 ### `content`
 
 Document content.
+
+
+Type: `string`  
+
+### `ttl`
+
+An optional TTL to set for items.
 
 
 Type: `string`  


### PR DESCRIPTION
The ttl (called expiry in couchbase) was implemented in couchbase cache implementation but was missing in processor.
This PR add a new field ttl to set this value (like it is done in cache implementation).