### PR TITLE
fix: reject output conditions with unknown matcher keys

### DIFF
--- a/internal/config/test/output.go
+++ b/internal/config/test/output.go
@@ -90,6 +90,7 @@ func (c OutputConditionsMap) CheckAll(fs fs.FS, dir string, part *message.Part) 
 
 func OutputConditionsFromParsed(pConf *docs.ParsedConfig) (m OutputConditionsMap, err error) {
 	m = OutputConditionsMap{}
+	line, _ := pConf.Line()
 	if pConf.Contains(fieldOutputBloblang) {
 		var tmpStr string
 		if tmpStr, err = pConf.FieldString(fieldOutputBloblang); err != nil {
@@ -119,11 +120,11 @@ func OutputConditionsFromParsed(pConf *docs.ParsedConfig) (m OutputConditionsMap
 		m[fieldOutputContentMatches] = ContentMatchesCondition(tmpStr)
 	}
 
-	if pConf.Contains(fieldOutputMetadataEquals) {
-		var tmpMap map[string]*docs.ParsedConfig
-		if tmpMap, err = pConf.FieldAnyMap(fieldOutputMetadataEquals); err != nil {
-			return
-		}
+	var tmpMap map[string]*docs.ParsedConfig
+	if tmpMap, err = pConf.FieldAnyMap(fieldOutputMetadataEquals); err != nil {
+		return
+	}
+	if len(tmpMap) > 0 {
 		metaMap := MetadataEqualsCondition{}
 		for k, v := range tmpMap {
 			if metaMap[k], err = v.FieldAny(); err != nil {
@@ -179,6 +180,13 @@ func OutputConditionsFromParsed(pConf *docs.ParsedConfig) (m OutputConditionsMap
 			return
 		}
 		m[fieldOutputJSONContains] = ContentJSONContainsCondition(tmpStr)
+	}
+
+	if len(m) == 0 {
+		if line > 0 {
+			return nil, fmt.Errorf("output condition at line %d must define at least one valid matcher", line)
+		}
+		return nil, errors.New("output condition must define at least one valid matcher")
 	}
 	return
 }

--- a/internal/config/test/output_test.go
+++ b/internal/config/test/output_test.go
@@ -83,6 +83,19 @@ metadata_equals:
 	assert.Equal(t, "(2,1) field this_doesnt_exist not recognised", lints[0].Error())
 }
 
+func TestConditionUnmarshalOnlyUnknownCondFails(t *testing.T) {
+	node, err := docs.UnmarshalYAML([]byte(`
+not_a_valid_matcher: "false"
+`))
+	require.NoError(t, err)
+
+	pConf, err := outputFields().ParsedConfigFromAny(node)
+	require.NoError(t, err)
+
+	_, err = OutputConditionsFromParsed(pConf)
+	require.EqualError(t, err, "output condition at line 2 must define at least one valid matcher")
+}
+
 func TestConditionCheckAll(t *testing.T) {
 	color.NoColor = true
 


### PR DESCRIPTION
## Bug
Fixes #382. A typo in an  matcher key can currently pass silently. Unknown matcher keys are dropped during parsing, leaving an empty condition map that acts as a no-op and lets the test pass.

## Fix
- Treat empty parsed output condition blocks as invalid and return a parser error.
- Parse  only when it actually contains keys, so it no longer masks empty/unknown matcher blocks.
- Added regression coverage for a condition block that only contains an unknown matcher.

## Validation
- 

This keeps valid test cases unchanged while failing fast on matcher typos.

Greetings, saschabuehrle