### PR TITLE
update(go): minor bump to 1.26

### DIFF
--- a/.github/workflows/cross_build.yml
+++ b/.github/workflows/cross_build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/deploy-docsite.yml
+++ b/.github/workflows/deploy-docsite.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
         check-latest: true
 
     - name: Deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
         check-latest: true
 
     - name: Release Notes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
         check-latest: true
 
     - name: Download External Deps
@@ -63,7 +63,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
         check-latest: true
 
     - name: Lint

--- a/go.mod
+++ b/go.mod
@@ -455,4 +455,4 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
-go 1.25.0
+go 1.26

--- a/go.mod
+++ b/go.mod
@@ -216,6 +216,7 @@ require (
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -393,7 +394,7 @@ require (
 	github.com/neo4j/neo4j-go-driver/v5 v5.24.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/opencontainers/runc v1.1.12 // indirect
+	github.com/opencontainers/runc v1.2.8 // indirect
 	github.com/oschwald/maxminddb-golang v1.11.0 // indirect
 	github.com/paulmach/orb v0.12.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1615,8 +1615,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/opencontainers/runc v1.1.12 h1:BOIssBaW1La0/qbNZHXOOa71dZfZEQOzW7dqQf3phss=
-github.com/opencontainers/runc v1.1.12/go.mod h1:S+lQwSfncpBha7XTy/5lBwWgm5+y5Ma/O44Ekby9FK8=
+github.com/opencontainers/runc v1.2.8 h1:RnEICeDReapbZ5lZEgHvj7E9Q3Eex9toYmaGBsbvU5Q=
+github.com/opencontainers/runc v1.2.8/go.mod h1:cC0YkmZcuvr+rtBZ6T7NBoVbMGNAdLa/21vIElJDOzI=
 github.com/opensearch-project/opensearch-go/v4 v4.5.0 h1:26XckmmF6MhlXt91Bu1yY6R51jy1Ns/C3XgIfvyeTRo=
 github.com/opensearch-project/opensearch-go/v4 v4.5.0/go.mod h1:VmFc7dqOEM3ZtLhrpleOzeq+cqUgNabqQG5gX0xId64=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/internal/bloblang/query/methods_test.go
+++ b/internal/bloblang/query/methods_test.go
@@ -2712,7 +2712,7 @@ func TestSliceHelperFunctions(t *testing.T) {
 				length:    10,
 				start:     nil,
 				end:       nil,
-				step:      ptr(int64(-1)),
+				step:      new(int64(-1)),
 				wantStart: 9,
 				wantEnd:   -1,
 				wantStep:  -1,
@@ -2720,8 +2720,8 @@ func TestSliceHelperFunctions(t *testing.T) {
 			{
 				name:      "negative indices",
 				length:    10,
-				start:     ptr(int64(-3)),
-				end:       ptr(int64(-1)),
+				start:     new(int64(-3)),
+				end:       new(int64(-1)),
 				step:      nil,
 				wantStart: 7,
 				wantEnd:   9,
@@ -2730,8 +2730,8 @@ func TestSliceHelperFunctions(t *testing.T) {
 			{
 				name:      "out of bounds clamping",
 				length:    5,
-				start:     ptr(int64(-10)),
-				end:       ptr(int64(10)),
+				start:     new(int64(-10)),
+				end:       new(int64(10)),
 				step:      nil,
 				wantStart: 0,
 				wantEnd:   5,
@@ -2750,25 +2750,20 @@ func TestSliceHelperFunctions(t *testing.T) {
 	})
 
 	t.Run("sliceString", func(t *testing.T) {
-		result, err := sliceString("hello world", ptr(int64(0)), ptr(int64(5)), ptr(int64(2)))
+		result, err := sliceString("hello world", new(int64(0)), new(int64(5)), new(int64(2)))
 		require.NoError(t, err)
 		assert.Equal(t, "hlo", result)
 	})
 
 	t.Run("sliceBytes", func(t *testing.T) {
-		result, err := sliceBytes([]byte("hello"), ptr(int64(1)), ptr(int64(4)), nil)
+		result, err := sliceBytes([]byte("hello"), new(int64(1)), new(int64(4)), nil)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("ell"), result)
 	})
 
 	t.Run("sliceArray", func(t *testing.T) {
-		result, err := sliceArray([]any{"a", "b", "c", "d"}, ptr(int64(1)), ptr(int64(3)), nil)
+		result, err := sliceArray([]any{"a", "b", "c", "d"}, new(int64(1)), new(int64(3)), nil)
 		require.NoError(t, err)
 		assert.Equal(t, []any{"b", "c"}, result)
 	})
-}
-
-// Helper function to create pointers to int64 values
-func ptr(i int64) *int64 {
-	return &i
 }

--- a/internal/cli/common/manager.go
+++ b/internal/cli/common/manager.go
@@ -296,7 +296,7 @@ func (s *StoppableManager) Stop(ctx context.Context) error {
 		return err
 	}
 	if err := s.mgr.CloseObservability(ctx); err != nil {
-		s.mgr.Logger().Error("Failed to cleanly close observability components: %w", err)
+		s.mgr.Logger().Error("Failed to cleanly close observability components: %v", err)
 	}
 	return nil
 }

--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -56,7 +56,7 @@ func RunService(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) int {
 		}
 	}
 	if strict && len(lints) > 0 {
-		logger.Error(cliOpts.ExecTemplate("Shutting down due to linter errors, to prevent shutdown run {{.ProductName}} with --chilled"))
+		logger.Error("%s", cliOpts.ExecTemplate("Shutting down due to linter errors, to prevent shutdown run {{.ProductName}} with --chilled"))
 		return 1
 	}
 
@@ -66,12 +66,12 @@ func RunService(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) int {
 
 	stoppableManager, err := CreateManager(c, cliOpts, logger, streamsMode, conf)
 	if err != nil {
-		logger.Error(err.Error())
+		logger.Error("%s", err.Error())
 		return 1
 	}
 
 	if err := cliOpts.OnManagerInitialised(stoppableManager.mgr, pConf); err != nil {
-		logger.Error(err.Error())
+		logger.Error("%s", err.Error())
 		return 1
 	}
 
@@ -138,7 +138,7 @@ func initStreamsMode(
 		}
 	}
 	if strict && len(lints) > 0 {
-		logger.Error(opts.ExecTemplate("Shutting down due to stream linter errors, to prevent shutdown run {{.ProductName}} with --chilled"))
+		logger.Error("%s", opts.ExecTemplate("Shutting down due to stream linter errors, to prevent shutdown run {{.ProductName}} with --chilled"))
 		os.Exit(1)
 	}
 
@@ -152,7 +152,7 @@ func initStreamsMode(
 			os.Exit(1)
 		}
 	}
-	logger.Info(opts.ExecTemplate("Launching {{.ProductName}} in streams mode, use CTRL+C to close"))
+	logger.Info("%s", opts.ExecTemplate("Launching {{.ProductName}} in streams mode, use CTRL+C to close"))
 
 	if err := confReader.SubscribeStreamChanges(func(id string, newStreamConf *stream.Config) error {
 		ctx, done := context.WithTimeout(context.Background(), time.Second*30)
@@ -212,7 +212,7 @@ func initNormalMode(
 
 	stoppableStream := NewSwappableStopper(initStream)
 
-	logger.Info(opts.ExecTemplate("Launching a {{.ProductName}} instance, use CTRL+C to close"))
+	logger.Info("%s", opts.ExecTemplate("Launching a {{.ProductName}} instance, use CTRL+C to close"))
 
 	if err := confReader.SubscribeConfigChanges(func(newStreamConf *config.Type) error {
 		ctx, done := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/config/reader.go
+++ b/internal/config/reader.go
@@ -390,7 +390,7 @@ func (r *Reader) TriggerMainUpdate(mgr bundle.NewManagement, strict bool, newPat
 
 	lintlog := mgr.Logger()
 	for _, lint := range lints {
-		lintlog.Info(lint)
+		lintlog.Info("%s", lint)
 	}
 	if strict && len(lints) > 0 {
 		mgr.Logger().Error("Rejecting updated main config due to linter errors, to allow linting errors run Bento with --chilled")
@@ -399,7 +399,7 @@ func (r *Reader) TriggerMainUpdate(mgr bundle.NewManagement, strict bool, newPat
 		return noReread(errors.New("file contained linting errors and is running in strict mode"))
 	}
 	for _, lintWarn := range lintWarns {
-		lintlog.Warn(lintWarn)
+		lintlog.Warn("%s", lintWarn)
 	}
 
 	// If the main config file has been changed then we remove all resources

--- a/internal/config/resource_reader.go
+++ b/internal/config/resource_reader.go
@@ -263,7 +263,7 @@ func (r *Reader) TriggerResourceUpdate(mgr bundle.NewManagement, strict bool, pa
 
 	lintlog := mgr.Logger()
 	for _, lint := range lints {
-		lintlog.Info(lint)
+		lintlog.Info("%s", lint)
 	}
 	if strict && len(lints) > 0 {
 		mgr.Logger().Error("Rejecting updated resource config due to linter errors, to allow linting errors run Bento with --chilled")
@@ -271,7 +271,7 @@ func (r *Reader) TriggerResourceUpdate(mgr bundle.NewManagement, strict bool, pa
 	}
 
 	for _, lintWarn := range lintWarns {
-		lintlog.Warn(lintWarn)
+		lintlog.Warn("%s", lintWarn)
 	}
 
 	newInfo := resInfoFromConfig(&newResConf)

--- a/internal/config/stream_reader.go
+++ b/internal/config/stream_reader.go
@@ -230,14 +230,14 @@ func (r *Reader) TriggerStreamUpdate(mgr bundle.NewManagement, strict bool, path
 
 	lintlog := mgr.Logger()
 	for _, lint := range lints {
-		lintlog.Info(lint)
+		lintlog.Info("%s", lint)
 	}
 	if strict && len(lints) > 0 {
 		mgr.Logger().Error("Rejecting updated stream %v config due to linter errors, to allow linting errors run Bento with --chilled.", info.id)
 		return noReread(errors.New("file contained linting errors and is running in strict mode"))
 	}
 	for _, lintWarn := range lintWarns {
-		lintlog.Warn(lintWarn)
+		lintlog.Warn("%s", lintWarn)
 	}
 
 	if err := r.streamUpdateFn(info.id, &conf); err != nil {

--- a/internal/impl/amqp09/input.go
+++ b/internal/impl/amqp09/input.go
@@ -327,13 +327,13 @@ func (a *amqp09Reader) disconnect() error {
 
 	if a.amqpChan != nil {
 		if err := a.amqpChan.Cancel(a.consumerTag, true); err != nil {
-			a.log.Errorf("Failed to cancel consumer: %w", err)
+			a.log.Errorf("Failed to cancel consumer: %v", err)
 		}
 		a.amqpChan = nil
 	}
 	if a.conn != nil {
 		if err := a.conn.Close(); err != nil {
-			a.log.Errorf("Failed to close connection cleanly: %w", err)
+			a.log.Errorf("Failed to close connection cleanly: %v", err)
 		}
 		a.conn = nil
 	}

--- a/internal/impl/amqp09/output.go
+++ b/internal/impl/amqp09/output.go
@@ -295,7 +295,7 @@ func (a *amqp09Writer) Connect(ctx context.Context) error {
 
 	if sExchange, isStatic := a.exchange.Static(); isStatic {
 		if err := a.declareExchange(sExchange); err != nil {
-			a.log.Errorf("Failed to declare exchange: %w", err)
+			a.log.Errorf("Failed to declare exchange: %v", err)
 		}
 	}
 	return nil
@@ -311,7 +311,7 @@ func (a *amqp09Writer) disconnect() error {
 	}
 	if a.conn != nil {
 		if err := a.conn.Close(); err != nil {
-			a.log.Errorf("Failed to close connection cleanly: %w", err)
+			a.log.Errorf("Failed to close connection cleanly: %v", err)
 		}
 		a.conn = nil
 	}
@@ -483,7 +483,7 @@ func (a *amqp09Writer) Write(ctx context.Context, msg *service.Message) error {
 	)
 	if err != nil {
 		_ = a.disconnect()
-		a.log.Errorf("Failed to send message: %w", err)
+		a.log.Errorf("Failed to send message: %v", err)
 		return service.ErrNotConnected
 	}
 	if !conf.Wait() {

--- a/internal/impl/aws/helper/iter_test.go
+++ b/internal/impl/aws/helper/iter_test.go
@@ -23,13 +23,9 @@ type mockClient struct {
 	start   bool
 }
 
-func stringPtr(s string) *string {
-	return &s
-}
-
 func (mc *mockClient) listFoo(token *string) (fooPage []foo, nextToken *string, err error) {
 	if mc.start && token == nil {
-		token = stringPtr("page1")
+		token = new("page1")
 		mc.start = false
 	}
 
@@ -56,8 +52,8 @@ func TestCollect(t *testing.T) {
 		},
 		"TestCollectMultiplePages": {
 			testPageMap: map[string]page{
-				"page1": {fooList: []foo{{name: "Alice"}, {name: "Bob"}}, nextToken: stringPtr("page2")},
-				"page2": {fooList: []foo{{name: "Carol"}, {name: "Dan"}}, nextToken: stringPtr("page3")},
+				"page1": {fooList: []foo{{name: "Alice"}, {name: "Bob"}}, nextToken: new("page2")},
+				"page2": {fooList: []foo{{name: "Carol"}, {name: "Dan"}}, nextToken: new("page3")},
 				"page3": {fooList: []foo{{name: "Ethan"}, {name: "Frank"}}, nextToken: nil},
 			},
 			expResult: []foo{{name: "Alice"}, {name: "Bob"}, {name: "Carol"}, {name: "Dan"}, {name: "Ethan"}, {name: "Frank"}},
@@ -70,7 +66,7 @@ func TestCollect(t *testing.T) {
 		},
 		"TestCollectError": {
 			testPageMap: map[string]page{
-				"page1": {fooList: []foo{{name: "Alice"}, {name: "Bob"}}, nextToken: stringPtr("INVALID_TOKEN")},
+				"page1": {fooList: []foo{{name: "Alice"}, {name: "Bob"}}, nextToken: new("INVALID_TOKEN")},
 				"page2": {fooList: []foo{{name: "Carol"}}, nextToken: nil},
 			},
 			expResult:     nil,

--- a/internal/impl/confluent/client.go
+++ b/internal/impl/confluent/client.go
@@ -135,13 +135,13 @@ func (c *schemaRegistryClient) GetSchemaByID(ctx context.Context, id int) (resPa
 	var resBody []byte
 	if resCode, resBody, err = c.doRequest(ctx, "GET", fmt.Sprintf("/schemas/ids/%v", id)); err != nil {
 		err = fmt.Errorf("request failed for schema '%v': %v", id, err)
-		c.mgr.Logger().Errorf(err.Error())
+		c.mgr.Logger().Errorf("%s", err.Error())
 		return
 	}
 
 	if resCode == http.StatusNotFound {
 		err = fmt.Errorf("schema '%v' not found by registry", id)
-		c.mgr.Logger().Errorf(err.Error())
+		c.mgr.Logger().Errorf("%s", err.Error())
 		return
 	}
 
@@ -190,13 +190,13 @@ func (c *schemaRegistryClient) GetSchemaBySubjectAndVersion(ctx context.Context,
 	var resBody []byte
 	if resCode, resBody, err = c.doRequest(ctx, "GET", path); err != nil {
 		err = fmt.Errorf("request failed for schema subject '%v': %v", subject, err)
-		c.mgr.Logger().Errorf(err.Error())
+		c.mgr.Logger().Errorf("%s", err.Error())
 		return
 	}
 
 	if resCode == http.StatusNotFound {
 		err = fmt.Errorf("schema subject '%v' not found by registry", subject)
-		c.mgr.Logger().Errorf(err.Error())
+		c.mgr.Logger().Errorf("%s", err.Error())
 		return
 	}
 
@@ -307,7 +307,7 @@ func (c *schemaRegistryClient) doRequest(ctx context.Context, verb, reqPath stri
 			} else {
 				err = fmt.Errorf("status code %v", resCode)
 			}
-			c.mgr.Logger().Errorf(err.Error())
+			c.mgr.Logger().Errorf("%s", err.Error())
 		}
 		break
 	}

--- a/internal/impl/elasticsearch/output_v2.go
+++ b/internal/impl/elasticsearch/output_v2.go
@@ -291,7 +291,7 @@ func (eso *EsOutput) WriteBatch(ctx context.Context, batch service.MessageBatch)
 	indexer, err := esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
 		Client: eso.client,
 		OnError: func(ctx context.Context, err error) {
-			eso.log.Errorf("Bulk Indexer Error: %w", err)
+			eso.log.Errorf("Bulk Indexer Error: %v", err)
 		},
 		Timeout: eso.conf.timeout,
 	})

--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -137,7 +137,7 @@ func init() {
 func createSubscription(conf pbiConfig, client *pubsub.Client, log *service.Logger) {
 	subsExists, err := client.Subscription(conf.SubscriptionID).Exists(context.Background())
 	if err != nil {
-		log.Errorf("Error checking if subscription exists", err)
+		log.Errorf("Error checking if subscription exists: %v", err)
 		return
 	}
 

--- a/internal/impl/gcp/output_bigquery_storage_test.go
+++ b/internal/impl/gcp/output_bigquery_storage_test.go
@@ -419,45 +419,45 @@ func createTestProtobufDescriptor(t *testing.T) protoreflect.FileDescriptor {
 	t.Helper()
 
 	fileDescProto := &descriptorpb.FileDescriptorProto{
-		Name:    proto.String("test.proto"),
-		Package: proto.String("test"),
+		Name:    new("test.proto"),
+		Package: new("test"),
 		MessageType: []*descriptorpb.DescriptorProto{
 			{
-				Name: proto.String("TestMessage"),
+				Name: new("TestMessage"),
 				Field: []*descriptorpb.FieldDescriptorProto{
 					{
-						Name:   proto.String("type"),
+						Name:   new("type"),
 						Number: proto.Int32(1),
 						Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
 					},
 					{
-						Name:   proto.String("public"),
+						Name:   new("public"),
 						Number: proto.Int32(2),
 						Type:   descriptorpb.FieldDescriptorProto_TYPE_BOOL.Enum(),
 					},
 					{
-						Name:     proto.String("repo"),
+						Name:     new("repo"),
 						Number:   proto.Int32(3),
 						Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-						TypeName: proto.String(".test.RepoMessage"),
+						TypeName: new(".test.RepoMessage"),
 					},
 				},
 			},
 			{
-				Name: proto.String("RepoMessage"),
+				Name: new("RepoMessage"),
 				Field: []*descriptorpb.FieldDescriptorProto{
 					{
-						Name:   proto.String("id"),
+						Name:   new("id"),
 						Number: proto.Int32(1),
 						Type:   descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
 					},
 					{
-						Name:   proto.String("name"),
+						Name:   new("name"),
 						Number: proto.Int32(2),
 						Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
 					},
 					{
-						Name:   proto.String("url"),
+						Name:   new("url"),
 						Number: proto.Int32(3),
 						Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
 					},

--- a/internal/impl/io/input_fsevent.go
+++ b/internal/impl/io/input_fsevent.go
@@ -211,7 +211,7 @@ func (f *fsEventWatcher) Connect(ctx context.Context) error {
 				if !ok {
 					return
 				}
-				f.log.Errorf("error:", err)
+				f.log.Errorf("error: %v", err)
 			}
 		}
 	}()

--- a/internal/impl/io/processor_subprocess.go
+++ b/internal/impl/io/processor_subprocess.go
@@ -260,14 +260,14 @@ func newSubprocWrapper(name string, args []string, maxBuf int, codecRecv string,
 					msgBytes = append(msgBytes, stdoutMsg...)
 				}
 				if len(msgBytes) > 0 {
-					log.Info(string(msgBytes))
+					log.Info("%s", string(msgBytes))
 				}
 				msgBytes = nil
 				for stderrMsg := range s.stderrChan {
 					msgBytes = append(msgBytes, stderrMsg...)
 				}
 				if len(msgBytes) > 0 {
-					log.Error(string(msgBytes))
+					log.Error("%s", string(msgBytes))
 				}
 
 				_ = s.start()

--- a/internal/impl/kafka/input_sarama_kafka_cg.go
+++ b/internal/impl/kafka/input_sarama_kafka_cg.go
@@ -66,7 +66,7 @@ func (k *kafkaReader) ConsumeClaim(sess sarama.ConsumerGroupSession, claim saram
 			nextTimedBatchChan = nil
 			flushedBatch, err := batchPolicy.Flush(sess.Context())
 			if err != nil {
-				k.mgr.Logger().Debugf("Timed flush batch error: %w", err)
+				k.mgr.Logger().Debugf("Timed flush batch error: %v", err)
 				return nil
 			}
 			if !flushBatch(sess.Context(), k.msgChan, flushedBatch, latestOffset+1) {
@@ -84,7 +84,7 @@ func (k *kafkaReader) ConsumeClaim(sess sarama.ConsumerGroupSession, claim saram
 				nextTimedBatchChan = nil
 				flushedBatch, err := batchPolicy.Flush(sess.Context())
 				if err != nil {
-					k.mgr.Logger().Debugf("Flush batch error: %w", err)
+					k.mgr.Logger().Debugf("Flush batch error: %v", err)
 					return nil
 				}
 				if !flushBatch(sess.Context(), k.msgChan, flushedBatch, latestOffset+1) {

--- a/internal/impl/kafka/input_sarama_kafka_parts.go
+++ b/internal/impl/kafka/input_sarama_kafka_parts.go
@@ -65,7 +65,7 @@ partMsgLoop:
 			nextTimedBatchChan = nil
 			flushedBatch, err := batchPolicy.Flush(ctx)
 			if err != nil {
-				k.mgr.Logger().Debugf("Timed flush batch error: %w", err)
+				k.mgr.Logger().Debugf("Timed flush batch error: %v", err)
 				break partMsgLoop
 			}
 			if !flushBatch(ctx, k.msgChan, flushedBatch, latestOffset+1) {
@@ -84,7 +84,7 @@ partMsgLoop:
 				nextTimedBatchChan = nil
 				flushedBatch, err := batchPolicy.Flush(ctx)
 				if err != nil {
-					k.mgr.Logger().Debugf("Flush batch error: %w", err)
+					k.mgr.Logger().Debugf("Flush batch error: %v", err)
 					break partMsgLoop
 				}
 				if !flushBatch(ctx, k.msgChan, flushedBatch, latestOffset+1) {

--- a/internal/impl/opensearch/output.go
+++ b/internal/impl/opensearch/output.go
@@ -323,7 +323,7 @@ func (e *Output) WriteBatch(ctx context.Context, msg service.MessageBatch) error
 	dur := time.Since(start)
 
 	e.log.Debugf(
-		"Successfully dispatched [%s] documents in %s (%s docs/sec)",
+		"Successfully dispatched [%d] documents in %s (%d docs/sec)",
 		biStats.NumFlushed,
 		dur.Truncate(time.Millisecond),
 		int64(1000.0/float64(dur/time.Millisecond)*float64(biStats.NumFlushed)),

--- a/internal/impl/parquet/schema_test.go
+++ b/internal/impl/parquet/schema_test.go
@@ -357,8 +357,7 @@ schema:
 				return
 			}
 
-			for i := 0; i < got.NumField(); i++ {
-				field := got.Field(i)
+			for field := range got.Fields() {
 				want, ok := tt.wantFields[field.Name]
 				if !ok {
 					t.Errorf("unexpected field: %s", field.Name)

--- a/internal/impl/pulsar/logger.go
+++ b/internal/impl/pulsar/logger.go
@@ -50,19 +50,19 @@ func (l defaultLogger) Error(args ...any) {
 }
 
 func (l defaultLogger) Debugf(format string, args ...any) {
-	l.backend.Debugf(format, args)
+	l.backend.Debugf(format, args...)
 }
 
 func (l defaultLogger) Infof(format string, args ...any) {
-	l.backend.Infof(format, args)
+	l.backend.Infof(format, args...)
 }
 
 func (l defaultLogger) Warnf(format string, args ...any) {
-	l.backend.Warnf(format, args)
+	l.backend.Warnf(format, args...)
 }
 
 func (l defaultLogger) Errorf(format string, args ...any) {
-	l.backend.Errorf(format, args)
+	l.backend.Errorf(format, args...)
 }
 
 // NoopLogger returns a logger that does nothing.

--- a/internal/impl/pure/processor_archive.go
+++ b/internal/impl/pure/processor_archive.go
@@ -268,7 +268,7 @@ func (d *archive) createHeaderFunc(msg service.MessageBatch) func(int, *service.
 		bBytes, _ := body.AsBytes()
 		name, err := msg.TryInterpolatedString(index, d.path)
 		if err != nil {
-			d.log.Errorf("Name interpolation error: %w", err)
+			d.log.Errorf("Name interpolation error: %v", err)
 		}
 		return fakeInfo{
 			name: name,

--- a/internal/impl/pure/processor_cached.go
+++ b/internal/impl/pure/processor_cached.go
@@ -199,7 +199,7 @@ func (proc *cachedProcessor) Process(ctx context.Context, msg *service.Message) 
 	for _, b := range resultBatch {
 		skip, err := shouldSkip(b, proc.skipOn)
 		if err != nil {
-			proc.manager.Logger().Errorf("skip_on check failed: %w, caching will be skipped as a precaution", err)
+			proc.manager.Logger().Errorf("skip_on check failed: %v, caching will be skipped as a precaution", err)
 			skip = true
 		}
 		shouldCache = shouldCache && !skip
@@ -215,7 +215,7 @@ func (proc *cachedProcessor) Process(ctx context.Context, msg *service.Message) 
 	// messages.
 	result, err := cachedProcSerialiseBatch(collapsedBatch)
 	if err != nil {
-		proc.manager.Logger().Errorf("failed to serialise resulting batch for caching: %w", err)
+		proc.manager.Logger().Errorf("failed to serialise resulting batch for caching: %v", err)
 		return collapsedBatch, nil
 	}
 
@@ -224,10 +224,10 @@ func (proc *cachedProcessor) Process(ctx context.Context, msg *service.Message) 
 		setErr = cache.Set(ctx, cacheKey, result, ttl)
 	})
 	if cerr != nil {
-		proc.manager.Logger().Errorf("failed to access cache for result: %w", err)
+		proc.manager.Logger().Errorf("failed to access cache for result: %v", err)
 	}
 	if setErr != nil {
-		proc.manager.Logger().Errorf("failed to write result to cache: %w", err)
+		proc.manager.Logger().Errorf("failed to write result to cache: %v", err)
 	}
 	return collapsedBatch, nil
 }

--- a/internal/impl/pure/processor_jq.go
+++ b/internal/impl/pure/processor_jq.go
@@ -203,7 +203,7 @@ func (j *jqProc) Process(ctx context.Context, msg *message.Part) ([]*message.Par
 
 	emitted, err := safeQuery(in, metadata, j.code)
 	if err != nil {
-		j.log.Debug(err.Error())
+		j.log.Debug("%s", err.Error())
 		return nil, err
 	}
 

--- a/internal/impl/pure/processor_log.go
+++ b/internal/impl/pure/processor_log.go
@@ -145,23 +145,23 @@ func (l *logProcessor) levelToLogFn(level string) (func(logger log.Modular, msg 
 	switch level {
 	case "TRACE":
 		return func(logger log.Modular, msg string) {
-			logger.Trace(msg)
+			logger.Trace("%s", msg)
 		}, nil
 	case "DEBUG":
 		return func(logger log.Modular, msg string) {
-			logger.Debug(msg)
+			logger.Debug("%s", msg)
 		}, nil
 	case "INFO":
 		return func(logger log.Modular, msg string) {
-			logger.Info(msg)
+			logger.Info("%s", msg)
 		}, nil
 	case "WARN":
 		return func(logger log.Modular, msg string) {
-			logger.Warn(msg)
+			logger.Warn("%s", msg)
 		}, nil
 	case "ERROR":
 		return func(logger log.Modular, msg string) {
-			logger.Error(msg)
+			logger.Error("%s", msg)
 		}, nil
 	}
 	return nil, fmt.Errorf("log level not recognised: %v", level)

--- a/internal/impl/python/instance.go
+++ b/internal/impl/python/instance.go
@@ -67,8 +67,8 @@ func (p *pythonProcessor) newInstance(ctx context.Context) (*pythonInstance, err
 		return nil, err
 	case err := <-handshakeErr:
 		if err != nil {
-			p.logger.Errorf("python handshake failed (stderr): %s)")
-			return nil, fmt.Errorf("handshake failed: %w", err)
+			p.logger.Errorf("python handshake failed (stderr): %s)", err)
+			return nil, fmt.Errorf("handshake failed: %v", err)
 		}
 	}
 

--- a/internal/impl/statsd/metrics_statsd.go
+++ b/internal/impl/statsd/metrics_statsd.go
@@ -49,7 +49,7 @@ type wrappedDatadogLogger struct {
 }
 
 func (s wrappedDatadogLogger) Printf(msg string, args ...any) {
-	s.log.Warnf(fmt.Sprintf(msg, args...))
+	s.log.Warnf("%s", fmt.Sprintf(msg, args...))
 }
 
 //------------------------------------------------------------------------------

--- a/internal/stream/type.go
+++ b/internal/stream/type.go
@@ -267,7 +267,7 @@ func (t *Type) Stop(ctx context.Context) error {
 		dumpBuf := bytes.NewBuffer(nil)
 		_ = pprof.Lookup("goroutine").WriteTo(dumpBuf, 1)
 
-		t.manager.Logger().Debug(dumpBuf.String())
+		t.manager.Logger().Debug("%s", dumpBuf.String())
 	} else {
 		t.manager.Logger().Error("Encountered error whilst forcefully shutting down: %v\n", err)
 	}

--- a/public/service/logger.go
+++ b/public/service/logger.go
@@ -136,7 +136,7 @@ func (l *Logger) Trace(message string) {
 	if l == nil {
 		return
 	}
-	l.m.Trace(message)
+	l.m.Trace("%s", message)
 }
 
 // Debugf logs a debug message using fmt.Sprintf when args are specified.
@@ -152,7 +152,7 @@ func (l *Logger) Debug(message string) {
 	if l == nil {
 		return
 	}
-	l.m.Debug(message)
+	l.m.Debug("%s", message)
 }
 
 // Infof logs an info message using fmt.Sprintf when args are specified.
@@ -168,7 +168,7 @@ func (l *Logger) Info(message string) {
 	if l == nil {
 		return
 	}
-	l.m.Info(message)
+	l.m.Info("%s", message)
 }
 
 // Warnf logs a warning message using fmt.Sprintf when args are specified.
@@ -184,7 +184,7 @@ func (l *Logger) Warn(message string) {
 	if l == nil {
 		return
 	}
-	l.m.Warn(message)
+	l.m.Warn("%s", message)
 }
 
 // Errorf logs an error message using fmt.Sprintf when args are specified.
@@ -200,7 +200,7 @@ func (l *Logger) Error(message string) {
 	if l == nil {
 		return
 	}
-	l.m.Error(message)
+	l.m.Error("%s", message)
 }
 
 // With adds a variadic set of fields to a logger. Each field must consist

--- a/public/service/stream_builder.go
+++ b/public/service/stream_builder.go
@@ -959,7 +959,7 @@ func (s *StreamBuilder) buildWithEnv(env *bundle.Environment, isStrictBuild bool
 	}
 
 	for _, lw := range s.lintWarns {
-		logger.Warn(lw.Error())
+		logger.Warn("%s", lw.Error())
 	}
 
 	engVer := s.engineVersion

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS build
+FROM golang:1.26 AS build
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/resources/docker/Dockerfile.cgo
+++ b/resources/docker/Dockerfile.cgo
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS build
+FROM golang:1.26 AS build
 
 ENV CGO_ENABLED=1
 ENV GOOS=linux


### PR DESCRIPTION
Bump to new minor Go version largely to address all these issues in the `govulncheck` report from the core library (see [failing run](https://github.com/warpstreamlabs/bento/actions/runs/23735490792/job/69138964737#step:4:10)).