### PR TITLE
feat(websocket): add headers support to websocket output

### DIFF
--- a/internal/impl/io/output_websocket.go
+++ b/internal/impl/io/output_websocket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"io/fs"
 	"net/http"
 	"net/url"
@@ -27,6 +28,14 @@ func websocketOutputSpec() *service.ConfigSpec {
 		Summary("Sends messages to an HTTP server via a websocket connection.").
 		Field(service.NewURLField("url").Description("The URL to connect to.")).
 		Field(service.NewURLField("proxy_url").Description("An optional HTTP proxy URL.").Advanced().Optional()).
+		Field(service.NewInterpolatedStringMapField("headers").
+			Description("A map of custom headers to add to the websocket handshake.").
+			Example(map[string]any{
+				"Sec-WebSocket-Protocol": "graphql-ws",
+				"Authorization":          `Bearer ${! env("TOKEN") }`,
+			}).
+			Advanced().Optional().
+			Default(map[string]any{})).
 		Field(service.NewTLSToggledField("tls"))
 
 	for _, f := range service.NewHTTPRequestAuthSignerFields() {
@@ -71,6 +80,8 @@ type websocketWriter struct {
 	tlsEnabled     bool
 	tlsConf        *tls.Config
 	reqSigner      func(f fs.FS, req *http.Request) error
+
+	headers map[string]*service.InterpolatedString
 }
 
 func newWebsocketWriterFromParsed(conf *service.ParsedConfig, mgr bundle.NewManagement) (*websocketWriter, error) {
@@ -98,6 +109,9 @@ func newWebsocketWriterFromParsed(conf *service.ParsedConfig, mgr bundle.NewMana
 	if ws.reqSigner, err = conf.HTTPRequestAuthSignerFromParsed(); err != nil {
 		return nil, err
 	}
+	if ws.headers, err = conf.FieldInterpolatedStringMap("headers"); err != nil {
+		return nil, err
+	}
 	return ws, nil
 }
 
@@ -117,6 +131,13 @@ func (w *websocketWriter) Connect(ctx context.Context) error {
 	}
 
 	headers := http.Header{}
+	for k, v := range w.headers {
+		value, err := v.TryString(service.NewMessage(nil))
+		if err != nil {
+			return fmt.Errorf(`failed string interpolation on header %q: %w`, k, err)
+		}
+		headers.Add(k, value)
+	}
 
 	err := w.reqSigner(w.mgr.FS(), &http.Request{
 		URL:    w.urlParsed,

--- a/internal/impl/io/output_websocket_test.go
+++ b/internal/impl/io/output_websocket_test.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -68,6 +69,108 @@ websocket:
 
 	m.TriggerCloseNow()
 	require.NoError(t, m.WaitForClose(ctx))
+}
+
+func TestWebsocketOutputHeaders(t *testing.T) {
+	tests := []struct {
+		name           string
+		headers        map[string]string
+		expectedHeader http.Header
+		envVar         map[string]string
+	}{
+		{
+			name: "static headers",
+			headers: map[string]string{
+				"X-Static-Header": "static-value",
+			},
+			expectedHeader: http.Header{
+				"X-Static-Header": []string{"static-value"},
+			},
+		},
+		{
+			name: "interpolated headers",
+			headers: map[string]string{
+				"X-Interpolated-Header": `${! env("TEST_OUTPUT_HEADER_VALUE") }`,
+			},
+			expectedHeader: http.Header{
+				"X-Interpolated-Header": []string{"interpolated-value"},
+			},
+			envVar: map[string]string{
+				"TEST_OUTPUT_HEADER_VALUE": "interpolated-value",
+			},
+		},
+		{
+			name: "mixed headers",
+			headers: map[string]string{
+				"X-Static-Header":       "static-value",
+				"X-Interpolated-Header": `${! env("TEST_OUTPUT_HEADER_VALUE") }`,
+			},
+			expectedHeader: http.Header{
+				"X-Static-Header":       []string{"static-value"},
+				"X-Interpolated-Header": []string{"interpolated-value"},
+			},
+			envVar: map[string]string{
+				"TEST_OUTPUT_HEADER_VALUE": "interpolated-value",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, done := context.WithTimeout(context.Background(), time.Second*30)
+			defer done()
+
+			for k, v := range test.envVar {
+				t.Setenv(k, v)
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for k, v := range test.expectedHeader {
+					require.Equal(t, v, r.Header[k], "Header %s mismatch", k)
+				}
+
+				upgrader := websocket.Upgrader{}
+				ws, err := upgrader.Upgrade(w, r, nil)
+				if err != nil {
+					return
+				}
+				defer ws.Close()
+
+				if _, _, err = ws.ReadMessage(); err != nil {
+					t.Error(err)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			wsURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+			wsURL.Scheme = "ws"
+
+			headersYAML := ""
+			if len(test.headers) > 0 {
+				headersYAML = "  headers:\n"
+				for k, v := range test.headers {
+					headersYAML += fmt.Sprintf("    %s: %q\n", k, v)
+				}
+			}
+
+			conf := parseYAMLOutputConf(t, `
+websocket:
+  url: %v
+%v`, wsURL.String(), headersYAML)
+
+			m, err := mock.NewManager().NewOutput(conf)
+			require.NoError(t, err)
+
+			tChan := make(chan message.Transaction)
+			require.NoError(t, m.Consume(tChan))
+
+			require.NoError(t, writeBatchToChan(ctx, t, message.QuickBatch([][]byte{[]byte("hello")}), tChan))
+
+			m.TriggerCloseNow()
+			require.NoError(t, m.WaitForClose(ctx))
+		})
+	}
 }
 
 func TestWebsocketOutputClose(t *testing.T) {

--- a/internal/impl/nsq/testdata/auth_server.go
+++ b/internal/impl/nsq/testdata/auth_server.go
@@ -9,10 +9,10 @@ import (
 // AuthResponse represents the NSQ authentication response format.
 // See: https://nsq.io/components/nsqd.html#auth
 type AuthResponse struct {
-	TTL            int              `json:"ttl"`
-	Identity       string           `json:"identity"`
-	IdentityURL    string           `json:"identity_url"`
-	Authorizations []Authorization  `json:"authorizations"`
+	TTL            int             `json:"ttl"`
+	Identity       string          `json:"identity"`
+	IdentityURL    string          `json:"identity_url"`
+	Authorizations []Authorization `json:"authorizations"`
 }
 
 // Authorization defines permissions for topics and channels.
@@ -79,8 +79,8 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 		IdentityURL: "",
 		Authorizations: []Authorization{
 			{
-				Topic:       ".*", // Allow all topics (regex pattern)
-				Channels:    []string{".*"}, // Allow all channels (regex pattern)
+				Topic:       ".*",                             // Allow all topics (regex pattern)
+				Channels:    []string{".*"},                   // Allow all channels (regex pattern)
 				Permissions: []string{"subscribe", "publish"}, // Full permissions
 			},
 		},

--- a/website/docs/components/outputs/websocket.md
+++ b/website/docs/components/outputs/websocket.md
@@ -43,6 +43,7 @@ output:
   websocket:
     url: "" # No default (required)
     proxy_url: "" # No default (optional)
+    headers: {}
     tls:
       enabled: false
       skip_cert_verify: false
@@ -86,6 +87,23 @@ An optional HTTP proxy URL.
 
 
 Type: `string`  
+
+### `headers`
+
+A map of custom headers to add to the websocket handshake.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `object`  
+Default: `{}`  
+
+```yml
+# Examples
+
+headers:
+  Authorization: Bearer ${! env("TOKEN") }
+  Sec-WebSocket-Protocol: graphql-ws
+```
 
 ### `tls`
 


### PR DESCRIPTION
## Summary

- Adds a `headers` field to the `websocket` output component
- Supports static and Bloblang-interpolated header values (e.g. `${! env("TOKEN") }`)
- Mirrors the existing `headers` implementation in the `websocket` input
- Adds unit tests covering static, interpolated, and mixed header cases

## Example config
```
websocket:
  url: ws://example.com/ws
  headers:
    Authorization: 'Bearer ${! env("TOKEN") }'
    Sec-WebSocket-Protocol: graphql-ws
```

## Test plan
- [x] `make test` passes - failures unrelated
- [x] `make docs` run to regenerate docs for new config field

Closes #739 
