### PR TITLE
fix(core/strict): Improve named arguments support for bloblang

### DIFF
--- a/internal/bundle/strict/bloblang.go
+++ b/internal/bundle/strict/bloblang.go
@@ -14,13 +14,13 @@ func StrictBloblangEnvironment(nm bundle.NewManagement) *bloblang.Environment {
 		_ = newEnv.RegisterFunction(spec, func(args *query.ParsedParams) (query.Function, error) {
 			if isBloblangFunctionIncompatible(name) {
 				nm.Logger().Warn("Disabling strict mode due to incompatible Bloblang function(s) of type '%s'", name)
-				nm.SetGeneric(strictModeEnabledKey, false)
+				nm.SetGeneric(strictModeEnabledKey{}, false)
 			} else {
 				// For compatible processors, set true if not already set
-				nm.GetOrSetGeneric(strictModeEnabledKey, true)
+				nm.GetOrSetGeneric(strictModeEnabledKey{}, true)
 			}
 
-			return query.InitFunctionHelper(name, args.Raw()...)
+			return query.AllFunctions.Init(name, args)
 		})
 	})
 
@@ -28,12 +28,12 @@ func StrictBloblangEnvironment(nm bundle.NewManagement) *bloblang.Environment {
 		_ = newEnv.RegisterMethod(spec, func(target query.Function, args *query.ParsedParams) (query.Function, error) {
 			if isBloblangMethodIncompatible(name) {
 				nm.Logger().Warn("Disabling strict mode due to incompatible Bloblang method(s) of type '%s'", name)
-				nm.SetGeneric(strictModeEnabledKey, false)
+				nm.SetGeneric(strictModeEnabledKey{}, false)
 			} else {
 				// For compatible processors, set true if not already set
-				nm.GetOrSetGeneric(strictModeEnabledKey, true)
+				nm.GetOrSetGeneric(strictModeEnabledKey{}, true)
 			}
-			return query.InitMethodHelper(name, target, args.Raw()...)
+			return query.AllMethods.Init(name, target, args)
 		})
 	})
 

--- a/internal/bundle/strict/bundle.go
+++ b/internal/bundle/strict/bundle.go
@@ -12,14 +12,12 @@ import (
 	"github.com/warpstreamlabs/bento/internal/pipeline/constructor"
 )
 
-const (
-	strictModeEnabledKey = "strict_mode_enabled"
-)
+type strictModeEnabledKey struct{}
 
 // isStrictModeEnabled returns whether the environment has been flagged as being strict
 // with the key-value pair `"strict_mode_enabled": true`.
 func isStrictModeEnabled(mgr bundle.NewManagement) bool {
-	ienabled, exists := mgr.GetGeneric(strictModeEnabledKey)
+	ienabled, exists := mgr.GetGeneric(strictModeEnabledKey{})
 	if !exists {
 		return false
 	}
@@ -78,10 +76,10 @@ func StrictBundle(b *bundle.Environment) *bundle.Environment {
 		_ = strictEnv.ProcessorAdd(func(conf processor.Config, nm bundle.NewManagement) (processor.V1, error) {
 			if isProcessorIncompatible(conf.Type) {
 				nm.Logger().Warn("Disabling strict mode due to incompatible processor(s) of type '%s'", conf.Type)
-				nm.SetGeneric(strictModeEnabledKey, false)
+				nm.SetGeneric(strictModeEnabledKey{}, false)
 			} else {
 				// For compatible processors, set true if not already set
-				nm.GetOrSetGeneric(strictModeEnabledKey, true)
+				nm.GetOrSetGeneric(strictModeEnabledKey{}, true)
 			}
 
 			proc, err := b.ProcessorInit(conf, nm)
@@ -98,9 +96,9 @@ func StrictBundle(b *bundle.Environment) *bundle.Environment {
 		_ = strictEnv.OutputAdd(func(conf output.Config, nm bundle.NewManagement, pcf ...processor.PipelineConstructorFunc) (output.Streamed, error) {
 			if isOutputIncompatible(conf.Type) {
 				nm.Logger().Warn("Disabling strict mode due to incompatible output(s) of type '%s'", conf.Type)
-				nm.SetGeneric(strictModeEnabledKey, false)
+				nm.SetGeneric(strictModeEnabledKey{}, false)
 			} else {
-				nm.GetOrSetGeneric(strictModeEnabledKey, true)
+				nm.GetOrSetGeneric(strictModeEnabledKey{}, true)
 			}
 
 			pcf = oprocessors.AppendFromConfig(conf, nm, pcf...)

--- a/internal/bundle/strict/processor.go
+++ b/internal/bundle/strict/processor.go
@@ -24,7 +24,7 @@ func wrapWithStrict(p iprocessor.V1, opts ...func(*strictProcessor)) *strictProc
 
 func setEnabledFromManager(mgr bundle.NewManagement) func(*strictProcessor) {
 	getEnabled := func() bool {
-		ienabled, exists := mgr.GetGeneric(strictModeEnabledKey)
+		ienabled, exists := mgr.GetGeneric(strictModeEnabledKey{})
 		if !exists {
 			return false
 		}

--- a/public/service/stream_builder_test.go
+++ b/public/service/stream_builder_test.go
@@ -1431,7 +1431,7 @@ error_handling:
 pipeline:
   processors:
     - bloblang: |
-        root = content().parse_json(use_number: false)
+        root = content().parse_json()
 
 error_handling:
   strategy: reject


### PR DESCRIPTION

- FIxes a bug wherein we were assuming all bloblang methods had nameless args, causing parsing issues on re-init.
- Re-initializes all bloblang functions and methods using the actual impl in `AllMethods` and `AllFunctions`.
- Changes the flag used for toggling strict mode key to instead use a private struct instead of a string key.