### PR TITLE
fix(ci): Assign resource limits to govulncheck job

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -7,7 +7,7 @@ on:
   #   paths:
   #     - go.mod
   #     - go.sum
-  pull_request:
+  # pull_request:
   #   paths:
   #     - go.mod
   #     - go.sum


### PR DESCRIPTION
Seems the `govulncheck` job is being OOM killed.

Running it locally without trying to tune the performance and the process used almost 20GiB (Go v1.26.0, Darwin/ARM64, M3 Chip).

<img width="650" height="130" alt="image" src="https://github.com/user-attachments/assets/d3d5e1cb-95d9-49c4-addf-ebbe793268dc" />

See how the job passes when we use `GOMEMLIMIT` (and other performanc vars):
- https://github.com/warpstreamlabs/bento/actions/runs/23352099808/job/67933270598?pr=784

But fails without these (presumably due to being OOM killed):
- https://github.com/warpstreamlabs/bento/actions/runs/23334485823/job/67933508819

## Changes

- Attaches a `GOMEMLIMIT=12GiB` to prevent any more memory being assigned than what the 14GiB would allow.
- Adds some other vars to help tune performance (i.e disable GC with `GOGC=off` and set `GOMAXPROCS=4` to match that of runner)