### PR TITLE
feat(kafka): add kafka_timestamp_ms metadata with millisecond precision

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -48,6 +48,7 @@ This input adds the following metadata fields to each message:
 - kafka_partition
 - kafka_offset
 - kafka_timestamp_unix
+- kafka_timestamp_ms
 - kafka_tombstone_message
 - All record headers
 ` + "```" + `
@@ -469,6 +470,7 @@ func (f *franzKafkaReader) recordToMessage(record *kgo.Record) *msgWithRecord {
 	msg.MetaSetMut("kafka_partition", int(record.Partition))
 	msg.MetaSetMut("kafka_offset", int(record.Offset))
 	msg.MetaSetMut("kafka_timestamp_unix", record.Timestamp.Unix())
+	msg.MetaSetMut("kafka_timestamp_ms", record.Timestamp.UnixMilli())
 	msg.MetaSetMut("kafka_tombstone_message", record.Value == nil)
 	if f.multiHeader {
 		// in multi header mode we gather headers so we can encode them as lists

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -48,7 +48,7 @@ This input adds the following metadata fields to each message:
 - kafka_partition
 - kafka_offset
 - kafka_timestamp_unix
-- kafka_timestamp_ms
+- kafka_timestamp_unix_ms
 - kafka_tombstone_message
 - All record headers
 ` + "```" + `
@@ -470,7 +470,7 @@ func (f *franzKafkaReader) recordToMessage(record *kgo.Record) *msgWithRecord {
 	msg.MetaSetMut("kafka_partition", int(record.Partition))
 	msg.MetaSetMut("kafka_offset", int(record.Offset))
 	msg.MetaSetMut("kafka_timestamp_unix", record.Timestamp.Unix())
-	msg.MetaSetMut("kafka_timestamp_ms", record.Timestamp.UnixMilli())
+	msg.MetaSetMut("kafka_timestamp_unix_ms", record.Timestamp.UnixMilli())
 	msg.MetaSetMut("kafka_tombstone_message", record.Value == nil)
 	if f.multiHeader {
 		// in multi header mode we gather headers so we can encode them as lists

--- a/internal/impl/kafka/input_sarama_kafka.go
+++ b/internal/impl/kafka/input_sarama_kafka.go
@@ -85,7 +85,7 @@ This input adds the following metadata fields to each message:
 - kafka_offset
 - kafka_lag
 - kafka_timestamp_unix
-- kafka_timestamp_ms
+- kafka_timestamp_unix_ms
 - kafka_tombstone_message
 - All existing message headers (version 0.11+)
 `+"```"+`
@@ -432,7 +432,7 @@ func dataToPart(highestOffset int64, data *sarama.ConsumerMessage, multiHeader b
 	part.MetaSetMut("kafka_offset", int(data.Offset))
 	part.MetaSetMut("kafka_lag", lag)
 	part.MetaSetMut("kafka_timestamp_unix", data.Timestamp.Unix())
-	part.MetaSetMut("kafka_timestamp_ms", data.Timestamp.UnixMilli())
+	part.MetaSetMut("kafka_timestamp_unix_ms", data.Timestamp.UnixMilli())
 	part.MetaSetMut("kafka_tombstone_message", data.Value == nil)
 
 	return part

--- a/internal/impl/kafka/input_sarama_kafka.go
+++ b/internal/impl/kafka/input_sarama_kafka.go
@@ -85,6 +85,7 @@ This input adds the following metadata fields to each message:
 - kafka_offset
 - kafka_lag
 - kafka_timestamp_unix
+- kafka_timestamp_ms
 - kafka_tombstone_message
 - All existing message headers (version 0.11+)
 `+"```"+`
@@ -431,6 +432,7 @@ func dataToPart(highestOffset int64, data *sarama.ConsumerMessage, multiHeader b
 	part.MetaSetMut("kafka_offset", int(data.Offset))
 	part.MetaSetMut("kafka_lag", lag)
 	part.MetaSetMut("kafka_timestamp_unix", data.Timestamp.Unix())
+	part.MetaSetMut("kafka_timestamp_ms", data.Timestamp.UnixMilli())
 	part.MetaSetMut("kafka_tombstone_message", data.Value == nil)
 
 	return part

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -123,6 +123,7 @@ This input adds the following metadata fields to each message:
 - kafka_offset
 - kafka_lag
 - kafka_timestamp_unix
+- kafka_timestamp_ms
 - kafka_tombstone_message
 - All existing message headers (version 0.11+)
 ```

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -123,7 +123,7 @@ This input adds the following metadata fields to each message:
 - kafka_offset
 - kafka_lag
 - kafka_timestamp_unix
-- kafka_timestamp_ms
+- kafka_timestamp_unix_ms
 - kafka_tombstone_message
 - All existing message headers (version 0.11+)
 ```

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -100,7 +100,7 @@ This input adds the following metadata fields to each message:
 - kafka_partition
 - kafka_offset
 - kafka_timestamp_unix
-- kafka_timestamp_ms
+- kafka_timestamp_unix_ms
 - kafka_tombstone_message
 - All record headers
 ```

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -100,6 +100,7 @@ This input adds the following metadata fields to each message:
 - kafka_partition
 - kafka_offset
 - kafka_timestamp_unix
+- kafka_timestamp_ms
 - kafka_tombstone_message
 - All record headers
 ```


### PR DESCRIPTION
## Summary
- Add `kafka_timestamp_ms` metadata field to both `kafka_franz` and `kafka` (Sarama) inputs
- Uses `record.Timestamp.UnixMilli()` for millisecond-precision timestamps
- Backward compatible — existing `kafka_timestamp_unix` (seconds) is unchanged

## Problem

`kafka_timestamp_unix` uses `record.Timestamp.Unix()` which truncates to integer seconds. For consumers measuring Kafka transit latency, this introduces up to ±1s rounding error, making sub-second latency tracking unreliable.

Example: actual transit of 200ms can be measured as 1047ms due to lost fractional seconds.

## Changes

| File | Change |
|------|--------|
| `input_kafka_franz.go` | Add `kafka_timestamp_ms` metadata + docs |
| `input_sarama_kafka.go` | Add `kafka_timestamp_ms` metadata + docs |
| `kafka_franz.md` | Document new metadata field |
| `kafka.md` | Document new metadata field |

## Usage

```yaml
pipeline:
  processors:
    - bloblang: |
        # Millisecond-precision Kafka transit latency
        let kafka_ts = metadata("kafka_timestamp_ms").number()
        let transit_ms = now_unix_milli() - $kafka_ts
        meta kafka_transit_ms = $transit_ms
```

Closes #807

## Test plan
- [x] `go vet ./internal/impl/kafka/...` passes
- [x] Backward compatible (no changes to existing `kafka_timestamp_unix`)
- [ ] CI checks