### PR TITLE
fix(scanner): guard against nil AckFunc in ackOnce to prevent panic

### DIFF
--- a/public/service/scanner.go
+++ b/public/service/scanner.go
@@ -86,7 +86,9 @@ func ackOnce(fn AckFunc) AckFunc {
 	return func(ctx context.Context, err error) error {
 		var ackErr error
 		once.Do(func() {
-			ackErr = fn(ctx, err)
+			if fn != nil {
+				ackErr = fn(ctx, err)
+			}
 		})
 		return ackErr
 	}

--- a/public/service/scanner_test.go
+++ b/public/service/scanner_test.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSimpleBatchScanner is a test helper that implements SimpleBatchScanner
+type mockSimpleBatchScanner struct {
+	batches []MessageBatch
+	errs    []error
+	index   int
+	closed  bool
+}
+
+func (m *mockSimpleBatchScanner) NextBatch(ctx context.Context) (MessageBatch, error) {
+	if m.index >= len(m.batches) {
+		return nil, io.EOF
+	}
+
+	batch := m.batches[m.index]
+	err := m.errs[m.index]
+	m.index++
+
+	return batch, err
+}
+
+func (m *mockSimpleBatchScanner) Close(ctx context.Context) error {
+	m.closed = true
+	return nil
+}
+
+func TestAutoAggregateBatchScannerAcksWithNilAckFunc(t *testing.T) {
+	// This test verifies that AutoAggregateBatchScannerAcks does not panic
+	// when provided with a nil AckFunc and the scanner encounters a non-EOF error.
+	// This reproduces the issue where the S3 processor passes nil as AckFunc
+	// and the CSV scanner encounters a parse error.
+
+	parseErr := errors.New("csv parse error: bare \" in non-quoted-field")
+
+	mock := &mockSimpleBatchScanner{
+		batches: []MessageBatch{nil},
+		errs:    []error{parseErr},
+	}
+
+	// Pass nil as AckFunc - this is what the S3 processor does
+	scanner := AutoAggregateBatchScannerAcks(mock, nil)
+
+	// This should NOT panic even though AckFunc is nil
+	require.NotPanics(t, func() {
+		_, _, err := scanner.NextBatch(context.Background())
+		// The error should be propagated
+		assert.Equal(t, parseErr, err)
+	})
+
+	// Clean up
+	require.NoError(t, scanner.Close(context.Background()))
+	assert.True(t, mock.closed)
+}
+
+func TestAutoAggregateBatchScannerAcksWithNilAckFuncOnClose(t *testing.T) {
+	// Test that Close doesn't panic when AckFunc is nil and scanner wasn't finished
+
+	mock := &mockSimpleBatchScanner{
+		batches: []MessageBatch{{NewMessage([]byte("test"))}},
+		errs:    []error{nil},
+	}
+
+	scanner := AutoAggregateBatchScannerAcks(mock, nil)
+
+	// Close without consuming all messages (simulates early termination)
+	// This should NOT panic
+	require.NotPanics(t, func() {
+		require.NoError(t, scanner.Close(context.Background()))
+	})
+	assert.True(t, mock.closed)
+}
+
+func TestAutoAggregateBatchScannerAcksWithValidAckFunc(t *testing.T) {
+	// Test normal operation with a valid AckFunc to ensure the fix
+	// doesn't break the normal case
+
+	mock := &mockSimpleBatchScanner{
+		batches: []MessageBatch{
+			{NewMessage([]byte("first"))},
+			{NewMessage([]byte("second"))},
+		},
+		errs: []error{nil, nil},
+	}
+
+	var ackCalled bool
+	var ackErr error
+	ackFn := func(ctx context.Context, err error) error {
+		ackCalled = true
+		ackErr = err
+		return nil
+	}
+
+	scanner := AutoAggregateBatchScannerAcks(mock, ackFn)
+
+	// Read first batch
+	batch1, ack1, err := scanner.NextBatch(context.Background())
+	require.NoError(t, err)
+	require.Len(t, batch1, 1)
+	b1, _ := batch1[0].AsBytes()
+	assert.Equal(t, "first", string(b1))
+
+	// Read second batch
+	batch2, ack2, err := scanner.NextBatch(context.Background())
+	require.NoError(t, err)
+	require.Len(t, batch2, 1)
+	b2, _ := batch2[0].AsBytes()
+	assert.Equal(t, "second", string(b2))
+
+	// Read EOF
+	_, _, err = scanner.NextBatch(context.Background())
+	assert.Equal(t, io.EOF, err)
+
+	// Ack should not be called yet
+	assert.False(t, ackCalled)
+
+	// Ack first batch
+	require.NoError(t, ack1(context.Background(), nil))
+	assert.False(t, ackCalled) // Still waiting for second
+
+	// Ack second batch - this should trigger the source ack
+	require.NoError(t, ack2(context.Background(), nil))
+	assert.True(t, ackCalled)
+	assert.NoError(t, ackErr)
+
+	require.NoError(t, scanner.Close(context.Background()))
+}
+
+func TestAutoAggregateBatchScannerAcksErrorPropagatesAck(t *testing.T) {
+	// Test that when a batch ack receives an error, it propagates to source ack
+
+	mock := &mockSimpleBatchScanner{
+		batches: []MessageBatch{
+			{NewMessage([]byte("first"))},
+		},
+		errs: []error{nil},
+	}
+
+	var ackErr error
+	ackFn := func(ctx context.Context, err error) error {
+		ackErr = err
+		return nil
+	}
+
+	scanner := AutoAggregateBatchScannerAcks(mock, ackFn)
+
+	// Read batch
+	_, ack, err := scanner.NextBatch(context.Background())
+	require.NoError(t, err)
+
+	// Read EOF
+	_, _, err = scanner.NextBatch(context.Background())
+	assert.Equal(t, io.EOF, err)
+
+	// Ack with error
+	processingErr := errors.New("processing failed")
+	require.NoError(t, ack(context.Background(), processingErr))
+
+	// Source ack should receive the error
+	assert.Equal(t, processingErr, ackErr)
+
+	require.NoError(t, scanner.Close(context.Background()))
+}


### PR DESCRIPTION
This PR fixes panic in `ackOnce` when `AckFunc` is `nil`.

The S3 processor passes `nil` as the `AckFunc` to `Scanner.Create()`. When the CSV scanner encounters a non-EOF error (such as a malformed CSV row), it calls `ackOnce(nil)` which attempts to invoke `nil(ctx, err)`, resulting in a panic.

## Root Cause

The issue is in the interaction between:

1. **S3 Processor** (`internal/impl/aws/processor_s3.go:240`): Creates a scanner without providing an `AckFunc`, passing `nil` instead.
2. **CSV Scanner** (`internal/impl/pure/scanner_csv.go`): When it encounters a parse error (not EOF), it returns the error.
3. **Scanner wrapper** (`public/service/scanner.go:133`): The `managedAckBatchScanner.NextBatch` calls `s.sourceAck(ctx, err)` on non-EOF errors.
4. **ackOnce** (`public/service/scanner.go:89`): The wrapper doesn't guard against a `nil` underlying function, leading to the nil pointer dereference.

## Fix

Add a nil check in `ackOnce` before calling the underlying `AckFunc`:

```go
func ackOnce(fn AckFunc) AckFunc {
    var once sync.Once
    return func(ctx context.Context, err error) error {
        var ackErr error
        once.Do(func() {
            if fn != nil {  // <-- Added nil guard
                ackErr = fn(ctx, err)
            }
        })
        return ackErr
    }
}
```

## Testing

Added unit tests in `public/service/scanner_test.go`:
- `TestAutoAggregateBatchScannerAcksWithNilAckFunc` - Reproduces the panic scenario
- `TestAutoAggregateBatchScannerAcksWithNilAckFuncOnClose` - Tests Close with nil AckFunc
- `TestAutoAggregateBatchScannerAcksWithValidAckFunc` - Ensures normal operation still works
- `TestAutoAggregateBatchScannerAcksErrorPropagatesAck` - Tests error propagation

## Reproduction

<details>
<summary>Reproduction steps</summary>

### Prerequisites

- Docker and Docker Compose
- Bento binary

### Files

**`docker-compose.yaml`**
```yaml
services:
  minio:
    image: minio/minio:latest
    container_name: minio-repro
    ports:
      - "9000:9000"
      - "9001:9001"
    environment:
      MINIO_ROOT_USER: minioadmin
      MINIO_ROOT_PASSWORD: minioadmin
    command: server /data --console-address ":9001"
    healthcheck:
      test: ["CMD", "mc", "ready", "local"]
      interval: 5s
      timeout: 5s
      retries: 5

  minio-init:
    image: minio/mc:latest
    container_name: minio-init
    depends_on:
      minio:
        condition: service_healthy
    entrypoint:
      - /bin/sh
      - -c
      - |
        mc alias set local http://minio:9000 minioadmin minioadmin
        mc mb local/test-bucket --ignore-existing
        printf 'header1\001header2\001header3\nvalue1\001"unclosed quote' > /tmp/malformed.csv
        mc cp /tmp/malformed.csv local/test-bucket/malformed.csv
        echo 'Malformed CSV uploaded to test-bucket/malformed.csv'
```

**`nil_ack_panic.yaml`**
```yaml
input:
  generate:
    count: 1
    interval: ""
    mapping: |
      root = {
        "bucket": env("TEST_BUCKET").or("test-bucket"),
        "key": env("TEST_KEY").or("malformed.csv")
      }

pipeline:
  processors:
    - aws_s3:
        endpoint: ${AWS_ENDPOINT_URL_S3:http://localhost:9000}
        bucket: ${! this.bucket }
        region: ${AWS_REGION:us-east-1}
        force_path_style_urls: true
        key: ${! this.key }
        credentials:
          id: ${AWS_ACCESS_KEY_ID:minioadmin}
          secret: ${AWS_SECRET_ACCESS_KEY:minioadmin}
        scanner:
          csv:
            custom_delimiter: "\x01"
            parse_header_row: true

output:
  stdout:
    codec: lines
```

### Steps

1. Start MinIO:
   ```bash
   docker-compose up -d
   ```

2. Wait for `minio-init` to complete:
   ```bash
   while docker ps --format '{{.Names}}' | grep -q minio-init; do sleep 1; done
   ```

3. Run the pipeline (before fix - will panic):
   ```bash
   bento run nil_ack_panic.yaml
   ```

4. Observe the panic:
   ```
   panic: runtime error: invalid memory address or nil pointer dereference
   [signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x108080a38]
   
   goroutine 83 [running]:
   github.com/warpstreamlabs/bento/internal/impl/pure.(*csvScannerCreator).Create.AutoAggregateBatchScannerAcks.ackOnce.func1.1()
       .../public/service/scanner.go:89 +0x28
   ...
   ```

</details>
