### PR TITLE
feat(tracing): inject message content into processor and output span …

### DIFF
--- a/internal/component/output/async_writer.go
+++ b/internal/component/output/async_writer.go
@@ -205,6 +205,13 @@ func (w *AsyncWriter) loop() {
 
 			w.log.Trace("Attempting to write %v messages to '%v'.\n", ts.Payload.Len(), w.typeStr)
 			_, spans := tracing.WithChildSpans(w.tracer, traceName, ts.Payload)
+			// Inject message content into output span attributes for provenance
+			_ = ts.Payload.Iter(func(i int, part *message.Part) error {
+				if i < len(spans) {
+					spans[i].SetTag("message.content", string(part.AsBytes()))
+				}
+				return nil
+			})
 
 			latency, err := w.latencyMeasuringWrite(closeLeisureCtx, ts.Payload)
 

--- a/internal/component/processor/auto_observed.go
+++ b/internal/component/processor/auto_observed.go
@@ -95,6 +95,7 @@ func (a *v2ToV1Processor) ProcessBatch(ctx context.Context, msg message.Batch) (
 	newParts := make([]*message.Part, 0, msg.Len())
 	_ = msg.Iter(func(i int, part *message.Part) error {
 		_, span := tracing.WithChildSpan(a.mgr.Tracer(), a.typeStr, part)
+		span.SetTag("message.content", string(part.AsBytes()))
 
 		nextParts, err := a.p.Process(ctx, part)
 		if err != nil {
@@ -228,6 +229,12 @@ func (a *v2BatchedToV1Processor) ProcessBatch(ctx context.Context, msg message.B
 
 	tStarted := time.Now()
 	_, spans := tracing.WithChildSpans(a.mgr.Tracer(), a.typeStr, msg)
+	_ = msg.Iter(func(i int, part *message.Part) error {
+		if i < len(spans) {
+			spans[i].SetTag("message.content", string(part.AsBytes()))
+		}
+		return nil
+	})
 
 	outputBatches, err := a.p.ProcessBatch(&BatchProcContext{
 		ctx:    ctx,

--- a/internal/tracing/otel.go
+++ b/internal/tracing/otel.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
@@ -120,12 +121,14 @@ func InitSpans(prov trace.TracerProvider, operationName string, batch message.Ba
 }
 
 // InitSpan sets up an OpenTracing span on a message part if one does not
-// already exist.
+// already exist. Injects message content as a span attribute for provenance.
 func InitSpan(prov trace.TracerProvider, operationName string, part *message.Part) *message.Part {
-	if GetActiveSpan(part) != nil {
+	if existing := GetActiveSpan(part); existing != nil {
+		existing.SetTag("message.content", string(part.AsBytes()))
 		return part
 	}
-	ctx, _ := prov.Tracer(name).Start(part.GetContext(), operationName)
+	ctx, s := prov.Tracer(name).Start(part.GetContext(), operationName)
+	s.SetAttributes(attribute.String("message.content", string(part.AsBytes())))
 	return message.WithContext(ctx, part)
 }
 


### PR DESCRIPTION
…attributes

Adds message.content as a span attribute on every processor span (single and batched) and every output span. This enables external tracers (e.g. custom OTel exporters) to capture per-message provenance data without per-pipeline configuration.

Used by EvoIoT for unified provenance/audit logging.