### PR TITLE
feat(kafka_franz): add extract_tracing_map support

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -156,6 +156,8 @@ With this option, you can return topic order and per-topic partition ordering. T
 			Description("An optional [`rate_limit`](/docs/components/rate_limits/about) to throttle invocations by.").
 			Default("").
 			Advanced()).
+		Field(service.NewExtractTracingSpanMappingField()).
+		Field(service.NewRootSpanWithLinkField().Version("1.17.0")).
 		LintRule(`
 let has_topic_partitions = this.topics.any(t -> t.contains(":"))
 root = if $has_topic_partitions {
@@ -175,7 +177,11 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			return service.AutoRetryNacksBatchedToggled(conf, rdr)
+			r, err := service.AutoRetryNacksBatchedToggled(conf, rdr)
+			if err != nil {
+				return nil, err
+			}
+			return conf.WrapBatchInputExtractTracingSpanMapping("kafka_franz", r)
 		})
 	if err != nil {
 		panic(err)

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -81,6 +81,8 @@ input:
       check: ""
       processors: [] # No default (optional)
     rate_limit: ""
+    extract_tracing_map: root = @ # No default (optional)
+    new_root_span_with_link: false # No default (optional)
 ```
 
 </TabItem>
@@ -744,5 +746,28 @@ An optional [`rate_limit`](/docs/components/rate_limits/about) to throttle invoc
 
 Type: `string`  
 Default: `""`  
+
+### `extract_tracing_map`
+
+EXPERIMENTAL: A [Bloblang mapping](/docs/guides/bloblang/about) that attempts to extract an object containing tracing propagation information, which will then be used as the root tracing span for the message. The specification of the extracted fields must match the format used by the service wide tracer.
+
+
+Type: `string`  
+
+```yml
+# Examples
+
+extract_tracing_map: root = @
+
+extract_tracing_map: root = this.meta.span
+```
+
+### `new_root_span_with_link`
+
+EXPERIMENTAL: Starts a new root span with link to parent.
+
+
+Type: `bool`  
+Requires version 1.17.0 or newer  
 
 


### PR DESCRIPTION
## Summary

Adds `extract_tracing_map` and `new_root_span_with_link` fields to the `kafka_franz` input, matching the existing support in the `kafka` (Sarama) and NATS inputs.

## Motivation

When using `kafka_franz` with the `open_telemetry_collector` tracer, Bento creates spans for processors and outputs but they are orphan root spans — not linked to the upstream trace that produced the Kafka message. The trace context (W3C `traceparent`/`tracestate`) is available in message metadata (since `kafka_franz` maps all Kafka headers to metadata), but there's no way to wire it into the tracing system.

The `kafka` (Sarama) input already supports this via `extract_tracing_map`, but `kafka_franz` does not. This means users of `kafka_franz` (and `kafka_franz_warpstream`) cannot achieve end-to-end distributed tracing across Kafka-based pipelines.

## Changes

1. Added `NewExtractTracingSpanMappingField()` and `NewRootSpanWithLinkField()` to the `kafka_franz` config spec
2. Wrapped the input with `WrapBatchInputExtractTracingSpanMapping` in the registration function

## Usage

```yaml
input:
  kafka_franz:
    seed_brokers: ["localhost:9092"]
    topics: ["my-topic"]
    consumer_group: "my-group"
    extract_tracing_map: "root = meta()"
```

With a tracer configured, all downstream processor and output spans will now be children of the upstream trace extracted from Kafka headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)