### PR TITLE
kafka+oauth2 implementation

### DIFF
--- a/internal/impl/kafka/franz_sasl_test.go
+++ b/internal/impl/kafka/franz_sasl_test.go
@@ -1,0 +1,100 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+func TestSaslMechanismsFromConfig(t *testing.T) {
+	saslConf := service.NewConfigSpec().Field(saslField())
+
+	tests := []struct {
+		name string
+		conf string
+	}{
+		{
+			name: "PLAIN",
+			conf: `
+sasl:
+  - mechanism: PLAIN
+    username: foo
+    password: bar
+`,
+		},
+		{
+			name: "OAUTHBEARER static",
+			conf: `
+sasl:
+  - mechanism: OAUTHBEARER
+    token: foo
+`,
+		},
+		{
+			name: "OAUTHBEARER oauth2",
+			conf: `
+sasl:
+  - mechanism: OAUTHBEARER
+    oauth2:
+      enabled: true
+      client_key: foo
+      client_secret: bar
+      token_url: http://localhost/token
+`,
+		},
+		{
+			name: "SCRAM-SHA-256",
+			conf: `
+sasl:
+  - mechanism: SCRAM-SHA-256
+    username: foo
+    password: bar
+`,
+		},
+		{
+			name: "SCRAM-SHA-512",
+			conf: `
+sasl:
+  - mechanism: SCRAM-SHA-512
+    username: foo
+    password: bar
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pConf, err := saslConf.ParseYAML(test.conf, nil)
+			require.NoError(t, err)
+
+			mechanisms, err := saslMechanismsFromConfig(pConf)
+			require.NoError(t, err)
+			assert.Len(t, mechanisms, 1)
+			assert.NotNil(t, mechanisms[0])
+
+			// We don't easily test the underlying mechanism details without brittle casting,
+			// but we can at least check if it doesn't panic when calling Name() or Authenticate.
+			// However, franz-go mechanisms are mostly opaque.
+		})
+	}
+}
+
+func TestSaslMechanismsFromConfigMultiple(t *testing.T) {
+	saslConf := service.NewConfigSpec().Field(saslField())
+	pConf, err := saslConf.ParseYAML(`
+sasl:
+  - mechanism: PLAIN
+    username: foo
+    password: bar
+  - mechanism: SCRAM-SHA-256
+    username: foo
+    password: bar
+`, nil)
+	require.NoError(t, err)
+
+	mechanisms, err := saslMechanismsFromConfig(pConf)
+	require.NoError(t, err)
+	assert.Len(t, mechanisms, 2)
+}

--- a/internal/impl/kafka/input_sarama_kafka.go
+++ b/internal/impl/kafka/input_sarama_kafka.go
@@ -103,7 +103,7 @@ If you're seeing issues writing to or reading from Kafka with this component the
 
 - I'm seeing logs that report `+"`Failed to connect to kafka: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)`"+`, but the brokers are definitely reachable.
 
-Unfortunately this error message will appear for a wide range of connection problems even when the broker endpoint can be reached. Double check your authentication configuration and also ensure that you have [enabled TLS](#tlsenabled) if applicable.`).
+Unfortunately this error message will appear for a wide range of connection problems even when the broker endpoint can be reached. Double check your authentication configuration and also ensure that you have [enabled TLS](#tlsenabled) if applicable.`+kafkaSaramaOAuth2Doc).
 		Fields(
 			service.NewStringListField(iskFieldAddresses).
 				Description("A list of broker addresses to connect to. If an item of the list contains commas it will be expanded into multiple addresses.").

--- a/internal/impl/kafka/integration_sasl_oauth_test.go
+++ b/internal/impl/kafka/integration_sasl_oauth_test.go
@@ -1,0 +1,290 @@
+package kafka_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/sasl/oauth"
+	"github.com/warpstreamlabs/bento/public/service/integration"
+)
+
+func createKafkaTopicSaslOauthConn(ctx context.Context, address, id string, partitions int32) error {
+	topicName := fmt.Sprintf("topic-%v", id)
+
+	opts := []kgo.Opt{kgo.SeedBrokers(address)}
+	var token string
+
+	var err error
+	token, err = unsecuredToken("test-client", 30*time.Minute)
+	if err != nil {
+		return err
+	}
+
+	opts = append(opts, kgo.SASL(oauth.Auth{
+		Token: token,
+	}.AsMechanism()))
+
+	cl, err := kgo.NewClient(opts...)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	createTopicsReq := kmsg.NewPtrCreateTopicsRequest()
+	topicReq := kmsg.NewCreateTopicsRequestTopic()
+	topicReq.NumPartitions = partitions
+	topicReq.Topic = topicName
+	topicReq.ReplicationFactor = 1
+	createTopicsReq.Topics = append(createTopicsReq.Topics, topicReq)
+
+	res, err := createTopicsReq.RequestWith(ctx, cl)
+	if err != nil {
+		return err
+	}
+	if len(res.Topics) != 1 {
+		return fmt.Errorf("expected one topic in response, saw %d", len(res.Topics))
+	}
+	return kerr.ErrorForCode(res.Topics[0].ErrorCode)
+}
+
+func TestIntegrationKafkaOauth2(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Parallel()
+
+	kafkaPort, err := integration.GetFreePort()
+	require.NoError(t, err)
+
+	kafkaPortStr := strconv.Itoa(kafkaPort)
+
+	kafkaConfig := fmt.Sprintf(`
+process.roles=broker,controller
+node.id=1
+controller.quorum.voters=1@localhost:9093
+listeners=BROKER://0.0.0.0:9092,CONTROLLER://localhost:9093
+advertised.listeners=BROKER://localhost:%s
+listener.security.protocol.map=BROKER:SASL_PLAINTEXT,CONTROLLER:PLAINTEXT
+inter.broker.listener.name=BROKER
+controller.listener.names=CONTROLLER
+
+sasl.mechanism.inter.broker.protocol=OAUTHBEARER
+sasl.enabled.mechanisms=OAUTHBEARER
+sasl.server.callback.handler.class=org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler
+sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredLoginCallbackHandler
+
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+`, kafkaPortStr)
+
+	jaasConfig := `KafkaServer {
+  org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required
+  unsecuredLoginStringClaim_sub="kafka-broker";
+};
+KafkaClient {
+  org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required
+  unsecuredLoginStringClaim_sub="kafka-broker";
+};`
+
+	// write kafka & jaas config to file to mount later
+	tmpDir := t.TempDir()
+	kafkaConfigPath := fmt.Sprintf("%s/server.properties", tmpDir)
+	jaasConfigPath := fmt.Sprintf("%s/kafka_server_jaas.conf", tmpDir)
+
+	err = os.WriteFile(kafkaConfigPath, []byte(kafkaConfig), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(jaasConfigPath, []byte(jaasConfig), 0644)
+	require.NoError(t, err)
+
+	// set up kafka container
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	options := &dockertest.RunOptions{
+		Repository:   "apache/kafka",
+		Tag:          "4.1.2",
+		Hostname:     "kafka",
+		ExposedPorts: []string{"9092"},
+		PortBindings: map[docker.Port][]docker.PortBinding{
+			"9092/tcp": {{HostIP: "", HostPort: kafkaPortStr}},
+		},
+		Env: []string{"KAFKA_OPTS=-Djava.security.auth.login.config=/tmp/kafka_server_jaas.conf"},
+		Mounts: []string{
+			fmt.Sprintf("%s:/tmp", tmpDir),
+		},
+		Cmd: []string{
+			"sh", "-c",
+			`/opt/kafka/bin/kafka-storage.sh format -t MkU3OEVBNTcwNTJENDM2Qk -c /tmp/server.properties --ignore-formatted && exec /opt/kafka/bin/kafka-server-start.sh /tmp/server.properties`,
+		},
+	}
+
+	pool.MaxWait = time.Minute
+	resource, err := pool.RunWithOptions(options)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, pool.Purge(resource))
+	})
+
+	_ = resource.Expire(900)
+	require.NoError(t, pool.Retry(func() error {
+		return createKafkaTopicSaslOauthConn(context.Background(), "localhost:"+kafkaPortStr, "sasloauth", 1)
+	}))
+
+	oAuthMockServer := StartMockOAuthServer(t)
+
+	t.Run("kafka franz", func(t *testing.T) {
+		template := fmt.Sprintf(`
+        output:
+          kafka_franz:
+            seed_brokers: [ localhost:$PORT ]
+            topic: $ID
+            sasl:
+              - mechanism: OAUTHBEARER
+                oauth2:
+                  enabled: true
+                  client_key: foo
+                  client_secret: bar
+                  token_url: %s/oauth2/token
+        input:
+          kafka_franz:
+            seed_brokers: [ localhost:$PORT ]
+            topics: [ $ID ]
+            consumer_group: consumer-group-$ID
+            sasl:
+              - mechanism: OAUTHBEARER
+                oauth2:
+                  enabled: true
+                  client_key: foo
+                  client_secret: bar
+                  token_url: %s/oauth2/token`, oAuthMockServer.URL, oAuthMockServer.URL)
+
+		suite := integration.StreamTests(
+			integration.StreamTestSendBatch(10),
+		)
+
+		suite.Run(
+			t, template,
+			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
+				require.NoError(t, createKafkaTopicSaslOauthConn(context.Background(), "localhost:"+kafkaPortStr, vars.ID, 1))
+			}),
+			integration.StreamTestOptPort(kafkaPortStr),
+		)
+	})
+
+	t.Run("kafka sarama", func(t *testing.T) {
+		template := fmt.Sprintf(`
+        output:
+          kafka:
+            addresses: [ localhost:$PORT ]
+            topic: $ID
+            sasl:
+              mechanism: OAUTHBEARER
+              oauth2:
+                enabled: true
+                client_key: foo
+                client_secret: bar
+                token_url: %s/oauth2/token
+        input:
+          kafka:
+            addresses: [ localhost:$PORT ]
+            topics: [ $ID ]
+            consumer_group: consumer-group-$ID
+            sasl:
+              mechanism: OAUTHBEARER
+              oauth2:
+                enabled: true
+                client_key: foo
+                client_secret: bar
+                token_url: %s/oauth2/token`, oAuthMockServer.URL, oAuthMockServer.URL)
+
+		suite := integration.StreamTests(
+			integration.StreamTestSendBatch(10),
+		)
+
+		suite.Run(
+			t, template,
+			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
+				require.NoError(t, createKafkaTopicSaslOauthConn(context.Background(), "localhost:"+kafkaPortStr, vars.ID, 1))
+			}),
+			integration.StreamTestOptPort(kafkaPortStr),
+		)
+	})
+}
+
+//------------------------------------------------------------------------------
+
+type MockOAuthServer struct {
+	URL    string
+	server *http.Server
+}
+
+func StartMockOAuthServer(t *testing.T) *MockOAuthServer {
+	t.Helper()
+
+	ms := &MockOAuthServer{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/token", ms.handleToken)
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	ms.URL = fmt.Sprintf("http://localhost:%d", port)
+	ms.server = &http.Server{Handler: mux}
+	go func() {
+		_ = ms.server.Serve(ln)
+	}()
+	t.Cleanup(func() {
+		_ = ms.server.Close()
+	})
+
+	return ms
+}
+
+func (ms *MockOAuthServer) handleToken(w http.ResponseWriter, r *http.Request) {
+	token, err := unsecuredToken("service-account", 30*time.Minute)
+	if err != nil {
+		http.Error(w, "token generation failed", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"access_token": token,
+		"token_type":   "Bearer",
+		"expires_in":   1800,
+	})
+}
+
+func unsecuredToken(subject string, ttl time.Duration) (string, error) {
+	now := time.Now()
+	header, err := json.Marshal(map[string]string{"alg": "none"})
+	if err != nil {
+		return "", err
+	}
+	claims, err := json.Marshal(map[string]any{
+		"sub": subject,
+		"iat": now.Unix(),
+		"exp": now.Add(ttl).Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(header) + "." + base64.RawURLEncoding.EncodeToString(claims) + ".", nil
+}

--- a/internal/impl/kafka/output_sarama_kafka.go
+++ b/internal/impl/kafka/output_sarama_kafka.go
@@ -72,7 +72,7 @@ If you're seeing issues writing to or reading from Kafka with this component the
 
 - I'm seeing logs that report `+"`Failed to connect to kafka: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)`"+`, but the brokers are definitely reachable.
 
-Unfortunately this error message will appear for a wide range of connection problems even when the broker endpoint can be reached. Double check your authentication configuration and also ensure that you have [enabled TLS](#tlsenabled) if applicable.`+service.OutputPerformanceDocs(true, true)).
+Unfortunately this error message will appear for a wide range of connection problems even when the broker endpoint can be reached. Double check your authentication configuration and also ensure that you have [enabled TLS](#tlsenabled) if applicable.`+kafkaSaramaOAuth2Doc+service.OutputPerformanceDocs(true, true)).
 		Fields(
 			service.NewStringListField(oskFieldAddresses).
 				Description("A list of broker addresses to connect to. If an item of the list contains commas it will be expanded into multiple addresses.").

--- a/internal/impl/kafka/sasl.go
+++ b/internal/impl/kafka/sasl.go
@@ -14,6 +14,8 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/oauth"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 func notImportedAWSFn(c *service.ParsedConfig) (sasl.Mechanism, error) {
@@ -50,6 +52,30 @@ func saslField() *service.ConfigField {
 		service.NewStringField("token").
 			Description("The token to use for a single session's OAUTHBEARER authentication.").
 			Default(""),
+		service.NewObjectField("oauth2",
+			service.NewBoolField("enabled").
+				Description("Whether to use OAuth version 2 in requests.").
+				Default(false),
+			service.NewStringField("client_key").
+				Description("A value used to identify the client to the token provider.").
+				Default(""),
+			service.NewStringField("client_secret").
+				Description("A secret used to establish ownership of the client key.").
+				Default("").Secret(),
+			service.NewURLField("token_url").
+				Description("The URL of the token provider.").
+				Default(""),
+			service.NewStringListField("scopes").
+				Description("A list of optional requested permissions.").
+				Default([]any{}).
+				Advanced(),
+			service.NewAnyMapField("endpoint_params").
+				Description("A list of optional endpoint parameters, values should be arrays of strings.").
+				Advanced().
+				Optional(),
+		).
+			Description("Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.").
+			Optional().Advanced(),
 		service.NewStringMapField("extensions").
 			Description("Key/value pairs to add to OAUTHBEARER authentication requests.").
 			Optional(),
@@ -136,6 +162,63 @@ func plainSaslFromConfig(c *service.ParsedConfig) (sasl.Mechanism, error) {
 }
 
 func oauthSaslFromConfig(c *service.ParsedConfig) (sasl.Mechanism, error) {
+	if c.Contains("oauth2") {
+		if enabled, _ := c.FieldBool("oauth2", "enabled"); enabled {
+			key, err := c.FieldString("oauth2", "client_key")
+			if err != nil {
+				return nil, err
+			}
+			secret, err := c.FieldString("oauth2", "client_secret")
+			if err != nil {
+				return nil, err
+			}
+			tokenURL, err := c.FieldString("oauth2", "token_url")
+			if err != nil {
+				return nil, err
+			}
+			scopes, err := c.FieldStringList("oauth2", "scopes")
+			if err != nil {
+				return nil, err
+			}
+			endpointParams := map[string][]string{}
+			if c.Contains("oauth2", "endpoint_params") {
+				params, err := c.FieldAnyMap("oauth2", "endpoint_params")
+				if err != nil {
+					return nil, err
+				}
+				for k, v := range params {
+					if endpointParams[k], err = v.FieldStringList(); err != nil {
+						return nil, err
+					}
+				}
+			}
+			var extensions map[string]string
+			if c.Contains("extensions") {
+				if extensions, err = c.FieldStringMap("extensions"); err != nil {
+					return nil, err
+				}
+			}
+			conf := &clientcredentials.Config{
+				ClientID:       key,
+				ClientSecret:   secret,
+				TokenURL:       tokenURL,
+				Scopes:         scopes,
+				EndpointParams: endpointParams,
+			}
+			ts := oauth2.ReuseTokenSource(nil, conf.TokenSource(context.Background()))
+			return oauth.Oauth(func(ctx context.Context) (oauth.Auth, error) {
+				tok, err := ts.Token()
+				if err != nil {
+					return oauth.Auth{}, err
+				}
+				return oauth.Auth{
+					Token:      tok.AccessToken,
+					Extensions: extensions,
+				}, nil
+			}), nil
+		}
+	}
+
 	token, err := c.FieldString("token")
 	if err != nil {
 		return nil, err
@@ -200,9 +283,11 @@ const (
 	saramaFieldSASLMechanism   = "mechanism"
 	saramaFieldSASLUser        = "user"
 	saramaFieldSASLPassword    = "password"
-	saramaFieldSASLAccessToken = "access_token"
-	saramaFieldSASLTokenCache  = "token_cache"
-	saramaFieldSASLTokenKey    = "token_key"
+	saramaFieldSASLAccessToken  = "access_token"
+	saramaFieldSASLTokenCache   = "token_cache"
+	saramaFieldSASLTokenKey     = "token_key"
+	saramaFieldSASLOAuth2       = "oauth2"
+	saramaFieldSASLExtensions   = "extensions"
 	saramaFieldSASLAws         = "aws"
 )
 
@@ -239,6 +324,34 @@ func SaramaSASLField() *service.ConfigField {
 		service.NewStringField(saramaFieldSASLTokenKey).
 			Description("Required when using a `token_cache`, the key to query the cache with for tokens.").
 			Default(""),
+		service.NewAnyMapField(saramaFieldSASLExtensions).
+			Description("A list of optional endpoint parameters, values should be arrays of strings.").
+			Advanced().
+			Optional(),
+		service.NewObjectField(saramaFieldSASLOAuth2,
+			service.NewBoolField("enabled").
+				Description("Whether to use OAuth version 2 in requests.").
+				Default(false),
+			service.NewStringField("client_key").
+				Description("A value used to identify the client to the token provider.").
+				Default(""),
+			service.NewStringField("client_secret").
+				Description("A secret used to establish ownership of the client key.").
+				Default("").Secret(),
+			service.NewURLField("token_url").
+				Description("The URL of the token provider.").
+				Default(""),
+			service.NewStringListField("scopes").
+				Description("A list of optional requested permissions.").
+				Default([]any{}).
+				Advanced(),
+			service.NewAnyMapField("endpoint_params").
+				Description("A list of optional endpoint parameters, values should be arrays of strings.").
+				Advanced().
+				Optional(),
+		).
+			Description("Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.").
+			Optional().Advanced(),
 		service.NewObjectField(saramaFieldSASLAws, config.SessionFields()...).
 			Description("Contains AWS specific fields for when the `mechanism` is set to `AWS_MSK_IAM`.").
 			Optional(),
@@ -283,12 +396,27 @@ func ApplySaramaSASLFromParsed(pConf *service.ParsedConfig, mgr *service.Resourc
 		return nil
 	}
 
+	var extensions map[string]string
+	if pConf.Contains(saramaFieldSASLExtensions) {
+		if extensions, err = pConf.FieldStringMap(saramaFieldSASLExtensions); err != nil {
+			return err
+		}
+	}
+
 	switch mechanism {
 	case sarama.SASLTypeOAuth:
 		var tp sarama.AccessTokenProvider
 		var err error
 
-		if tokenCache != "" {
+		if pConf.Contains(saramaFieldSASLOAuth2) {
+			if enabled, _ := pConf.FieldBool(saramaFieldSASLOAuth2, "enabled"); enabled {
+				if tp, err = newOAuth2AccessTokenProvider(pConf.Namespace(saramaFieldSASLOAuth2), extensions); err != nil {
+					return err
+				}
+			}
+		}
+
+		if tp == nil && tokenCache != "" {
 			if tp, err = newCacheAccessTokenProvider(mgr, tokenCache, tokenKey); err != nil {
 				return err
 			}
@@ -382,4 +510,66 @@ func newStaticAccessTokenProvider(token string) (*staticAccessTokenProvider, err
 
 func (s *staticAccessTokenProvider) Token() (*sarama.AccessToken, error) {
 	return &sarama.AccessToken{Token: s.token}, nil
+}
+
+//------------------------------------------------------------------------------
+
+type oauth2AccessTokenProvider struct {
+	ts         oauth2.TokenSource
+	extensions map[string]string
+}
+
+func newOAuth2AccessTokenProvider(conf *service.ParsedConfig, extensions map[string]string) (*oauth2AccessTokenProvider, error) {
+	key, err := conf.FieldString("client_key")
+	if err != nil {
+		return nil, err
+	}
+	secret, err := conf.FieldString("client_secret")
+	if err != nil {
+		return nil, err
+	}
+	tokenURL, err := conf.FieldString("token_url")
+	if err != nil {
+		return nil, err
+	}
+	scopes, err := conf.FieldStringList("scopes")
+	if err != nil {
+		return nil, err
+	}
+	endpointParams := map[string][]string{}
+	if conf.Contains("endpoint_params") {
+		params, err := conf.FieldAnyMap("endpoint_params")
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range params {
+			if endpointParams[k], err = v.FieldStringList(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	oauthConf := &clientcredentials.Config{
+		ClientID:       key,
+		ClientSecret:   secret,
+		TokenURL:       tokenURL,
+		Scopes:         scopes,
+		EndpointParams: endpointParams,
+	}
+
+	return &oauth2AccessTokenProvider{
+		ts:         oauth2.ReuseTokenSource(nil, oauthConf.TokenSource(context.Background())),
+		extensions: extensions,
+	}, nil
+}
+
+func (o *oauth2AccessTokenProvider) Token() (*sarama.AccessToken, error) {
+	tok, err := o.ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return &sarama.AccessToken{
+		Token:      tok.AccessToken,
+		Extensions: o.extensions,
+	}, nil
 }

--- a/internal/impl/kafka/sasl.go
+++ b/internal/impl/kafka/sasl.go
@@ -283,11 +283,11 @@ const (
 	saramaFieldSASLMechanism   = "mechanism"
 	saramaFieldSASLUser        = "user"
 	saramaFieldSASLPassword    = "password"
-	saramaFieldSASLAccessToken  = "access_token"
-	saramaFieldSASLTokenCache   = "token_cache"
-	saramaFieldSASLTokenKey     = "token_key"
-	saramaFieldSASLOAuth2       = "oauth2"
-	saramaFieldSASLExtensions   = "extensions"
+	saramaFieldSASLAccessToken = "access_token"
+	saramaFieldSASLTokenCache  = "token_cache"
+	saramaFieldSASLTokenKey    = "token_key"
+	saramaFieldSASLOAuth2      = "oauth2"
+	saramaFieldSASLExtensions  = "extensions"
 	saramaFieldSASLAws         = "aws"
 )
 

--- a/internal/impl/kafka/sasl.go
+++ b/internal/impl/kafka/sasl.go
@@ -413,16 +413,16 @@ func ApplySaramaSASLFromParsed(pConf *service.ParsedConfig, mgr *service.Resourc
 				if tp, err = newOAuth2AccessTokenProvider(pConf.Namespace(saramaFieldSASLOAuth2), extensions); err != nil {
 					return err
 				}
-			}
-		}
-
-		if tp == nil && tokenCache != "" {
-			if tp, err = newCacheAccessTokenProvider(mgr, tokenCache, tokenKey); err != nil {
-				return err
-			}
-		} else {
-			if tp, err = newStaticAccessTokenProvider(accessToken); err != nil {
-				return err
+			} else {
+				if tokenCache != "" {
+					if tp, err = newCacheAccessTokenProvider(mgr, tokenCache, tokenKey); err != nil {
+						return err
+					}
+				} else {
+					if tp, err = newStaticAccessTokenProvider(accessToken); err != nil {
+						return err
+					}
+				}
 			}
 		}
 		conf.Net.SASL.TokenProvider = tp

--- a/internal/impl/kafka/sasl.go
+++ b/internal/impl/kafka/sasl.go
@@ -18,6 +18,19 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 )
 
+const kafkaSaramaOAuth2Doc = `
+
+### Sasl Oauthbearer Config Options
+
+There are currently 3 ways to configure SASL OAUTH2: 
+
+ - Static Token with ` + "`sasl.access_token`" + `
+ - Token Cache with ` + "`sasl.token_cache` & `sasl.token_key`" + `
+ - Fetching Tokens from an Auth service with the` + "`sasl.oauth2` fields`" + `
+
+
+`
+
 func notImportedAWSFn(c *service.ParsedConfig) (sasl.Mechanism, error) {
 	return nil, errors.New("unable to configure AWS SASL as this binary does not import components/aws")
 }

--- a/internal/impl/kafka/sasl.go
+++ b/internal/impl/kafka/sasl.go
@@ -75,7 +75,7 @@ func saslField() *service.ConfigField {
 				Optional(),
 		).
 			Description("Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.").
-			Optional().Advanced(),
+			Optional().Version("1.18.0").Advanced(),
 		service.NewStringMapField("extensions").
 			Description("Key/value pairs to add to OAUTHBEARER authentication requests.").
 			Optional(),
@@ -193,7 +193,7 @@ func oauthSaslFromConfig(c *service.ParsedConfig) (sasl.Mechanism, error) {
 				}
 			}
 			var extensions map[string]string
-			if c.Contains("extensions") {
+			if c.Contains("oauth2", "extensions") {
 				if extensions, err = c.FieldStringMap("extensions"); err != nil {
 					return nil, err
 				}
@@ -324,10 +324,6 @@ func SaramaSASLField() *service.ConfigField {
 		service.NewStringField(saramaFieldSASLTokenKey).
 			Description("Required when using a `token_cache`, the key to query the cache with for tokens.").
 			Default(""),
-		service.NewAnyMapField(saramaFieldSASLExtensions).
-			Description("A list of optional endpoint parameters, values should be arrays of strings.").
-			Advanced().
-			Optional(),
 		service.NewObjectField(saramaFieldSASLOAuth2,
 			service.NewBoolField("enabled").
 				Description("Whether to use OAuth version 2 in requests.").
@@ -349,9 +345,13 @@ func SaramaSASLField() *service.ConfigField {
 				Description("A list of optional endpoint parameters, values should be arrays of strings.").
 				Advanced().
 				Optional(),
+			service.NewAnyMapField(saramaFieldSASLExtensions).
+				Description("A list of optional endpoint parameters, values should be arrays of strings.").
+				Advanced().
+				Optional(),
 		).
 			Description("Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.").
-			Optional().Advanced(),
+			Optional().Version("1.18.0").Advanced(),
 		service.NewObjectField(saramaFieldSASLAws, config.SessionFields()...).
 			Description("Contains AWS specific fields for when the `mechanism` is set to `AWS_MSK_IAM`.").
 			Optional(),
@@ -396,13 +396,6 @@ func ApplySaramaSASLFromParsed(pConf *service.ParsedConfig, mgr *service.Resourc
 		return nil
 	}
 
-	var extensions map[string]string
-	if pConf.Contains(saramaFieldSASLExtensions) {
-		if extensions, err = pConf.FieldStringMap(saramaFieldSASLExtensions); err != nil {
-			return err
-		}
-	}
-
 	switch mechanism {
 	case sarama.SASLTypeOAuth:
 		var tp sarama.AccessTokenProvider
@@ -410,7 +403,7 @@ func ApplySaramaSASLFromParsed(pConf *service.ParsedConfig, mgr *service.Resourc
 
 		if pConf.Contains(saramaFieldSASLOAuth2) {
 			if enabled, _ := pConf.FieldBool(saramaFieldSASLOAuth2, "enabled"); enabled {
-				if tp, err = newOAuth2AccessTokenProvider(pConf.Namespace(saramaFieldSASLOAuth2), extensions); err != nil {
+				if tp, err = newOAuth2AccessTokenProvider(pConf.Namespace(saramaFieldSASLOAuth2)); err != nil {
 					return err
 				}
 			} else {
@@ -519,7 +512,7 @@ type oauth2AccessTokenProvider struct {
 	extensions map[string]string
 }
 
-func newOAuth2AccessTokenProvider(conf *service.ParsedConfig, extensions map[string]string) (*oauth2AccessTokenProvider, error) {
+func newOAuth2AccessTokenProvider(conf *service.ParsedConfig) (*oauth2AccessTokenProvider, error) {
 	key, err := conf.FieldString("client_key")
 	if err != nil {
 		return nil, err
@@ -546,6 +539,13 @@ func newOAuth2AccessTokenProvider(conf *service.ParsedConfig, extensions map[str
 			if endpointParams[k], err = v.FieldStringList(); err != nil {
 				return nil, err
 			}
+		}
+	}
+
+	var extensions map[string]string
+	if conf.Contains("extensions") {
+		if extensions, err = conf.FieldStringMap(saramaFieldSASLExtensions); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/impl/kafka/sasl_test.go
+++ b/internal/impl/kafka/sasl_test.go
@@ -179,3 +179,33 @@ sasl:
 		t.Errorf("Wrong SASL token: %v != %v", act, expected)
 	}
 }
+
+func TestApplyOAuth2ClientCredentialsSarama(t *testing.T) {
+	saslConf := service.NewConfigSpec().Field(kafka.SaramaSASLField())
+	pConf, err := saslConf.ParseYAML(`
+sasl:
+  mechanism: OAUTHBEARER
+  oauth2:
+    enabled: true
+    client_key: foo
+    client_secret: bar
+    token_url: http://localhost/token
+    scopes: [ a, b ]
+    endpoint_params:
+      foo: [ bar ]
+`, nil)
+	require.NoError(t, err)
+
+	conf := &sarama.Config{}
+	require.NoError(t, kafka.ApplySaramaSASLFromParsed(pConf, service.MockResources(), conf))
+
+	if !conf.Net.SASL.Enable {
+		t.Errorf("SASL not enabled")
+	}
+
+	if conf.Net.SASL.Mechanism != sarama.SASLTypeOAuth {
+		t.Errorf("Wrong SASL mechanism: %v != %v", conf.Net.SASL.Mechanism, sarama.SASLTypeOAuth)
+	}
+
+	require.NotNil(t, conf.Net.SASL.TokenProvider)
+}

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -63,6 +63,14 @@ input:
       access_token: ""
       token_cache: ""
       token_key: ""
+      extensions: {} # No default (optional)
+      oauth2:
+        enabled: false
+        client_key: ""
+        client_secret: ""
+        token_url: ""
+        scopes: []
+        endpoint_params: {} # No default (optional)
       aws:
         region: ""
         endpoint: ""
@@ -430,6 +438,70 @@ Required when using a `token_cache`, the key to query the cache with for tokens.
 
 Type: `string`  
 Default: `""`  
+
+### `sasl.extensions`
+
+A list of optional endpoint parameters, values should be arrays of strings.
+
+
+Type: `object`  
+
+### `sasl.oauth2`
+
+Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.
+
+
+Type: `object`  
+
+### `sasl.oauth2.enabled`
+
+Whether to use OAuth version 2 in requests.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `sasl.oauth2.client_key`
+
+A value used to identify the client to the token provider.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl.oauth2.client_secret`
+
+A secret used to establish ownership of the client key.
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl.oauth2.token_url`
+
+The URL of the token provider.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl.oauth2.scopes`
+
+A list of optional requested permissions.
+
+
+Type: `array`  
+Default: `[]`  
+
+### `sasl.oauth2.endpoint_params`
+
+A list of optional endpoint parameters, values should be arrays of strings.
+
+
+Type: `object`  
 
 ### `sasl.aws`
 

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -151,6 +151,17 @@ If you're seeing issues writing to or reading from Kafka with this component the
 
 Unfortunately this error message will appear for a wide range of connection problems even when the broker endpoint can be reached. Double check your authentication configuration and also ensure that you have [enabled TLS](#tlsenabled) if applicable.
 
+### Sasl Oauthbearer Config Options
+
+There are currently 3 ways to configure SASL OAUTH2: 
+
+ - Static Token with `sasl.access_token`
+ - Token Cache with `sasl.token_cache` & `sasl.token_key`
+ - Fetching Tokens from an Auth service with the`sasl.oauth2` fields`
+
+
+
+
 ## Fields
 
 ### `addresses`

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -63,7 +63,6 @@ input:
       access_token: ""
       token_cache: ""
       token_key: ""
-      extensions: {} # No default (optional)
       oauth2:
         enabled: false
         client_key: ""
@@ -71,6 +70,7 @@ input:
         token_url: ""
         scopes: []
         endpoint_params: {} # No default (optional)
+        extensions: {} # No default (optional)
       aws:
         region: ""
         endpoint: ""
@@ -439,19 +439,13 @@ Required when using a `token_cache`, the key to query the cache with for tokens.
 Type: `string`  
 Default: `""`  
 
-### `sasl.extensions`
-
-A list of optional endpoint parameters, values should be arrays of strings.
-
-
-Type: `object`  
-
 ### `sasl.oauth2`
 
 Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.
 
 
 Type: `object`  
+Requires version 1.18.0 or newer  
 
 ### `sasl.oauth2.enabled`
 
@@ -497,6 +491,13 @@ Type: `array`
 Default: `[]`  
 
 ### `sasl.oauth2.endpoint_params`
+
+A list of optional endpoint parameters, values should be arrays of strings.
+
+
+Type: `object`  
+
+### `sasl.oauth2.extensions`
 
 A list of optional endpoint parameters, values should be arrays of strings.
 

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -508,6 +508,63 @@ The token to use for a single session's OAUTHBEARER authentication.
 Type: `string`  
 Default: `""`  
 
+### `sasl[].oauth2`
+
+Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.
+
+
+Type: `object`  
+
+### `sasl[].oauth2.enabled`
+
+Whether to use OAuth version 2 in requests.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `sasl[].oauth2.client_key`
+
+A value used to identify the client to the token provider.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].oauth2.client_secret`
+
+A secret used to establish ownership of the client key.
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].oauth2.token_url`
+
+The URL of the token provider.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].oauth2.scopes`
+
+A list of optional requested permissions.
+
+
+Type: `array`  
+Default: `[]`  
+
+### `sasl[].oauth2.endpoint_params`
+
+A list of optional endpoint parameters, values should be arrays of strings.
+
+
+Type: `object`  
+
 ### `sasl[].extensions`
 
 Key/value pairs to add to OAUTHBEARER authentication requests.

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -514,6 +514,7 @@ Allows you to specify open authentication via OAuth version 2 using the client c
 
 
 Type: `object`  
+Requires version 1.18.0 or newer  
 
 ### `sasl[].oauth2.enabled`
 

--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -71,6 +71,14 @@ output:
       access_token: ""
       token_cache: ""
       token_key: ""
+      extensions: {} # No default (optional)
+      oauth2:
+        enabled: false
+        client_key: ""
+        client_secret: ""
+        token_url: ""
+        scopes: []
+        endpoint_params: {} # No default (optional)
       aws:
         region: ""
         endpoint: ""
@@ -392,6 +400,70 @@ Required when using a `token_cache`, the key to query the cache with for tokens.
 
 Type: `string`  
 Default: `""`  
+
+### `sasl.extensions`
+
+A list of optional endpoint parameters, values should be arrays of strings.
+
+
+Type: `object`  
+
+### `sasl.oauth2`
+
+Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.
+
+
+Type: `object`  
+
+### `sasl.oauth2.enabled`
+
+Whether to use OAuth version 2 in requests.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `sasl.oauth2.client_key`
+
+A value used to identify the client to the token provider.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl.oauth2.client_secret`
+
+A secret used to establish ownership of the client key.
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl.oauth2.token_url`
+
+The URL of the token provider.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl.oauth2.scopes`
+
+A list of optional requested permissions.
+
+
+Type: `array`  
+Default: `[]`  
+
+### `sasl.oauth2.endpoint_params`
+
+A list of optional endpoint parameters, values should be arrays of strings.
+
+
+Type: `object`  
 
 ### `sasl.aws`
 

--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -71,7 +71,6 @@ output:
       access_token: ""
       token_cache: ""
       token_key: ""
-      extensions: {} # No default (optional)
       oauth2:
         enabled: false
         client_key: ""
@@ -79,6 +78,7 @@ output:
         token_url: ""
         scopes: []
         endpoint_params: {} # No default (optional)
+        extensions: {} # No default (optional)
       aws:
         region: ""
         endpoint: ""
@@ -401,19 +401,13 @@ Required when using a `token_cache`, the key to query the cache with for tokens.
 Type: `string`  
 Default: `""`  
 
-### `sasl.extensions`
-
-A list of optional endpoint parameters, values should be arrays of strings.
-
-
-Type: `object`  
-
 ### `sasl.oauth2`
 
 Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.
 
 
 Type: `object`  
+Requires version 1.18.0 or newer  
 
 ### `sasl.oauth2.enabled`
 
@@ -459,6 +453,13 @@ Type: `array`
 Default: `[]`  
 
 ### `sasl.oauth2.endpoint_params`
+
+A list of optional endpoint parameters, values should be arrays of strings.
+
+
+Type: `object`  
+
+### `sasl.oauth2.extensions`
 
 A list of optional endpoint parameters, values should be arrays of strings.
 

--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -152,6 +152,17 @@ If you're seeing issues writing to or reading from Kafka with this component the
 
 Unfortunately this error message will appear for a wide range of connection problems even when the broker endpoint can be reached. Double check your authentication configuration and also ensure that you have [enabled TLS](#tlsenabled) if applicable.
 
+### Sasl Oauthbearer Config Options
+
+There are currently 3 ways to configure SASL OAUTH2: 
+
+ - Static Token with `sasl.access_token`
+ - Token Cache with `sasl.token_cache` & `sasl.token_key`
+ - Fetching Tokens from an Auth service with the`sasl.oauth2` fields`
+
+
+
+
 ## Performance
 
 This output benefits from sending multiple messages in flight in parallel for improved performance. You can tune the max number of in flight messages (or message batches) with the field `max_in_flight`.

--- a/website/docs/components/outputs/kafka_franz.md
+++ b/website/docs/components/outputs/kafka_franz.md
@@ -648,6 +648,63 @@ The token to use for a single session's OAUTHBEARER authentication.
 Type: `string`  
 Default: `""`  
 
+### `sasl[].oauth2`
+
+Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.
+
+
+Type: `object`  
+
+### `sasl[].oauth2.enabled`
+
+Whether to use OAuth version 2 in requests.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `sasl[].oauth2.client_key`
+
+A value used to identify the client to the token provider.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].oauth2.client_secret`
+
+A secret used to establish ownership of the client key.
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].oauth2.token_url`
+
+The URL of the token provider.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].oauth2.scopes`
+
+A list of optional requested permissions.
+
+
+Type: `array`  
+Default: `[]`  
+
+### `sasl[].oauth2.endpoint_params`
+
+A list of optional endpoint parameters, values should be arrays of strings.
+
+
+Type: `object`  
+
 ### `sasl[].extensions`
 
 Key/value pairs to add to OAUTHBEARER authentication requests.

--- a/website/docs/components/outputs/kafka_franz.md
+++ b/website/docs/components/outputs/kafka_franz.md
@@ -654,6 +654,7 @@ Allows you to specify open authentication via OAuth version 2 using the client c
 
 
 Type: `object`  
+Requires version 1.18.0 or newer  
 
 ### `sasl[].oauth2.enabled`
 


### PR DESCRIPTION
resolves https://github.com/warpstreamlabs/bento/issues/437.
config for both kafka/franz:
  
      oauth2:
        enabled: <bool>
        client_key: <id>
        client_secret: <secret>
        token_url: <://your/oidc/realm/token>
        scopes: [] #optional
        endpoint_params: {} #optional