### PR TITLE
doc fix new root span with link kafka version

### DIFF
--- a/internal/impl/kafka/input_sarama_kafka.go
+++ b/internal/impl/kafka/input_sarama_kafka.go
@@ -126,7 +126,7 @@ Unfortunately this error message will appear for a wide range of connection prob
 				Description("A maximum estimate for the time taken to process a message, this is used for tuning consumer group synchronization.").
 				Advanced().Default("100ms"),
 			service.NewExtractTracingSpanMappingField(),
-			service.NewRootSpanWithLinkField(),
+			service.NewRootSpanWithLinkField().Version("1.14.0"),
 			service.NewObjectField(iskFieldGroup,
 				service.NewDurationField(iskFieldGroupSessionTimeout).
 					Description("A period after which a consumer of the group is kicked after no heartbeats.").

--- a/public/service/config_extract_tracing.go
+++ b/public/service/config_extract_tracing.go
@@ -32,7 +32,6 @@ func NewExtractTracingSpanMappingField() *ConfigField {
 func NewRootSpanWithLinkField() *ConfigField {
 	return NewBoolField(nrswlField).
 		Description("EXPERIMENTAL: Starts a new root span with link to parent.").
-		Version("1.0.0").
 		Optional().
 		Advanced()
 }

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -615,7 +615,7 @@ EXPERIMENTAL: Starts a new root span with link to parent.
 
 
 Type: `bool`  
-Requires version 1.0.0 or newer  
+Requires version 1.14.0 or newer  
 
 ### `group`
 


### PR DESCRIPTION
erroneous version number for a new field `new_root_span_with_link` - this PR updates it to v1.14.0 