### PR TITLE
feat: Support for generic registrations against environment

### DIFF
--- a/internal/bundle/environment.go
+++ b/internal/bundle/environment.go
@@ -18,20 +18,23 @@ type Environment struct {
 	tracers    *TracerSet
 
 	scanners *ScannerSet
+
+	constructors *ConstructorSet
 }
 
 // NewEnvironment creates an empty environment.
 func NewEnvironment() *Environment {
 	return &Environment{
-		buffers:    &BufferSet{},
-		caches:     &CacheSet{},
-		inputs:     &InputSet{},
-		outputs:    &OutputSet{},
-		processors: &ProcessorSet{},
-		rateLimits: &RateLimitSet{},
-		metrics:    &MetricsSet{},
-		tracers:    &TracerSet{},
-		scanners:   &ScannerSet{},
+		buffers:      &BufferSet{},
+		caches:       &CacheSet{},
+		inputs:       &InputSet{},
+		outputs:      &OutputSet{},
+		processors:   &ProcessorSet{},
+		rateLimits:   &RateLimitSet{},
+		metrics:      &MetricsSet{},
+		tracers:      &TracerSet{},
+		scanners:     &ScannerSet{},
+		constructors: &ConstructorSet{},
 	}
 }
 
@@ -39,6 +42,9 @@ func NewEnvironment() *Environment {
 // independently.
 func (e *Environment) Clone() *Environment {
 	newEnv := NewEnvironment()
+	for _, v := range e.constructors.ctors {
+		_ = newEnv.constructors.Add(v)
+	}
 	for _, v := range e.buffers.specs {
 		_ = newEnv.buffers.Add(v.constructor, v.spec)
 	}
@@ -100,13 +106,14 @@ func (e *Environment) GetDocs(name string, ctype docs.Type) (docs.ComponentSpec,
 
 // GlobalEnvironment contains service-wide singleton bundles.
 var GlobalEnvironment = &Environment{
-	buffers:    AllBuffers,
-	caches:     AllCaches,
-	inputs:     AllInputs,
-	outputs:    AllOutputs,
-	processors: AllProcessors,
-	rateLimits: AllRateLimits,
-	metrics:    AllMetrics,
-	tracers:    AllTracers,
-	scanners:   AllScanners,
+	buffers:      AllBuffers,
+	caches:       AllCaches,
+	inputs:       AllInputs,
+	outputs:      AllOutputs,
+	processors:   AllProcessors,
+	rateLimits:   AllRateLimits,
+	metrics:      AllMetrics,
+	tracers:      AllTracers,
+	scanners:     AllScanners,
+	constructors: AllConstructors,
 }

--- a/internal/bundle/generic.go
+++ b/internal/bundle/generic.go
@@ -1,0 +1,41 @@
+package bundle
+
+// AllConstructors is a set containing every single constructor that has been registered.
+var AllConstructors = &ConstructorSet{
+	ctors: []ManagedConstructor{},
+}
+
+//------------------------------------------------------------------------------
+
+// ConstructorAdd adds a new constructor to this environment by providing a
+// constructor function.
+func (e *Environment) ConstructorAdd(ctor ManagedConstructor) error {
+	// TODO(gregfurman): Should we be making these idempotent?
+	return e.constructors.Add(ctor)
+}
+
+// ConstructorInit attempts to initilise all constructors registered against the environment.
+func (e *Environment) ConstructorInit(mgr NewManagement) error {
+	for _, ctor := range e.constructors.ctors {
+		if err := ctor(mgr); err != nil {
+			return wrapComponentErr(mgr, "constructor", err)
+		}
+	}
+	return nil
+}
+
+//------------------------------------------------------------------------------
+
+// ManagedConstructor allows for a construction function to be registered against a manager.
+type ManagedConstructor func(NewManagement) error
+
+// ConstructorSet contains a set of managed constructor functions to be run against the environment.
+type ConstructorSet struct {
+	ctors []ManagedConstructor
+}
+
+// Add a new managed constructor function to this set.
+func (s *ConstructorSet) Add(ctor ManagedConstructor) error {
+	s.ctors = append(s.ctors, ctor)
+	return nil
+}

--- a/internal/manager/type.go
+++ b/internal/manager/type.go
@@ -306,6 +306,10 @@ func New(conf ResourceConfig, opts ...OptFunc) (*Type, error) {
 		}
 	}
 
+	if err := t.env.ConstructorInit(t); err != nil {
+		return nil, err
+	}
+
 	return t, nil
 }
 

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -456,6 +456,16 @@ func (e *Environment) RegisterBatchProcessor(name string, spec *ConfigSpec, ctor
 	}, componentSpec)
 }
 
+// RegisterManagedConstructor attempts to register a managed constructor that
+// will be called during environment initialization with access to service
+// resources. The constructor will be called once during environment setup.
+func (e *Environment) RegisterManagedConstructor(ctor ManagedConstructor) error {
+	return e.internal.ConstructorAdd(func(nm bundle.NewManagement) error {
+		res := newResourcesFromManager(nm)
+		return ctor(res)
+	})
+}
+
 // WalkProcessors executes a provided function argument for every processor
 // component that has been registered to the environment.
 func (e *Environment) WalkProcessors(fn func(name string, config *ConfigView)) {

--- a/public/service/plugins.go
+++ b/public/service/plugins.go
@@ -205,3 +205,20 @@ func RegisterBatchScannerCreator(name string, spec *ConfigSpec, ctor BatchScanne
 func RegisterTemplateYAML(yamlStr string) error {
 	return globalEnvironment.RegisterTemplateYAML(yamlStr)
 }
+
+// ManagedConstructor is a func that's provided access to a service manager and
+// must return an error if the initialization fails.
+//
+// Experimental: This type signature is experimental and therefore subject to
+// change outside of major version releases.
+type ManagedConstructor func(mgr LimitedResources) error
+
+// RegisterManagedConstructor attempts to register a non-specific constructor that
+// will be called during service initialization with access to service resources.
+// The constructor will be called once during environment setup.
+//
+// Experimental: This type signature is experimental and therefore subject to
+// change outside of major version releases.
+func RegisterManagedConstructor(ctor ManagedConstructor) error {
+	return globalEnvironment.RegisterManagedConstructor(ctor)
+}

--- a/public/service/resources.go
+++ b/public/service/resources.go
@@ -16,6 +16,28 @@ import (
 	"github.com/warpstreamlabs/bento/internal/manager/mock"
 )
 
+var _ LimitedResources = (*Resources)(nil)
+
+// LimitedResources provides constrained access a subset of resources
+// that are deemed safe for use within any component.
+//
+// Future versions will likely see this interface replaced entirely
+// by the `service.Resources` implementation. However, while this functionality
+// is still evolving, preventing full-access is safer.
+//
+// While this can be circumvented with type-assertions, it is strongly
+// discouraged and should be done so at your own risk.
+//
+// Experimental: This interface is experimental and therefore subject to
+// change outside of major version releases.
+type LimitedResources interface {
+	AccessCache(ctx context.Context, name string, fn func(c Cache)) error
+	AccessRateLimit(ctx context.Context, name string, fn func(r RateLimit)) error
+
+	HasCache(name string) bool
+	HasRateLimit(name string) bool
+}
+
 // Resources provides access to service-wide resources.
 type Resources struct {
 	mgr bundle.NewManagement


### PR DESCRIPTION
## Motivation

Supports registering arbitrary constructors against the bento environment. 

This has two main outcomes:
1. Allows us to bridge the gap between the bloblang environment and bento resources (see companion PR)
2. Provides an alternative approach to our (frankly hacky) `bundle` based approach for customising the entire blobl environment on startup.

## Changes

- Creates a `ConstructorSet` which contains a slice of all constructors registered. These are run in order of registration and after `resource` configurations have been initialised.
- Adds a `LimitedResources` interface, intended for usage with these new constructors, which constrains what operations should be possible when registering a custom managed constructor against the env.