### PR TITLE
add(bloblang): is_unicode bytes method

### DIFF
--- a/internal/impl/pure/bloblang_string.go
+++ b/internal/impl/pure/bloblang_string.go
@@ -1,8 +1,11 @@
 package pure
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/url"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/warpstreamlabs/bento/internal/bloblang/query"
 	"github.com/warpstreamlabs/bento/public/bloblang"
@@ -32,6 +35,48 @@ func init() {
 		}); err != nil {
 		panic(err)
 	}
+
+	if err := bloblang.RegisterMethodV2("is_unicode",
+		bloblang.NewPluginSpec().
+			Category(query.MethodCategoryParsing).
+			Description("Returns whether a byte array consists entirely of valid Unicode characters. Checks both UTF-8 encoding validity and rejects Unicode noncharacters (U+FFFE, U+FFFF, etc.) and surrogates.").
+			Example("Invalid UTF-8 bytes return false.", `root = this.body.decode("base64").is_unicode()`,
+				[2]string{
+					fmt.Sprintf(`{"body":"%s"}`, base64.StdEncoding.EncodeToString([]byte{0xff, 0xfe, 0x00})),
+					`false`,
+				},
+			).
+			Example("Valid Unicode string returns true.", `root = this.bytes().is_unicode()`,
+				[2]string{
+					`"I'm a simple string."`,
+					`true`,
+				},
+			).
+			Example("Unicode non-characters return false.", `root = this.body.decode("base64").is_unicode()`,
+				[2]string{
+					fmt.Sprintf(`{"body":"%s"}`, base64.StdEncoding.EncodeToString([]byte{0xef, 0xbf, 0xbe})),
+					`false`,
+				},
+			),
+		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+			return bloblang.BytesMethod(func(data []byte) (any, error) {
+				if !utf8.Valid(data) {
+					return false, nil
+				}
+
+				// Check for Unicode noncharacters
+				for _, r := range string(data) {
+					if unicode.Is(unicode.Noncharacter_Code_Point, r) {
+						return false, nil
+					}
+				}
+
+				return true, nil
+			}), nil
+		}); err != nil {
+		panic(err)
+	}
+
 }
 
 func urlValuesToMap(values url.Values) map[string]any {

--- a/internal/impl/pure/bloblang_string_test.go
+++ b/internal/impl/pure/bloblang_string_test.go
@@ -63,3 +63,91 @@ func TestParseUrlencoded(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUnicode(t *testing.T) {
+	testCases := []struct {
+		name   string
+		method string
+		target any
+		args   []any
+		exp    any
+	}{
+		{
+			name:   "valid utf8 string",
+			method: "is_unicode",
+			target: []byte("hello world"),
+			args:   []any{},
+			exp:    true,
+		},
+		{
+			name:   "valid utf8 with unicode characters",
+			method: "is_unicode",
+			target: []byte("héllo wörld"),
+			args:   []any{},
+			exp:    true,
+		},
+		{
+			name:   "empty bytes",
+			method: "is_unicode",
+			target: []byte{},
+			args:   []any{},
+			exp:    true,
+		},
+		{
+			name:   "invalid utf8 bytes",
+			method: "is_unicode",
+			target: []byte{0xff, 0xfe},
+			args:   []any{},
+			exp:    false,
+		},
+		{
+			name:   "utf16 le bom",
+			method: "is_unicode",
+			target: []byte{0xff, 0xfe, 0x00},
+			args:   []any{},
+			exp:    false,
+		},
+		{
+			name:   "lone continuation byte",
+			method: "is_unicode",
+			target: []byte{0x80},
+			args:   []any{},
+			exp:    false,
+		},
+		{
+			name:   "truncated multibyte sequence",
+			method: "is_unicode",
+			target: []byte{0xc3}, // start of a 2-byte sequence with no second byte
+			args:   []any{},
+			exp:    false,
+		},
+		{
+			name:   "valid string appended with non-unicode",
+			method: "is_unicode",
+			target: []byte("test6￾"),
+			args:   []any{},
+			exp:    false,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			targetClone := value.IClone(test.target)
+			argsClone := value.IClone(test.args).([]any)
+
+			fn, err := query.InitMethodHelper(test.method, query.NewLiteralFunction("", targetClone), argsClone...)
+			require.NoError(t, err)
+
+			res, err := fn.Exec(query.FunctionContext{
+				Maps:     map[string]query.Function{},
+				Index:    0,
+				MsgBatch: nil,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, test.exp, res)
+			assert.Equal(t, test.target, targetClone)
+			assert.Equal(t, test.args, argsClone)
+		})
+	}
+}

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -3094,6 +3094,40 @@ root.doc = this.doc.format_yaml().string()
 # Out: {"doc":"foo: bar\n"}
 ```
 
+### `is_unicode`
+
+Returns whether a byte array consists entirely of valid Unicode characters. Checks both UTF-8 encoding validity and rejects Unicode noncharacters (U+FFFE, U+FFFF, etc.) and surrogates.
+
+#### Examples
+
+
+Invalid UTF-8 bytes return false.
+
+```coffee
+root = this.body.decode("base64").is_unicode()
+
+# In:  {"body":"//4A"}
+# Out: false
+```
+
+Valid Unicode string returns true.
+
+```coffee
+root = this.bytes().is_unicode()
+
+# In:  "I'm a simple string."
+# Out: true
+```
+
+Unicode non-characters return false.
+
+```coffee
+root = this.body.decode("base64").is_unicode()
+
+# In:  {"body":"77++"}
+# Out: false
+```
+
 ### `parse_csv`
 
 Attempts to parse a string into an array of objects by following the CSV format described in RFC 4180.


### PR DESCRIPTION
## Motivation

Certain components (i.e the `aws_sqs` output) only support payloads that are valid unicode.

This method will allow us to check this and handle it within a processor.

## Changes

- Adds a bytes method `is_unicode` that can be used to check if a byte array is valid unicode via bloblang.