### PR TITLE
chore: Update golangci-lint to v2.11.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.10.0
+        version: v2.11.3
 
   build-docsite:
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ go build -o bento ./cmd/bento/main.go
 Bento uses [golangci-lint][golangci-lint] for linting, which you can install with:
 
 ```shell
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.3
 ```
 
 Check the [GitHub Action](.github/workflows/test.yml ) for what version is currently used in CI.


### PR DESCRIPTION
For some reason the golangci-lint `v9` action is breaking against `2.10.0`.