### PR TITLE
feat(grpc_client): add metadata support to gRPC client output

### DIFF
--- a/internal/impl/grpc_client/client_output.go
+++ b/internal/impl/grpc_client/client_output.go
@@ -47,7 +47,7 @@ const (
 
 const grpcClientOutputDescription = `
 
-### Expected Message Format 
+### Expected Message Format
 
 Either the field ` + "`reflection` or `proto_files`" + ` must be supplied, which will provide the protobuf schema Bento will use to marshall the Bento message into protobuf.
 
@@ -120,7 +120,7 @@ output:
 				Default([]any{}).
 				Example([]string{"./grpc_test_server/helloworld.proto"}),
 			service.NewInterpolatedStringMapField(grpcClientOutputMetadata).
-				Description("A map of metadata key/value pairs to add to gRPC requests. Values support [interpolation functions](/docs/configuration/interpolation#bloblang-queries). For `unary` and `server_stream` RPC types, metadata is evaluated per message. For `client_stream` and `bidi` RPC types, metadata is evaluated from the first message in the batch only, since gRPC stream metadata is sent once at stream creation.").
+				Description("A map of metadata key/value pairs to add to gRPC requests. For `unary` and `server_stream` RPC types, metadata is evaluated per message. For `client_stream` and `bidi` RPC types, metadata is evaluated from the first message in the batch only, since gRPC stream metadata is sent once at stream creation.").
 				Example(map[string]any{
 					"application":  "bento",
 					"x-request-id": `${!metadata("request_id")}`,
@@ -146,7 +146,7 @@ output:
 			service.NewOutputMaxInFlightField(),
 			service.NewBatchPolicyField(grpcClientOutputBatching),
 		).LintRule(
-		`root = match { 
+		`root = match {
   this.rpc_type == "bidi" && this.propagate_response == true => "cannot set propagate_response to true when rpc_type is bidi",
   this.reflection == false && (!this.exists("proto_files") || this.proto_files.length() == 0) => "reflection must be true or proto_files must be populated"
 }`,

--- a/internal/impl/grpc_client/client_output.go
+++ b/internal/impl/grpc_client/client_output.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/credentials/oauth"
 	_ "google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	grpcmd "google.golang.org/grpc/metadata"
 )
 
 const (
@@ -30,6 +31,7 @@ const (
 	grpcClientOutputProtoFiles             = "proto_files"
 	grpcClientOutputBatching               = "batching"
 	grpcClientOutputPropRes                = "propagate_response"
+	grpcClientOutputMetadata               = "metadata"
 	grpcClientOutputTls                    = "tls"
 	grpcClientOutputHealthCheck            = "health_check"
 	grpcClientOutputHealthCheckToggle      = "enabled"
@@ -102,6 +104,14 @@ output:
 				Description("A list of filepaths of .proto files that should contain the schemas necessary for the gRPC method.").
 				Default([]any{}).
 				Example([]string{"./grpc_test_server/helloworld.proto"}),
+			service.NewInterpolatedStringMapField(grpcClientOutputMetadata).
+				Description("A map of metadata key/value pairs to add to gRPC requests. Values support [interpolation functions](/docs/configuration/interpolation#bloblang-queries).").
+				Example(map[string]any{
+					"application":  "bento",
+					"x-request-id": `${!metadata("request_id")}`,
+				}).
+				Default(map[string]any{}).
+				Optional(),
 			service.NewBoolField(grpcClientOutputPropRes).
 				Description("Whether responses from the server should be [propagated back](/docs/guides/sync_responses) to the input.").
 				Default(false).
@@ -210,6 +220,7 @@ type grpcClientWriter struct {
 	reflectClient          *grpcreflect.Client
 	protoFiles             []string
 	propResponse           bool
+	metadata               map[string]*service.InterpolatedString
 	tls                    *tls.Config
 	oauth                  oauth2Config
 	healthCheckEnabled     bool
@@ -247,6 +258,10 @@ func newGrpcClientWriterFromParsed(conf *service.ParsedConfig, _ *service.Resour
 		return nil, err
 	}
 	propResponse, err := conf.FieldBool(grpcClientOutputPropRes)
+	if err != nil {
+		return nil, err
+	}
+	md, err := conf.FieldInterpolatedStringMap(grpcClientOutputMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -316,6 +331,7 @@ func newGrpcClientWriterFromParsed(conf *service.ParsedConfig, _ *service.Resour
 		reflection:   reflection,
 		protoFiles:   protoFiles,
 		propResponse: propResponse,
+		metadata:     md,
 		tls:          tls,
 		oauth:        oauth,
 
@@ -463,7 +479,20 @@ func (gcw *grpcClientWriter) Close(ctx context.Context) (err error) {
 	return nil
 }
 
-//------------------------------------------------------------------------------
+func (gcw *grpcClientWriter) contextWithMetadata(ctx context.Context, msg *service.Message) (context.Context, error) {
+	if len(gcw.metadata) == 0 {
+		return ctx, nil
+	}
+	pairs := make([]string, 0, len(gcw.metadata)*2)
+	for k, v := range gcw.metadata {
+		s, err := v.TryString(msg)
+		if err != nil {
+			return ctx, fmt.Errorf("metadata %q interpolation error: %w", k, err)
+		}
+		pairs = append(pairs, k, s)
+	}
+	return grpcmd.AppendToOutgoingContext(ctx, pairs...), nil
+}
 
 func (gcw *grpcClientWriter) unaryHandler(ctx context.Context, msgBatch service.MessageBatch) error {
 	var batchErr *service.BatchError
@@ -487,7 +516,13 @@ func (gcw *grpcClientWriter) unaryHandler(ctx context.Context, msgBatch service.
 			continue
 		}
 
-		resProtoMessage, err := gcw.stub.InvokeRpc(ctx, gcw.method, request)
+		rpcCtx, err := gcw.contextWithMetadata(ctx, msg)
+		if err != nil {
+			batchErrFailed(i, err)
+			continue
+		}
+
+		resProtoMessage, err := gcw.stub.InvokeRpc(rpcCtx, gcw.method, request)
 		if err != nil {
 			batchErrFailed(i, err)
 			continue
@@ -527,8 +562,12 @@ func (gcw *grpcClientWriter) unaryHandler(ctx context.Context, msgBatch service.
 }
 
 func (gcw *grpcClientWriter) clientStreamHandler(ctx context.Context, msgBatch service.MessageBatch) error {
+	rpcCtx, err := gcw.contextWithMetadata(ctx, msgBatch[0])
+	if err != nil {
+		return err
+	}
 
-	clientStream, err := gcw.stub.InvokeRpcClientStream(ctx, gcw.method)
+	clientStream, err := gcw.stub.InvokeRpcClientStream(rpcCtx, gcw.method)
 	if err != nil {
 		return err
 	}
@@ -602,7 +641,13 @@ msgLoop:
 			continue
 		}
 
-		serverStream, err := gcw.stub.InvokeRpcServerStream(ctx, gcw.method, request)
+		rpcCtx, err := gcw.contextWithMetadata(ctx, msg)
+		if err != nil {
+			batchErrFailed(i, err)
+			continue
+		}
+
+		serverStream, err := gcw.stub.InvokeRpcServerStream(rpcCtx, gcw.method, request)
 		if err != nil {
 			batchErrFailed(i, err)
 			continue
@@ -670,7 +715,12 @@ func (gcw *grpcClientWriter) bidirectionalHandler(ctx context.Context, msgBatch 
 		batchErr.Failed(i, err)
 	}
 
-	bidi, err := gcw.stub.InvokeRpcBidiStream(ctx, gcw.method)
+	rpcCtx, err := gcw.contextWithMetadata(ctx, msgBatch[0])
+	if err != nil {
+		return err
+	}
+
+	bidi, err := gcw.stub.InvokeRpcBidiStream(rpcCtx, gcw.method)
 	if err != nil {
 		return err
 	}

--- a/internal/impl/grpc_client/client_output.go
+++ b/internal/impl/grpc_client/client_output.go
@@ -51,6 +51,21 @@ const grpcClientOutputDescription = `
 
 Either the field ` + "`reflection` or `proto_files`" + ` must be supplied, which will provide the protobuf schema Bento will use to marshall the Bento message into protobuf.
 
+### Metadata
+
+The ` + "`metadata`" + ` field allows you to attach key/value pairs as gRPC metadata (headers) to outgoing requests. Values support [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+How metadata is applied depends on the ` + "`rpc_type`:" + `
+
+- ` + "`" + rpcTypeUnary + "`" + `: Metadata is evaluated **per message**. Each message in a batch can produce different metadata values via interpolation.` + `
+- ` + "`" + rpcTypeServerStream + "`" + `: Metadata is evaluated **per message**, since each message opens its own server stream.` + `
+- ` + "`" + rpcTypeClientStream + "`" + `: Metadata is evaluated from the **first message in the batch** only. gRPC metadata is sent as headers when the stream is opened, so it cannot vary per message within a single stream.` + `
+- ` + "`" + rpcTypeBidi + "`" + `: Same as ` + "`client_stream`" + ` — metadata is evaluated from the **first message in the batch**.` + `
+
+:::caution
+For ` + "`client_stream`" + ` and ` + "`bidi`" + ` RPC types, gRPC metadata is a stream-level concept (sent as HTTP/2 headers at stream creation). If you use interpolation functions that produce different values per message (e.g. ` + "`${! json(\"id\") }`" + `), only the value from the **first message** in the batch will be used for the entire stream. This is a gRPC protocol limitation, not a Bento limitation.
+:::
+
 ### Propagating Responses
 
 It's possible to propagate the response(s) from each gRPC method invocation back to the input source by
@@ -105,7 +120,7 @@ output:
 				Default([]any{}).
 				Example([]string{"./grpc_test_server/helloworld.proto"}),
 			service.NewInterpolatedStringMapField(grpcClientOutputMetadata).
-				Description("A map of metadata key/value pairs to add to gRPC requests. Values support [interpolation functions](/docs/configuration/interpolation#bloblang-queries).").
+				Description("A map of metadata key/value pairs to add to gRPC requests. Values support [interpolation functions](/docs/configuration/interpolation#bloblang-queries). For `unary` and `server_stream` RPC types, metadata is evaluated per message. For `client_stream` and `bidi` RPC types, metadata is evaluated from the first message in the batch only, since gRPC stream metadata is sent once at stream creation.").
 				Example(map[string]any{
 					"application":  "bento",
 					"x-request-id": `${!metadata("request_id")}`,

--- a/internal/impl/grpc_client/client_output_test.go
+++ b/internal/impl/grpc_client/client_output_test.go
@@ -57,6 +57,7 @@ type testServer struct {
 	SayMultiHellosInvocations    int
 	SayHelloHowAreYouInvocations int
 	SayHelloBidiInvocations      int
+	receivedMetadata             []metadata.MD
 	port                         int
 }
 
@@ -149,9 +150,12 @@ func startGRPCServer(t *testing.T, opts ...testServerOpt) *testServer {
 
 //------------------------------------------------------------------------------
 
-func (s *testServer) SayHello(_ context.Context, in *test_server.HelloRequest) (*test_server.HelloReply, error) {
+func (s *testServer) SayHello(ctx context.Context, in *test_server.HelloRequest) (*test_server.HelloReply, error) {
 	s.mu.Lock()
 	s.SayHelloInvocations++
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		s.receivedMetadata = append(s.receivedMetadata, md)
+	}
 	s.mu.Unlock()
 	if s.returnErrors {
 		return nil, errors.New("ERROR :( ")
@@ -162,6 +166,9 @@ func (s *testServer) SayHello(_ context.Context, in *test_server.HelloRequest) (
 func (s *testServer) SayMultipleHellos(stream test_server.Greeter_SayMultipleHellosServer) error {
 	s.mu.Lock()
 	s.SayMultiHellosInvocations++
+	if md, ok := metadata.FromIncomingContext(stream.Context()); ok {
+		s.receivedMetadata = append(s.receivedMetadata, md)
+	}
 	s.mu.Unlock()
 	names := []string{}
 
@@ -186,6 +193,9 @@ func (s *testServer) SayMultipleHellos(stream test_server.Greeter_SayMultipleHel
 func (s *testServer) SayHelloHowAreYou(in *test_server.HelloRequest, stream test_server.Greeter_SayHelloHowAreYouServer) error {
 	s.mu.Lock()
 	s.SayHelloHowAreYouInvocations++
+	if md, ok := metadata.FromIncomingContext(stream.Context()); ok {
+		s.receivedMetadata = append(s.receivedMetadata, md)
+	}
 	s.mu.Unlock()
 
 	if s.returnErrors {
@@ -205,9 +215,12 @@ func (s *testServer) SayHelloHowAreYou(in *test_server.HelloRequest, stream test
 	return nil
 }
 
-func (s *testServer) SayHelloBidi(grpc.BidiStreamingServer[test_server.HelloRequest, test_server.HelloReply]) error {
+func (s *testServer) SayHelloBidi(stream grpc.BidiStreamingServer[test_server.HelloRequest, test_server.HelloReply]) error {
 	s.mu.Lock()
 	s.SayHelloBidiInvocations++
+	if md, ok := metadata.FromIncomingContext(stream.Context()); ok {
+		s.receivedMetadata = append(s.receivedMetadata, md)
+	}
 	s.mu.Unlock()
 
 	if s.returnErrors {
@@ -278,6 +291,14 @@ func withReturnErrors() testServerOpt {
 	return func(ts *testServer) {
 		ts.returnErrors = true
 	}
+}
+
+func (s *testServer) getReceivedMetadata() []metadata.MD {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]metadata.MD, len(s.receivedMetadata))
+	copy(cp, s.receivedMetadata)
+	return cp
 }
 
 //------------------------------------------------------------------------------
@@ -930,6 +951,247 @@ grpc_client:
 			}
 		})
 	}
+}
+
+func TestGrpcClientWriterMetadataUnary(t *testing.T) {
+	ts := startGRPCServer(t, withReflection())
+
+	yamlConf := fmt.Sprintf(`
+grpc_client:
+  address: localhost:%v
+  service: helloworld.Greeter
+  method: SayHello
+  reflection: true
+  metadata:
+    x-custom-key: custom-value
+    x-request-name: fixed-name
+`, ts.port)
+
+	sendChan, receiveChan, err := startGrpcClientOutput(t, yamlConf)
+	require.NoError(t, err)
+
+	for _, input := range namesInputTestData {
+		testMsg := message.QuickBatch([][]byte{[]byte(input)})
+		select {
+		case sendChan <- message.NewTransaction(testMsg, receiveChan):
+		case <-time.After(time.Second * 20):
+			t.Fatal("Send timed out")
+		}
+	}
+
+	for i := range namesInputTestData {
+		select {
+		case err := <-receiveChan:
+			require.NoError(t, err)
+		case <-time.After(time.Second * 20):
+			t.Fatalf("Response %d timed out", i)
+		}
+	}
+
+	assert.Eventually(t, func() bool {
+		return ts.SayHelloInvocations == len(namesInputTestData)
+	}, time.Second*10, time.Millisecond*20)
+
+	received := ts.getReceivedMetadata()
+	require.Len(t, received, len(namesInputTestData))
+	for _, md := range received {
+		assert.Equal(t, []string{"custom-value"}, md.Get("x-custom-key"))
+		assert.Equal(t, []string{"fixed-name"}, md.Get("x-request-name"))
+	}
+}
+
+func TestGrpcClientWriterMetadataClientStream(t *testing.T) {
+	ts := startGRPCServer(t, withReflection())
+
+	yamlConf := fmt.Sprintf(`
+grpc_client:
+  address: localhost:%v
+  service: helloworld.Greeter
+  method: SayMultipleHellos
+  reflection: true
+  rpc_type: client_stream
+  metadata:
+    x-stream-id: my-stream
+  batching:
+    count: 4
+`, ts.port)
+
+	sendChan, receiveChan, err := startGrpcClientOutput(t, yamlConf)
+	require.NoError(t, err)
+
+	for _, input := range namesInputTestData {
+		testMsg := message.QuickBatch([][]byte{[]byte(input)})
+		select {
+		case sendChan <- message.NewTransaction(testMsg, receiveChan):
+		case <-time.After(time.Second * 20):
+			t.Fatal("Send timed out")
+		}
+	}
+
+	for i := range namesInputTestData {
+		select {
+		case err := <-receiveChan:
+			require.NoError(t, err)
+		case <-time.After(time.Second * 20):
+			t.Fatalf("Response %d timed out", i)
+		}
+	}
+
+	assert.Eventually(t, func() bool {
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		return ts.SayMultiHellosInvocations == 1
+	}, time.Second*10, time.Millisecond*20)
+
+	received := ts.getReceivedMetadata()
+	require.Len(t, received, 1)
+	assert.Equal(t, []string{"my-stream"}, received[0].Get("x-stream-id"))
+}
+
+func TestGrpcClientWriterMetadataServerStream(t *testing.T) {
+	ts := startGRPCServer(t, withReflection())
+
+	yamlConf := fmt.Sprintf(`
+grpc_client:
+  address: localhost:%v
+  service: helloworld.Greeter
+  method: SayHelloHowAreYou
+  reflection: true
+  rpc_type: server_stream
+  metadata:
+    x-server-stream: "true"
+`, ts.port)
+
+	sendChan, receiveChan, err := startGrpcClientOutput(t, yamlConf)
+	require.NoError(t, err)
+
+	for _, input := range namesInputTestData {
+		testMsg := message.QuickBatch([][]byte{[]byte(input)})
+		select {
+		case sendChan <- message.NewTransaction(testMsg, receiveChan):
+		case <-time.After(time.Second * 20):
+			t.Fatal("Send timed out")
+		}
+	}
+
+	for i := range namesInputTestData {
+		select {
+		case err := <-receiveChan:
+			require.NoError(t, err)
+		case <-time.After(time.Second * 20):
+			t.Fatalf("Response %d timed out", i)
+		}
+	}
+
+	assert.Eventually(t, func() bool {
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		return ts.SayHelloHowAreYouInvocations == len(namesInputTestData)
+	}, time.Second*10, time.Millisecond*20)
+
+	received := ts.getReceivedMetadata()
+	require.Len(t, received, len(namesInputTestData))
+	for _, md := range received {
+		assert.Equal(t, []string{"true"}, md.Get("x-server-stream"))
+	}
+}
+
+func TestGrpcClientWriterMetadataBidi(t *testing.T) {
+	ts := startGRPCServer(t, withReflection())
+
+	yamlConf := fmt.Sprintf(`
+grpc_client:
+  address: localhost:%v
+  service: helloworld.Greeter
+  method: SayHelloBidi
+  reflection: true
+  rpc_type: bidi
+  metadata:
+    x-bidi-key: bidi-value
+  batching:
+    count: 4
+`, ts.port)
+
+	sendChan, receiveChan, err := startGrpcClientOutput(t, yamlConf)
+	require.NoError(t, err)
+
+	for _, input := range namesInputTestData {
+		testMsg := message.QuickBatch([][]byte{[]byte(input)})
+		select {
+		case sendChan <- message.NewTransaction(testMsg, receiveChan):
+		case <-time.After(time.Second * 20):
+			t.Fatal("Send timed out")
+		}
+	}
+
+	for i := range namesInputTestData {
+		select {
+		case err := <-receiveChan:
+			require.NoError(t, err)
+		case <-time.After(time.Second * 20):
+			t.Fatalf("Response %d timed out", i)
+		}
+	}
+
+	assert.Eventually(t, func() bool {
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		return ts.SayHelloBidiInvocations == 1
+	}, time.Second*10, time.Millisecond*20)
+
+	received := ts.getReceivedMetadata()
+	require.Len(t, received, 1)
+	assert.Equal(t, []string{"bidi-value"}, received[0].Get("x-bidi-key"))
+}
+
+func TestGrpcClientWriterMetadataInterpolation(t *testing.T) {
+	ts := startGRPCServer(t, withReflection())
+
+	yamlConf := fmt.Sprintf(`
+grpc_client:
+  address: localhost:%v
+  service: helloworld.Greeter
+  method: SayHello
+  reflection: true
+  metadata:
+    x-name: ${! json("name") }
+`, ts.port)
+
+	sendChan, receiveChan, err := startGrpcClientOutput(t, yamlConf)
+	require.NoError(t, err)
+
+	for _, input := range namesInputTestData {
+		testMsg := message.QuickBatch([][]byte{[]byte(input)})
+		select {
+		case sendChan <- message.NewTransaction(testMsg, receiveChan):
+		case <-time.After(time.Second * 20):
+			t.Fatal("Send timed out")
+		}
+	}
+
+	for i := range namesInputTestData {
+		select {
+		case err := <-receiveChan:
+			require.NoError(t, err)
+		case <-time.After(time.Second * 20):
+			t.Fatalf("Response %d timed out", i)
+		}
+	}
+
+	assert.Eventually(t, func() bool {
+		return ts.SayHelloInvocations == len(namesInputTestData)
+	}, time.Second*10, time.Millisecond*20)
+
+	received := ts.getReceivedMetadata()
+	require.Len(t, received, len(namesInputTestData))
+
+	gotNames := make([]string, 0, len(received))
+	for _, md := range received {
+		vals := md.Get("x-name")
+		require.Len(t, vals, 1)
+		gotNames = append(gotNames, vals[0])
+	}
+	assert.ElementsMatch(t, names, gotNames)
 }
 
 //------------------------------------------------------------------------------

--- a/website/docs/components/outputs/grpc_client.md
+++ b/website/docs/components/outputs/grpc_client.md
@@ -39,6 +39,7 @@ output:
     rpc_type: unary
     reflection: false
     proto_files: []
+    metadata: {}
     health_check: {}
     max_in_flight: 64
     batching:
@@ -63,6 +64,7 @@ output:
     rpc_type: unary
     reflection: false
     proto_files: []
+    metadata: {}
     propagate_response: false
     health_check:
       enabled: false
@@ -95,9 +97,24 @@ output:
 </Tabs>
 
 
-### Expected Message Format 
+### Expected Message Format
 
 Either the field `reflection` or `proto_files` must be supplied, which will provide the protobuf schema Bento will use to marshall the Bento message into protobuf.
+
+### Metadata
+
+The `metadata` field allows you to attach key/value pairs as gRPC metadata (headers) to outgoing requests. Values support [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+How metadata is applied depends on the `rpc_type`:
+
+- `unary`: Metadata is evaluated **per message**. Each message in a batch can produce different metadata values via interpolation.
+- `server_stream`: Metadata is evaluated **per message**, since each message opens its own server stream.
+- `client_stream`: Metadata is evaluated from the **first message in the batch** only. gRPC metadata is sent as headers when the stream is opened, so it cannot vary per message within a single stream.
+- `bidi`: Same as `client_stream` — metadata is evaluated from the **first message in the batch**.
+
+:::caution
+For `client_stream` and `bidi` RPC types, gRPC metadata is a stream-level concept (sent as HTTP/2 headers at stream creation). If you use interpolation functions that produce different values per message (e.g. `${! json("id") }`), only the value from the **first message** in the batch will be used for the entire stream. This is a gRPC protocol limitation, not a Bento limitation.
+:::
 
 ### Propagating Responses
 
@@ -209,6 +226,23 @@ Default: `[]`
 
 proto_files:
   - ./grpc_test_server/helloworld.proto
+```
+
+### `metadata`
+
+A map of metadata key/value pairs to add to gRPC requests. For `unary` and `server_stream` RPC types, metadata is evaluated per message. For `client_stream` and `bidi` RPC types, metadata is evaluated from the first message in the batch only, since gRPC stream metadata is sent once at stream creation.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `object`  
+Default: `{}`  
+
+```yml
+# Examples
+
+metadata:
+  application: bento
+  x-request-id: ${!metadata("request_id")}
 ```
 
 ### `propagate_response`


### PR DESCRIPTION
## Summary

- Adds a new `metadata` config field to the `grpc_client` output, allowing users to attach custom key/value metadata pairs to outgoing gRPC requests
- Values support Bloblang interpolation for dynamic per-message metadata (e.g. `${! json("name") }`, `${! metadata("request_id") }`)
- Metadata is injected into all RPC types: unary (per-message), client_stream (per-batch), server_stream (per-message), and bidi (per-batch)
- Clearly documents the per-RPC-type behavior, noting that `client_stream` and `bidi` use metadata from the first message only (gRPC protocol constraint)

## Example Usage

```yaml
output:
  grpc_client:
    address: localhost:50051
    service: helloworld.Greeter
    method: SayHello
    reflection: true
    metadata:
      x-request-id: ${! uuid_v4() }
      x-source: bento
      x-correlation-id: ${! metadata("correlation_id") }
```

## Implementation Details

- New `metadata` field registered via `NewInterpolatedStringMapField` (consistent with how `headers` works in websocket, NATS, HTTP outputs)
- `contextWithMetadata` helper resolves interpolations against the current message and appends pairs to the outgoing gRPC context via `grpc/metadata.AppendToOutgoingContext`
- For stream-based RPCs (client_stream, bidi), metadata is resolved from the first message in the batch since the stream is opened once per batch — this is a gRPC protocol constraint (metadata = HTTP/2 headers = sent once at stream open)
- Added a "Metadata" section to the component description with a callout warning about the stream-level behavior, similar to the archive processor warning on the `aws_s3` output docs

## Tests

5 new test cases covering:
- Static metadata on unary, client stream, server stream, and bidi RPCs
- Bloblang interpolation producing dynamic per-message metadata values
- All existing tests continue to pass with no regressions