### PR TITLE
fix(sql): nil pointer panics, race conditions, and resource leaks in SQL outputs

### DIFF
--- a/internal/impl/sql/cache_sql.go
+++ b/internal/impl/sql/cache_sql.go
@@ -194,8 +194,10 @@ func newSQLCacheFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (
 	go func() {
 		<-s.shutSig.HardStopChan()
 		s.dbMut.Lock()
-		_ = s.db.Close()
-		s.db = nil
+		if s.db != nil {
+			_ = s.db.Close()
+			s.db = nil
+		}
 		s.dbMut.Unlock()
 		s.shutSig.TriggerHasStopped()
 	}()

--- a/internal/impl/sql/cache_sql.go
+++ b/internal/impl/sql/cache_sql.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -95,6 +96,7 @@ type sqlCache struct {
 	driver string
 	dsn    string
 	db     *sql.DB
+	dbMut  sync.RWMutex
 
 	keyColumn string
 
@@ -182,6 +184,8 @@ func newSQLCacheFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (
 		}
 	}
 
+	s.dbMut.Lock()
+	defer s.dbMut.Unlock()
 	if s.db, err = sqlOpenWithReworks(context.Background(), s.logger, s.driver, s.dsn, connSettings); err != nil {
 		return nil, err
 	}
@@ -189,13 +193,18 @@ func newSQLCacheFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (
 
 	go func() {
 		<-s.shutSig.HardStopChan()
+		s.dbMut.Lock()
 		_ = s.db.Close()
+		s.db = nil
+		s.dbMut.Unlock()
 		s.shutSig.TriggerHasStopped()
 	}()
 	return s, nil
 }
 
 func (s *sqlCache) Get(ctx context.Context, key string) (value []byte, err error) {
+	s.dbMut.RLock()
+	defer s.dbMut.RUnlock()
 	err = s.selectBuilder.
 		Where(squirrel.Eq{s.keyColumn: key}).
 		RunWith(s.db).QueryRowContext(ctx).
@@ -207,11 +216,15 @@ func (s *sqlCache) Get(ctx context.Context, key string) (value []byte, err error
 }
 
 func (s *sqlCache) Set(ctx context.Context, key string, value []byte, ttl *time.Duration) error {
+	s.dbMut.RLock()
+	defer s.dbMut.RUnlock()
 	_, err := s.upsertBuilder.Values(key, value).RunWith(s.db).ExecContext(ctx)
 	return err
 }
 
 func (s *sqlCache) Add(ctx context.Context, key string, value []byte, ttl *time.Duration) error {
+	s.dbMut.RLock()
+	defer s.dbMut.RUnlock()
 	_, err := s.insertBuilder.Values(key, value).RunWith(s.db).ExecContext(ctx)
 	if err != nil {
 		// This is difficult, ideally we need to translate any error that
@@ -225,6 +238,8 @@ func (s *sqlCache) Add(ctx context.Context, key string, value []byte, ttl *time.
 }
 
 func (s *sqlCache) Delete(ctx context.Context, key string) error {
+	s.dbMut.RLock()
+	defer s.dbMut.RUnlock()
 	_, err := s.deleteBuilder.Where(squirrel.Eq{s.keyColumn: key}).RunWith(s.db).ExecContext(ctx)
 	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		err = service.ErrKeyNotFound

--- a/internal/impl/sql/conn_fields.go
+++ b/internal/impl/sql/conn_fields.go
@@ -54,7 +54,6 @@ The ` + "[`duckdb`](https://github.com/duckdb/duckdb-go)" + ` driver requires cg
 	Example("db_file.duckdb?threads=4&access_mode=READ_ONLY")
 
 func connFields() []*service.ConfigField {
-
 	connFields := []*service.ConfigField{
 		service.NewStringListField("init_files").
 			Description(`
@@ -164,7 +163,6 @@ CREATE TABLE IF NOT EXISTS some_table (
 	connFields = append(connFields, config.SessionFields()...)
 
 	return connFields
-
 }
 
 func rawQueryField() *service.ConfigField {
@@ -222,7 +220,6 @@ func (c *connSettings) apply(ctx context.Context, db *sql.DB, log *service.Logge
 				log.Debug("Successfully ran init_statement")
 			}
 		}
-
 	})
 }
 
@@ -348,7 +345,7 @@ func reworkDSN(driver, dsn string) (string, error) {
 		uq := u.Query()
 		u.Path = uq.Get("database")
 		if username, password := uq.Get("username"), uq.Get("password"); username != "" {
-			if password != "" {
+			if password == "" {
 				u.User = url.User(username)
 			} else {
 				u.User = url.UserPassword(username, password)

--- a/internal/impl/sql/conn_fields_export_test.go
+++ b/internal/impl/sql/conn_fields_export_test.go
@@ -1,0 +1,4 @@
+package sql
+
+// ReworkDSN exposes the unexported reworkDSN function for tests.
+var ReworkDSN = reworkDSN

--- a/internal/impl/sql/conn_fields_test.go
+++ b/internal/impl/sql/conn_fields_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	isql "github.com/warpstreamlabs/bento/internal/impl/sql"
 	baws "github.com/warpstreamlabs/bento/internal/impl/sql/aws"
 
 	"github.com/warpstreamlabs/bento/public/service"
@@ -360,6 +361,71 @@ func TestBuildAwsDsnFromIAM(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedDSN, awsSecretDsn)
+		})
+	}
+}
+
+func TestReworkDSN(t *testing.T) {
+	tests := []struct {
+		name        string
+		driver      string
+		dsn         string
+		expectedDSN string
+		expectError bool
+	}{
+		{
+			name:        "non-clickhouse driver is unchanged",
+			driver:      "postgres",
+			dsn:         "postgres://user:pass@localhost:5432/mydb",
+			expectedDSN: "postgres://user:pass@localhost:5432/mydb",
+		},
+		{
+			name:        "clickhouse modern-style DSN is unchanged",
+			driver:      "clickhouse",
+			dsn:         "clickhouse://user:pass@localhost:9000/mydb",
+			expectedDSN: "clickhouse://user:pass@localhost:9000/mydb",
+		},
+		{
+			name:        "old-style tcp with username and password",
+			driver:      "clickhouse",
+			dsn:         "tcp://localhost:9000?database=mydb&username=alice&password=secret",
+			expectedDSN: "clickhouse://alice:secret@localhost:9000/mydb",
+		},
+		{
+			name:        "old-style tcp with username only",
+			driver:      "clickhouse",
+			dsn:         "tcp://localhost:9000?database=mydb&username=alice",
+			expectedDSN: "clickhouse://alice@localhost:9000/mydb",
+		},
+		{
+			name:        "old-style tcp with no credentials",
+			driver:      "clickhouse",
+			dsn:         "tcp://localhost:9000?database=mydb",
+			expectedDSN: "clickhouse://localhost:9000/mydb",
+		},
+		{
+			name:        "old-style tcp with extra query params preserved",
+			driver:      "clickhouse",
+			dsn:         "tcp://localhost:9000?database=mydb&username=alice&password=secret&compress=true",
+			expectedDSN: "clickhouse://alice:secret@localhost:9000/mydb?compress=true",
+		},
+		{
+			name:        "old-style tcp with no database",
+			driver:      "clickhouse",
+			dsn:         "tcp://localhost:9000?username=alice&password=secret",
+			expectedDSN: "clickhouse://alice:secret@localhost:9000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isql.ReworkDSN(tt.driver, tt.dsn)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedDSN, got)
+			}
 		})
 	}
 }

--- a/internal/impl/sql/input_sql_select.go
+++ b/internal/impl/sql/input_sql_select.go
@@ -251,6 +251,7 @@ func (s *sqlSelectInput) Connect(ctx context.Context) (err error) {
 		}
 		if s.db != nil {
 			_ = s.db.Close()
+			s.db = nil
 		}
 		s.dbMut.Unlock()
 

--- a/internal/impl/sql/input_sql_select.go
+++ b/internal/impl/sql/input_sql_select.go
@@ -249,10 +249,12 @@ func (s *sqlSelectInput) Connect(ctx context.Context) (err error) {
 			_ = s.rows.Close()
 			s.rows = nil
 		}
+
 		if s.db != nil {
 			_ = s.db.Close()
 			s.db = nil
 		}
+
 		s.dbMut.Unlock()
 
 		s.shutSig.TriggerHasStopped()

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -254,8 +254,7 @@ func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageB
 	s.dbMut.RLock()
 	defer s.dbMut.RUnlock()
 
-	db := s.db
-	if db == nil {
+	if s.db == nil {
 		return service.ErrNotConnected
 	}
 
@@ -271,7 +270,7 @@ func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageB
 
 	if s.useTxStmt {
 		var err error
-		if tx, err = db.Begin(); err != nil {
+		if tx, err = s.db.Begin(); err != nil {
 			return err
 		}
 		sqlStr, _, err := insertBuilder.ToSql()
@@ -313,7 +312,7 @@ func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageB
 
 	var err error
 	if tx == nil {
-		_, err = insertBuilder.RunWith(db).ExecContext(ctx)
+		_, err = insertBuilder.RunWith(s.db).ExecContext(ctx)
 	} else {
 		err = tx.Commit()
 	}

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -273,14 +273,19 @@ func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageB
 		if tx, err = s.db.Begin(); err != nil {
 			return err
 		}
+		defer func() {
+			_ = tx.Rollback()
+		}()
 		sqlStr, _, err := insertBuilder.ToSql()
 		if err != nil {
 			return err
 		}
 		if stmt, err = tx.Prepare(sqlStr); err != nil {
-			_ = tx.Rollback()
 			return err
 		}
+		defer func() {
+			_ = stmt.Close()
+		}()
 	}
 
 	for i := range batch {
@@ -305,7 +310,6 @@ func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageB
 		if tx == nil {
 			insertBuilder = insertBuilder.Values(args...)
 		} else if _, err := stmt.Exec(args...); err != nil {
-			_ = tx.Rollback()
 			return err
 		}
 	}

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -254,7 +254,8 @@ func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageB
 	s.dbMut.RLock()
 	defer s.dbMut.RUnlock()
 
-	if s.db == nil {
+	db := s.db
+	if db == nil {
 		return service.ErrNotConnected
 	}
 
@@ -270,7 +271,7 @@ func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageB
 
 	if s.useTxStmt {
 		var err error
-		if tx, err = s.db.Begin(); err != nil {
+		if tx, err = db.Begin(); err != nil {
 			return err
 		}
 		sqlStr, _, err := insertBuilder.ToSql()
@@ -312,7 +313,7 @@ func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageB
 
 	var err error
 	if tx == nil {
-		_, err = insertBuilder.RunWith(s.db).ExecContext(ctx)
+		_, err = insertBuilder.RunWith(db).ExecContext(ctx)
 	} else {
 		err = tx.Commit()
 	}

--- a/internal/impl/sql/output_sql_insert_test.go
+++ b/internal/impl/sql/output_sql_insert_test.go
@@ -139,9 +139,7 @@ func TestSQLInsertOutputWriteBatchBadConnNilRace(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for range workers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ready() // hold until all goroutines are lined up
 
 			// Step 1: read path — RLock, nil check, then use s.db.
@@ -156,7 +154,7 @@ func TestSQLInsertOutputWriteBatchBadConnNilRace(t *testing.T) {
 			output.dbMut.Lock()
 			output.db = db
 			output.dbMut.Unlock()
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -195,9 +193,7 @@ func TestSQLInsertOutputShutdownNilRace(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for range workers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ready()
 
 			// Step 1: read path.
@@ -215,7 +211,7 @@ func TestSQLInsertOutputShutdownNilRace(t *testing.T) {
 			output.dbMut.Lock()
 			output.db = db
 			output.dbMut.Unlock()
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/impl/sql/output_sql_insert_test.go
+++ b/internal/impl/sql/output_sql_insert_test.go
@@ -2,12 +2,83 @@ package sql
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"sync"
 	"testing"
 
+	"github.com/Jeffail/shutdown"
+	"github.com/Masterminds/squirrel"
 	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
 
 	"github.com/warpstreamlabs/bento/public/service"
 )
+
+// newTestSQLiteDB opens a real file-backed SQLite database using the modernc
+// driver (already a module dependency) and runs createStmt to prepare the
+// schema.
+//
+// A file-backed DSN is used instead of ":memory:" because SQLite in-memory
+// databases are per-connection: when the sql.DB pool opens a second connection
+// it would see an empty database and return "no such table" errors.
+func newTestSQLiteDB(t *testing.T, createStmt string) *sql.DB {
+	t.Helper()
+
+	f, err := os.CreateTemp(t.TempDir(), "test_*.db")
+	if err != nil {
+		t.Fatalf("create temp db file: %v", err)
+	}
+	f.Close()
+
+	dsn := fmt.Sprintf("file:%s?cache=shared&mode=rwc", f.Name())
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec(createStmt); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	return db
+}
+
+// raceBarrier returns a function that blocks each caller until all n callers
+// have arrived, then releases them all simultaneously. This maximises
+// concurrent overlap and makes the TOCTOU window as wide as possible.
+func raceBarrier(n int) func() {
+	var (
+		mu      sync.Mutex
+		cond    = sync.NewCond(&mu)
+		waiting int
+	)
+	return func() {
+		mu.Lock()
+		defer mu.Unlock()
+		waiting++
+		if waiting == n {
+			cond.Broadcast()
+		} else {
+			for waiting < n {
+				cond.Wait()
+			}
+		}
+	}
+}
+
+// defaultConnSettings returns a minimal connSettings that performs no
+// credential rewriting, suitable for tests that inject a *sql.DB directly.
+func defaultConnSettings() *connSettings {
+	return &connSettings{
+		getCredentials: func(dsn, driver string) (string, string, error) {
+			return dsn, "", nil
+		},
+	}
+}
 
 func TestSQLInsertOutputEmptyShutdown(t *testing.T) {
 	conf := `
@@ -27,4 +98,125 @@ args_mapping: 'root = [ this.id ]'
 	insertOutput, err := newSQLInsertOutputFromConfig(insertConfig, service.MockResources())
 	require.NoError(t, err)
 	require.NoError(t, insertOutput.Close(context.Background()))
+}
+
+// TestSQLInsertOutputWriteBatchBadConnNilRace verifies that a concurrent
+// bad-connection nil-reset cannot cause a nil pointer panic inside writeBatch.
+//
+// Before the fix, writeBatch held only an RLock for its entire duration.
+// RWMutex permits concurrent readers, so a writer could legally acquire the
+// write lock and zero s.db between the nil check and the subsequent use of
+// s.db inside insertBuilder.RunWith — a classic TOCTOU window. The fix
+// captures s.db into a local variable immediately after the nil check so that
+// both the check and the use refer to the same pointer value.
+//
+// NOTE: because every access to s.db goes through the mutex, go test -race
+// does not flag this. The additional serialisation the race detector imposes
+// may also suppress the interleaving needed to trigger the panic. Run without
+// -race for the most reliable reproduction of the unfixed behaviour.
+func TestSQLInsertOutputWriteBatchBadConnNilRace(t *testing.T) {
+	db := newTestSQLiteDB(t, `CREATE TABLE IF NOT EXISTS things (foo TEXT NOT NULL)`)
+
+	output := &sqlInsertOutput{
+		logger:       service.MockResources().Logger(),
+		shutSig:      shutdown.NewSignaller(),
+		driver:       "sqlite",
+		builder:      squirrel.Insert("things").Columns("foo"),
+		connSettings: defaultConnSettings(),
+		db:           db,
+	}
+
+	ctx := context.Background()
+	batch := service.MessageBatch{
+		service.NewMessage([]byte(`{"foo":"bar"}`)),
+	}
+
+	// Each goroutine races writeBatch (RLock → nil check → use s.db) against
+	// the bad-conn nil-reset (write lock → s.db = nil).
+	const workers = 50
+
+	ready := raceBarrier(workers)
+	var wg sync.WaitGroup
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ready() // hold until all goroutines are lined up
+
+			// Step 1: read path — RLock, nil check, then use s.db.
+			_ = output.writeBatch(ctx, batch)
+
+			// Step 2: write path — mirrors WriteBatch's bad-conn error handler.
+			output.dbMut.Lock()
+			output.db = nil
+			output.dbMut.Unlock()
+
+			// Restore so the next goroutine has a live *sql.DB to race against.
+			output.dbMut.Lock()
+			output.db = db
+			output.dbMut.Unlock()
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestSQLInsertOutputShutdownNilRace verifies that the shutdown goroutine
+// zeroing s.db cannot cause a nil pointer panic inside a concurrent writeBatch.
+//
+// The shutdown goroutine spawned inside Connect acquires the write lock,
+// closes the database, and sets s.db = nil — the same write-side operation as
+// the bad-conn reset, just from a different call site. The fix (capturing s.db
+// into a local variable under the RLock) closes the TOCTOU window for both
+// writers identically.
+//
+// NOTE: go test -race does not flag this. Run without -race to reproduce.
+func TestSQLInsertOutputShutdownNilRace(t *testing.T) {
+	db := newTestSQLiteDB(t, `CREATE TABLE IF NOT EXISTS things (foo TEXT NOT NULL)`)
+
+	output := &sqlInsertOutput{
+		logger:       service.MockResources().Logger(),
+		shutSig:      shutdown.NewSignaller(),
+		driver:       "sqlite",
+		builder:      squirrel.Insert("things").Columns("foo"),
+		connSettings: defaultConnSettings(),
+		db:           db,
+	}
+
+	ctx := context.Background()
+	batch := service.MessageBatch{
+		service.NewMessage([]byte(`{"foo":"bar"}`)),
+	}
+
+	const workers = 50
+
+	ready := raceBarrier(workers)
+	var wg sync.WaitGroup
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ready()
+
+			// Step 1: read path.
+			_ = output.writeBatch(ctx, batch)
+
+			// Step 2: mimic the shutdown goroutine's critical section.
+			output.dbMut.Lock()
+			if output.db != nil {
+				_ = output.db.Close()
+				output.db = nil
+			}
+			output.dbMut.Unlock()
+
+			// Restore for the next goroutine.
+			output.dbMut.Lock()
+			output.db = db
+			output.dbMut.Unlock()
+		}()
+	}
+
+	wg.Wait()
 }

--- a/internal/impl/sql/output_sql_insert_test.go
+++ b/internal/impl/sql/output_sql_insert_test.go
@@ -17,13 +17,6 @@ import (
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
-// newTestSQLiteDB opens a real file-backed SQLite database using the modernc
-// driver (already a module dependency) and runs createStmt to prepare the
-// schema.
-//
-// A file-backed DSN is used instead of ":memory:" because SQLite in-memory
-// databases are per-connection: when the sql.DB pool opens a second connection
-// it would see an empty database and return "no such table" errors.
 func newTestSQLiteDB(t *testing.T, createStmt string) *sql.DB {
 	t.Helper()
 
@@ -47,9 +40,6 @@ func newTestSQLiteDB(t *testing.T, createStmt string) *sql.DB {
 	return db
 }
 
-// raceBarrier returns a function that blocks each caller until all n callers
-// have arrived, then releases them all simultaneously. This maximises
-// concurrent overlap and makes the TOCTOU window as wide as possible.
 func raceBarrier(n int) func() {
 	var (
 		mu      sync.Mutex
@@ -70,8 +60,6 @@ func raceBarrier(n int) func() {
 	}
 }
 
-// defaultConnSettings returns a minimal connSettings that performs no
-// credential rewriting, suitable for tests that inject a *sql.DB directly.
 func defaultConnSettings() *connSettings {
 	return &connSettings{
 		getCredentials: func(dsn, driver string) (string, string, error) {
@@ -100,77 +88,24 @@ args_mapping: 'root = [ this.id ]'
 	require.NoError(t, insertOutput.Close(context.Background()))
 }
 
-// TestSQLInsertOutputWriteBatchBadConnNilRace verifies that a concurrent
-// bad-connection nil-reset cannot cause a nil pointer panic inside writeBatch.
-//
-// Before the fix, writeBatch held only an RLock for its entire duration.
-// RWMutex permits concurrent readers, so a writer could legally acquire the
-// write lock and zero s.db between the nil check and the subsequent use of
-// s.db inside insertBuilder.RunWith — a classic TOCTOU window. The fix
-// captures s.db into a local variable immediately after the nil check so that
-// both the check and the use refer to the same pointer value.
-//
-// NOTE: because every access to s.db goes through the mutex, go test -race
-// does not flag this. The additional serialisation the race detector imposes
-// may also suppress the interleaving needed to trigger the panic. Run without
-// -race for the most reliable reproduction of the unfixed behaviour.
-func TestSQLInsertOutputWriteBatchBadConnNilRace(t *testing.T) {
-	db := newTestSQLiteDB(t, `CREATE TABLE IF NOT EXISTS things (foo TEXT NOT NULL)`)
-
+func TestSQLInsertOutputWriteBatchWithNilDB(t *testing.T) {
 	output := &sqlInsertOutput{
 		logger:       service.MockResources().Logger(),
 		shutSig:      shutdown.NewSignaller(),
 		driver:       "sqlite",
 		builder:      squirrel.Insert("things").Columns("foo"),
 		connSettings: defaultConnSettings(),
-		db:           db,
 	}
 
-	ctx := context.Background()
 	batch := service.MessageBatch{
 		service.NewMessage([]byte(`{"foo":"bar"}`)),
 	}
 
-	// Each goroutine races writeBatch (RLock → nil check → use s.db) against
-	// the bad-conn nil-reset (write lock → s.db = nil).
-	const workers = 50
-
-	ready := raceBarrier(workers)
-	var wg sync.WaitGroup
-
-	for range workers {
-		wg.Go(func() {
-			ready() // hold until all goroutines are lined up
-
-			// Step 1: read path — RLock, nil check, then use s.db.
-			_ = output.writeBatch(ctx, batch)
-
-			// Step 2: write path — mirrors WriteBatch's bad-conn error handler.
-			output.dbMut.Lock()
-			output.db = nil
-			output.dbMut.Unlock()
-
-			// Restore so the next goroutine has a live *sql.DB to race against.
-			output.dbMut.Lock()
-			output.db = db
-			output.dbMut.Unlock()
-		})
-	}
-
-	wg.Wait()
+	err := output.WriteBatch(context.Background(), batch)
+	require.ErrorIs(t, err, service.ErrNotConnected)
 }
 
-// TestSQLInsertOutputShutdownNilRace verifies that the shutdown goroutine
-// zeroing s.db cannot cause a nil pointer panic inside a concurrent writeBatch.
-//
-// The shutdown goroutine spawned inside Connect acquires the write lock,
-// closes the database, and sets s.db = nil — the same write-side operation as
-// the bad-conn reset, just from a different call site. The fix (capturing s.db
-// into a local variable under the RLock) closes the TOCTOU window for both
-// writers identically.
-//
-// NOTE: go test -race does not flag this. Run without -race to reproduce.
-func TestSQLInsertOutputShutdownNilRace(t *testing.T) {
+func TestSQLInsertOutputWriteBatchConcurrentDBClose(t *testing.T) {
 	db := newTestSQLiteDB(t, `CREATE TABLE IF NOT EXISTS things (foo TEXT NOT NULL)`)
 
 	output := &sqlInsertOutput{
@@ -196,10 +131,8 @@ func TestSQLInsertOutputShutdownNilRace(t *testing.T) {
 		wg.Go(func() {
 			ready()
 
-			// Step 1: read path.
-			_ = output.writeBatch(ctx, batch)
+			_ = output.WriteBatch(ctx, batch)
 
-			// Step 2: mimic the shutdown goroutine's critical section.
 			output.dbMut.Lock()
 			if output.db != nil {
 				_ = output.db.Close()
@@ -207,7 +140,6 @@ func TestSQLInsertOutputShutdownNilRace(t *testing.T) {
 			}
 			output.dbMut.Unlock()
 
-			// Restore for the next goroutine.
 			output.dbMut.Lock()
 			output.db = db
 			output.dbMut.Unlock()

--- a/internal/impl/sql/output_sql_insert_test.go
+++ b/internal/impl/sql/output_sql_insert_test.go
@@ -17,57 +17,6 @@ import (
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
-func newTestSQLiteDB(t *testing.T, createStmt string) *sql.DB {
-	t.Helper()
-
-	f, err := os.CreateTemp(t.TempDir(), "test_*.db")
-	if err != nil {
-		t.Fatalf("create temp db file: %v", err)
-	}
-	f.Close()
-
-	dsn := fmt.Sprintf("file:%s?cache=shared&mode=rwc", f.Name())
-	db, err := sql.Open("sqlite", dsn)
-	if err != nil {
-		t.Fatalf("sql.Open: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
-	if _, err := db.Exec(createStmt); err != nil {
-		t.Fatalf("create table: %v", err)
-	}
-
-	return db
-}
-
-func raceBarrier(n int) func() {
-	var (
-		mu      sync.Mutex
-		cond    = sync.NewCond(&mu)
-		waiting int
-	)
-	return func() {
-		mu.Lock()
-		defer mu.Unlock()
-		waiting++
-		if waiting == n {
-			cond.Broadcast()
-		} else {
-			for waiting < n {
-				cond.Wait()
-			}
-		}
-	}
-}
-
-func defaultConnSettings() *connSettings {
-	return &connSettings{
-		getCredentials: func(dsn, driver string) (string, string, error) {
-			return dsn, "", nil
-		},
-	}
-}
-
 func TestSQLInsertOutputEmptyShutdown(t *testing.T) {
 	conf := `
 driver: meow
@@ -147,4 +96,55 @@ func TestSQLInsertOutputWriteBatchConcurrentDBClose(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func newTestSQLiteDB(t *testing.T, createStmt string) *sql.DB {
+	t.Helper()
+
+	f, err := os.CreateTemp(t.TempDir(), "test_*.db")
+	if err != nil {
+		t.Fatalf("create temp db file: %v", err)
+	}
+	f.Close()
+
+	dsn := fmt.Sprintf("file:%s?cache=shared&mode=rwc", f.Name())
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec(createStmt); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	return db
+}
+
+func raceBarrier(n int) func() {
+	var (
+		mu      sync.Mutex
+		cond    = sync.NewCond(&mu)
+		waiting int
+	)
+	return func() {
+		mu.Lock()
+		defer mu.Unlock()
+		waiting++
+		if waiting == n {
+			cond.Broadcast()
+		} else {
+			for waiting < n {
+				cond.Wait()
+			}
+		}
+	}
+}
+
+func defaultConnSettings() *connSettings {
+	return &connSettings{
+		getCredentials: func(dsn, driver string) (string, string, error) {
+			return dsn, "", nil
+		},
+	}
 }

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -198,8 +198,10 @@ func (s *sqlRawOutput) Connect(ctx context.Context) error {
 		<-s.shutSig.HardStopChan()
 
 		s.dbMut.Lock()
-		_ = s.db.Close()
-		s.db = nil
+		if s.db != nil {
+			_ = s.db.Close()
+			s.db = nil
+		}
 		s.dbMut.Unlock()
 
 		s.shutSig.TriggerHasStopped()

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -227,8 +227,7 @@ func (s *sqlRawOutput) writeBatch(ctx context.Context, batch service.MessageBatc
 	s.dbMut.RLock()
 	defer s.dbMut.RUnlock()
 
-	db := s.db
-	if db == nil {
+	if s.db == nil {
 		return service.ErrNotConnected
 	}
 
@@ -264,7 +263,7 @@ func (s *sqlRawOutput) writeBatch(ctx context.Context, batch service.MessageBatc
 			}
 		}
 
-		if _, err := db.ExecContext(ctx, queryStr, args...); err != nil {
+		if _, err := s.db.ExecContext(ctx, queryStr, args...); err != nil {
 			return err
 		}
 	}

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -199,6 +199,7 @@ func (s *sqlRawOutput) Connect(ctx context.Context) error {
 
 		s.dbMut.Lock()
 		_ = s.db.Close()
+		s.db = nil
 		s.dbMut.Unlock()
 
 		s.shutSig.TriggerHasStopped()
@@ -225,6 +226,11 @@ func (s *sqlRawOutput) WriteBatch(ctx context.Context, batch service.MessageBatc
 func (s *sqlRawOutput) writeBatch(ctx context.Context, batch service.MessageBatch) error {
 	s.dbMut.RLock()
 	defer s.dbMut.RUnlock()
+
+	db := s.db
+	if db == nil {
+		return service.ErrNotConnected
+	}
 
 	var executor *service.MessageBatchBloblangExecutor
 	if s.argsMapping != nil {
@@ -258,7 +264,7 @@ func (s *sqlRawOutput) writeBatch(ctx context.Context, batch service.MessageBatc
 			}
 		}
 
-		if _, err := s.db.ExecContext(ctx, queryStr, args...); err != nil {
+		if _, err := db.ExecContext(ctx, queryStr, args...); err != nil {
 			return err
 		}
 	}

--- a/internal/impl/sql/output_sql_raw_test.go
+++ b/internal/impl/sql/output_sql_raw_test.go
@@ -1,0 +1,201 @@
+package sql
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+func TestSQLRawOutputEmptyShutdown(t *testing.T) {
+	conf := `
+driver: meow
+dsn: woof
+query: "INSERT INTO footable (foo) VALUES (?);"
+`
+
+	spec := sqlRawOutputConfig()
+	env := service.NewEnvironment()
+
+	rawConfig, err := spec.ParseYAML(conf, env)
+	require.NoError(t, err)
+
+	rawOutput, err := newSQLRawOutputFromConfig(rawConfig, service.MockResources())
+	require.NoError(t, err)
+	require.NoError(t, rawOutput.Close(context.Background()))
+}
+
+// TestSQLRawOutputWriteBatchBadConnNilRace verifies that a concurrent
+// bad-connection nil-reset cannot cause a nil pointer panic inside writeBatch.
+//
+// Before the fix, writeBatch held only an RLock and called s.db.ExecContext
+// with no nil guard. A writer could legally acquire the write lock and zero
+// s.db between the start of writeBatch and the ExecContext call — a classic
+// TOCTOU window. The fix captures s.db into a local variable under the RLock
+// and adds a nil guard, so both the check and all subsequent uses refer to the
+// same pointer value.
+//
+// NOTE: because every access to s.db goes through the mutex, go test -race
+// does not flag this. The additional serialisation the race detector imposes
+// may also suppress the interleaving needed to trigger the panic. Run without
+// -race for the most reliable reproduction of the unfixed behaviour.
+func TestSQLRawOutputWriteBatchBadConnNilRace(t *testing.T) {
+	db := newTestSQLiteDB(t, `CREATE TABLE IF NOT EXISTS things (foo TEXT NOT NULL)`)
+
+	output := newSQLRawOutput(
+		service.MockResources().Logger(),
+		"sqlite",
+		"", // dsn unused; we inject db directly below
+		"INSERT INTO things (foo) VALUES (?)",
+		nil, // no dynamic query
+		nil, // no args mapping
+		defaultConnSettings(),
+		aws.Config{},
+	)
+	output.db = db
+
+	ctx := context.Background()
+	batch := service.MessageBatch{
+		service.NewMessage([]byte(`hello`)),
+	}
+
+	// Each goroutine races writeBatch (RLock → nil check → ExecContext) against
+	// the bad-conn nil-reset (write lock → s.db = nil).
+	const workers = 50
+
+	ready := raceBarrier(workers)
+	var wg sync.WaitGroup
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ready() // hold until all goroutines are lined up
+
+			// Step 1: read path — RLock, nil check, then db.ExecContext.
+			_ = output.writeBatch(ctx, batch)
+
+			// Step 2: write path — mirrors WriteBatch's bad-conn error handler.
+			output.dbMut.Lock()
+			output.db = nil
+			output.dbMut.Unlock()
+
+			// Restore so the next goroutine has a live *sql.DB to race against.
+			output.dbMut.Lock()
+			output.db = db
+			output.dbMut.Unlock()
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestSQLRawOutputShutdownNilRace verifies that the shutdown goroutine zeroing
+// s.db cannot cause a nil pointer panic inside a concurrent writeBatch.
+//
+// The shutdown goroutine spawned inside Connect acquires the write lock, closes
+// the database, and sets s.db = nil — the same write-side operation as the
+// bad-conn reset, just from a different call site. The fix (capturing s.db into
+// a local variable under the RLock) closes the TOCTOU window for both writers
+// identically.
+//
+// NOTE: go test -race does not flag this. Run without -race to reproduce.
+func TestSQLRawOutputShutdownNilRace(t *testing.T) {
+	db := newTestSQLiteDB(t, `CREATE TABLE IF NOT EXISTS things (foo TEXT NOT NULL)`)
+
+	output := newSQLRawOutput(
+		service.MockResources().Logger(),
+		"sqlite",
+		"",
+		"INSERT INTO things (foo) VALUES (?)",
+		nil,
+		nil,
+		defaultConnSettings(),
+		aws.Config{},
+	)
+	output.db = db
+
+	ctx := context.Background()
+	batch := service.MessageBatch{
+		service.NewMessage([]byte(`hello`)),
+	}
+
+	const workers = 50
+
+	ready := raceBarrier(workers)
+	var wg sync.WaitGroup
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ready()
+
+			// Step 1: read path.
+			_ = output.writeBatch(ctx, batch)
+
+			// Step 2: mimic the shutdown goroutine's critical section.
+			output.dbMut.Lock()
+			if output.db != nil {
+				_ = output.db.Close()
+				output.db = nil
+			}
+			output.dbMut.Unlock()
+
+			// Restore for the next goroutine.
+			output.dbMut.Lock()
+			output.db = db
+			output.dbMut.Unlock()
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestSQLRawOutputShutdownNilsDB verifies that writeBatch returns
+// service.ErrNotConnected after the shutdown goroutine closes and nils s.db.
+//
+// Before the fix, the shutdown goroutine in Connect closed s.db but never set
+// s.db = nil. writeBatch would then find a non-nil but closed *sql.DB, call
+// ExecContext, and receive a generic driver error. Because that error does not
+// match driver.ErrBadConn, WriteBatch's reconnect branch was never taken and
+// the output remained permanently broken until the process restarted.
+//
+// The fix adds s.db = nil to the shutdown goroutine after Close, consistent
+// with the sql_insert shutdown goroutine. writeBatch then sees a nil db, returns
+// service.ErrNotConnected, and WriteBatch's caller can trigger a reconnect.
+func TestSQLRawOutputShutdownNilsDB(t *testing.T) {
+	db := newTestSQLiteDB(t, `CREATE TABLE IF NOT EXISTS things (foo TEXT NOT NULL)`)
+
+	output := newSQLRawOutput(
+		service.MockResources().Logger(),
+		"sqlite",
+		"",
+		"INSERT INTO things (foo) VALUES (?)",
+		nil,
+		nil,
+		defaultConnSettings(),
+		aws.Config{},
+	)
+	output.db = db
+
+	// Reproduce what the fixed shutdown goroutine does: close and nil s.db.
+	output.dbMut.Lock()
+	_ = output.db.Close()
+	output.db = nil
+	output.dbMut.Unlock()
+
+	ctx := context.Background()
+	batch := service.MessageBatch{
+		service.NewMessage([]byte(`hello`)),
+	}
+
+	err := output.writeBatch(ctx, batch)
+	require.ErrorIs(t, err, service.ErrNotConnected)
+}

--- a/internal/impl/sql/output_sql_raw_test.go
+++ b/internal/impl/sql/output_sql_raw_test.go
@@ -73,9 +73,7 @@ func TestSQLRawOutputWriteBatchBadConnNilRace(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for range workers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ready() // hold until all goroutines are lined up
 
 			// Step 1: read path — RLock, nil check, then db.ExecContext.
@@ -90,7 +88,7 @@ func TestSQLRawOutputWriteBatchBadConnNilRace(t *testing.T) {
 			output.dbMut.Lock()
 			output.db = db
 			output.dbMut.Unlock()
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -132,9 +130,7 @@ func TestSQLRawOutputShutdownNilRace(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for range workers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ready()
 
 			// Step 1: read path.
@@ -152,7 +148,7 @@ func TestSQLRawOutputShutdownNilRace(t *testing.T) {
 			output.dbMut.Lock()
 			output.db = db
 			output.dbMut.Unlock()
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/impl/sql/output_sql_raw_test.go
+++ b/internal/impl/sql/output_sql_raw_test.go
@@ -31,80 +31,27 @@ query: "INSERT INTO footable (foo) VALUES (?);"
 	require.NoError(t, rawOutput.Close(context.Background()))
 }
 
-// TestSQLRawOutputWriteBatchBadConnNilRace verifies that a concurrent
-// bad-connection nil-reset cannot cause a nil pointer panic inside writeBatch.
-//
-// Before the fix, writeBatch held only an RLock and called s.db.ExecContext
-// with no nil guard. A writer could legally acquire the write lock and zero
-// s.db between the start of writeBatch and the ExecContext call — a classic
-// TOCTOU window. The fix captures s.db into a local variable under the RLock
-// and adds a nil guard, so both the check and all subsequent uses refer to the
-// same pointer value.
-//
-// NOTE: because every access to s.db goes through the mutex, go test -race
-// does not flag this. The additional serialisation the race detector imposes
-// may also suppress the interleaving needed to trigger the panic. Run without
-// -race for the most reliable reproduction of the unfixed behaviour.
-func TestSQLRawOutputWriteBatchBadConnNilRace(t *testing.T) {
-	db := newTestSQLiteDB(t, `CREATE TABLE IF NOT EXISTS things (foo TEXT NOT NULL)`)
-
+func TestSQLRawOutputWriteBatchWithNilDB(t *testing.T) {
 	output := newSQLRawOutput(
 		service.MockResources().Logger(),
 		"sqlite",
-		"", // dsn unused; we inject db directly below
+		"",
 		"INSERT INTO things (foo) VALUES (?)",
-		nil, // no dynamic query
-		nil, // no args mapping
+		nil,
+		nil,
 		defaultConnSettings(),
 		aws.Config{},
 	)
-	output.db = db
 
-	ctx := context.Background()
 	batch := service.MessageBatch{
 		service.NewMessage([]byte(`hello`)),
 	}
 
-	// Each goroutine races writeBatch (RLock → nil check → ExecContext) against
-	// the bad-conn nil-reset (write lock → s.db = nil).
-	const workers = 50
-
-	ready := raceBarrier(workers)
-	var wg sync.WaitGroup
-
-	for range workers {
-		wg.Go(func() {
-			ready() // hold until all goroutines are lined up
-
-			// Step 1: read path — RLock, nil check, then db.ExecContext.
-			_ = output.writeBatch(ctx, batch)
-
-			// Step 2: write path — mirrors WriteBatch's bad-conn error handler.
-			output.dbMut.Lock()
-			output.db = nil
-			output.dbMut.Unlock()
-
-			// Restore so the next goroutine has a live *sql.DB to race against.
-			output.dbMut.Lock()
-			output.db = db
-			output.dbMut.Unlock()
-		})
-	}
-
-	wg.Wait()
+	err := output.WriteBatch(context.Background(), batch)
+	require.ErrorIs(t, err, service.ErrNotConnected)
 }
 
-// TestSQLRawOutputShutdownNilRace verifies that the shutdown goroutine zeroing
-// s.db cannot cause a nil pointer panic inside a concurrent writeBatch.
-//
-// The shutdown goroutine spawned inside Connect acquires the write lock, closes
-// the database, and sets s.db = nil — the same write-side operation as the
-// bad-conn reset, just from a different call site. The fix (capturing s.db into
-// a local variable under the RLock) closes the TOCTOU window for both writers
-// identically.
-//
-// NOTE: go test -race does not flag this. Run without -race to reproduce.
-func TestSQLRawOutputShutdownNilRace(t *testing.T) {
+func TestSQLRawOutputWriteBatchConcurrentDBClose(t *testing.T) {
 	db := newTestSQLiteDB(t, `CREATE TABLE IF NOT EXISTS things (foo TEXT NOT NULL)`)
 
 	output := newSQLRawOutput(
@@ -133,10 +80,8 @@ func TestSQLRawOutputShutdownNilRace(t *testing.T) {
 		wg.Go(func() {
 			ready()
 
-			// Step 1: read path.
-			_ = output.writeBatch(ctx, batch)
+			_ = output.WriteBatch(ctx, batch)
 
-			// Step 2: mimic the shutdown goroutine's critical section.
 			output.dbMut.Lock()
 			if output.db != nil {
 				_ = output.db.Close()
@@ -144,7 +89,6 @@ func TestSQLRawOutputShutdownNilRace(t *testing.T) {
 			}
 			output.dbMut.Unlock()
 
-			// Restore for the next goroutine.
 			output.dbMut.Lock()
 			output.db = db
 			output.dbMut.Unlock()
@@ -152,46 +96,4 @@ func TestSQLRawOutputShutdownNilRace(t *testing.T) {
 	}
 
 	wg.Wait()
-}
-
-// TestSQLRawOutputShutdownNilsDB verifies that writeBatch returns
-// service.ErrNotConnected after the shutdown goroutine closes and nils s.db.
-//
-// Before the fix, the shutdown goroutine in Connect closed s.db but never set
-// s.db = nil. writeBatch would then find a non-nil but closed *sql.DB, call
-// ExecContext, and receive a generic driver error. Because that error does not
-// match driver.ErrBadConn, WriteBatch's reconnect branch was never taken and
-// the output remained permanently broken until the process restarted.
-//
-// The fix adds s.db = nil to the shutdown goroutine after Close, consistent
-// with the sql_insert shutdown goroutine. writeBatch then sees a nil db, returns
-// service.ErrNotConnected, and WriteBatch's caller can trigger a reconnect.
-func TestSQLRawOutputShutdownNilsDB(t *testing.T) {
-	db := newTestSQLiteDB(t, `CREATE TABLE IF NOT EXISTS things (foo TEXT NOT NULL)`)
-
-	output := newSQLRawOutput(
-		service.MockResources().Logger(),
-		"sqlite",
-		"",
-		"INSERT INTO things (foo) VALUES (?)",
-		nil,
-		nil,
-		defaultConnSettings(),
-		aws.Config{},
-	)
-	output.db = db
-
-	// Reproduce what the fixed shutdown goroutine does: close and nil s.db.
-	output.dbMut.Lock()
-	_ = output.db.Close()
-	output.db = nil
-	output.dbMut.Unlock()
-
-	ctx := context.Background()
-	batch := service.MessageBatch{
-		service.NewMessage([]byte(`hello`)),
-	}
-
-	err := output.writeBatch(ctx, batch)
-	require.ErrorIs(t, err, service.ErrNotConnected)
 }

--- a/internal/impl/sql/processor_sql_insert.go
+++ b/internal/impl/sql/processor_sql_insert.go
@@ -198,6 +198,7 @@ func NewSQLInsertProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 
 		s.dbMut.Lock()
 		_ = s.db.Close()
+		s.db = nil
 		s.dbMut.Unlock()
 
 		s.shutSig.TriggerHasStopped()
@@ -223,14 +224,19 @@ func (s *sqlInsertProcessor) ProcessBatch(ctx context.Context, batch service.Mes
 		if tx, err = s.db.Begin(); err != nil {
 			return nil, err
 		}
+		defer func() {
+			_ = tx.Rollback()
+		}()
 		sqlStr, _, err := insertBuilder.ToSql()
 		if err != nil {
 			return nil, err
 		}
 		if stmt, err = tx.Prepare(sqlStr); err != nil {
-			_ = tx.Rollback()
 			return nil, err
 		}
+		defer func() {
+			_ = stmt.Close()
+		}()
 	}
 
 	for i, msg := range batch {

--- a/internal/impl/sql/processor_sql_insert.go
+++ b/internal/impl/sql/processor_sql_insert.go
@@ -197,8 +197,10 @@ func NewSQLInsertProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 		<-s.shutSig.HardStopChan()
 
 		s.dbMut.Lock()
-		_ = s.db.Close()
-		s.db = nil
+		if s.db != nil {
+			_ = s.db.Close()
+			s.db = nil
+		}
 		s.dbMut.Unlock()
 
 		s.shutSig.TriggerHasStopped()

--- a/internal/impl/sql/processor_sql_raw.go
+++ b/internal/impl/sql/processor_sql_raw.go
@@ -202,8 +202,10 @@ func newSQLRawProcessor(
 		<-s.shutSig.HardStopChan()
 
 		s.dbMut.Lock()
-		_ = s.db.Close()
-		s.db = nil
+		if s.db != nil {
+			_ = s.db.Close()
+			s.db = nil
+		}
 		s.dbMut.Unlock()
 
 		s.shutSig.TriggerHasStopped()

--- a/internal/impl/sql/processor_sql_raw.go
+++ b/internal/impl/sql/processor_sql_raw.go
@@ -203,6 +203,7 @@ func newSQLRawProcessor(
 
 		s.dbMut.Lock()
 		_ = s.db.Close()
+		s.db = nil
 		s.dbMut.Unlock()
 
 		s.shutSig.TriggerHasStopped()
@@ -275,6 +276,7 @@ func (s *sqlRawProcessor) ProcessBatch(ctx context.Context, batch service.Messag
 			} else {
 				msg.SetStructuredMut(jArray)
 			}
+			_ = rows.Close()
 		}
 	}
 	return []service.MessageBatch{batch}, nil

--- a/internal/impl/sql/processor_sql_select.go
+++ b/internal/impl/sql/processor_sql_select.go
@@ -198,8 +198,10 @@ func NewSQLSelectProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 		<-s.shutSig.HardStopChan()
 
 		s.dbMut.Lock()
-		_ = s.db.Close()
-		s.db = nil
+		if s.db != nil {
+			_ = s.db.Close()
+			s.db = nil
+		}
 		s.dbMut.Unlock()
 
 		s.shutSig.TriggerHasStopped()

--- a/internal/impl/sql/processor_sql_select.go
+++ b/internal/impl/sql/processor_sql_select.go
@@ -199,6 +199,7 @@ func NewSQLSelectProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 
 		s.dbMut.Lock()
 		_ = s.db.Close()
+		s.db = nil
 		s.dbMut.Unlock()
 
 		s.shutSig.TriggerHasStopped()
@@ -259,6 +260,7 @@ func (s *sqlSelectProcessor) ProcessBatch(ctx context.Context, batch service.Mes
 		} else {
 			msg.SetStructuredMut(jArray)
 		}
+		_ = rows.Close()
 	}
 	return []service.MessageBatch{batch}, nil
 }


### PR DESCRIPTION
This fixes a collection of bugs in the SQL output, processor, and cache components. Most are latent race conditions or resource leaks that show up under load or during shutdown.

We experienced a bug that would be fixed by these changes in production during a database upgrade.

Fixes #770 

### Changes

- `output_sql_insert`, `processor_sql_insert`: Replaced scattered `tx.Rollback()` calls with `defer tx.Rollback()` so rollback always fires on early return. Added `defer stmt.Close()` to ensure prepared statements are released.
- `output_sql_raw`, `processor_sql_raw`, `processor_sql_select`, `input_sql_select`: Set `db = nil` after `db.Close()` in shutdown goroutines. Added a nil-guard in `writeBatch` - previously a write after shutdown would panic rather than return `ErrNotConnected`.
- `processor_sql_raw`, `processor_sql_select`: Added `rows.Close()` after iterating result sets. Without this, DB connections were held open longer than needed.
- `cache_sql`: Added a `sync.RWMutex` around the `db` field. The shutdown goroutine and all cache methods (`Get`, `Set`, `Add`, `Delete`) were accessing it without synchronization.
- `conn_fields`: Fixed an inverted condition in `reworkDSN` for ClickHouse legacy TCP DSNs - the `password == ""` branch was backwards, so username-only connections got the wrong user info.

### Explanation

The shutdown race could cause a nil dereference mid-write. Prepared statements leaked on partial failures. Rows from raw/select processors were never explicitly closed, holding connections open. The DSN bug silently misconfigured ClickHouse connections that had a username but no password.

Tests cover the `reworkDSN` logic (including the fixed inversion) and nil-connection behavior for `sql_insert` and `sql_raw` outputs.

