### PR TITLE
test: Simplify ping check for embedded DuckDB

### DIFF
--- a/internal/impl/sql/integration_cgo_test.go
+++ b/internal/impl/sql/integration_cgo_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -34,9 +33,7 @@ func TestIntegrationDuckDB(t *testing.T) {
 		}
 	})
 
-	require.Eventually(t, func() bool {
-		return db.Ping() == nil
-	}, time.Second, 100*time.Millisecond, "duckdb did not respond to ping in time")
+	require.NoError(t, db.Ping())
 
 	createTable := func(name string) (string, error) {
 		_, err := db.Exec(fmt.Sprintf(`create table %s (


### PR DESCRIPTION
DuckDB is embedded and does not require network calls so `Ping()` should succeed immediately.