### PR TITLE
feat(elasticsearch_v2): add API auth for output

### DIFF
--- a/internal/impl/elasticsearch/integration_v2_test.go
+++ b/internal/impl/elasticsearch/integration_v2_test.go
@@ -96,10 +96,11 @@ output:
 func TestIntegrationV2Connect(t *testing.T) {
 	integration.CheckSkip(t)
 	tests := []struct {
-		name       string
-		env        []string
-		pollURL    func(port string) string
-		configYAML func(argsString []string) string
+		name        string
+		env         []string
+		pollURL     func(port string) string
+		createToken func(port string) string
+		configYAML  func(argsString []string) string
 	}{
 		{
 			name: "NoAuth",
@@ -154,6 +155,58 @@ basic_auth:
   username: elastic
   password: password
 `, argsAny...)
+			},
+		},
+		{
+			name: "APIAuth",
+			env: []string{
+				"discovery.type=single-node",
+				"xpack.security.enabled=true",
+				"xpack.security.transport.ssl.enabled=false",
+				"xpack.security.http.ssl.enabled=false",
+				"ES_JAVA_OPTS=-Xms512m -Xmx512m",
+				"ELASTIC_PASSWORD=password",
+			},
+			pollURL: func(port string) string {
+				return fmt.Sprintf("http://elastic:password@localhost:%s", port)
+			},
+			configYAML: func(argsString []string) string {
+				argsAny := make([]any, 0, 2)
+				for _, v := range argsString {
+					argsAny = append(argsAny, v)
+				}
+				return fmt.Sprintf(`
+urls: 
+  - http://localhost:%s
+index: test-index
+id: ${! uuid_v4 }
+api_key: %s
+`, argsAny...)
+			},
+			createToken: func(port string) string {
+				apiKeyReqBody := []byte(`{"name": "bento-integration-test-key"}`)
+				reqURL := fmt.Sprintf("http://localhost:%s/_security/api_key", port)
+
+				req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, reqURL, bytes.NewBuffer(apiKeyReqBody))
+				require.NoError(t, err)
+
+				// Authenticate using the bootstrap password we set in the environment variables
+				req.SetBasicAuth("elastic", "password")
+				req.Header.Set("Content-Type", "application/json")
+
+				resp, err := http.DefaultClient.Do(req)
+				require.NoError(t, err, "failed to make api key generation request")
+				defer resp.Body.Close()
+
+				require.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 OK when generating API key")
+
+				var apiKeyRes struct {
+					Encoded string `json:"encoded"`
+				}
+				err = json.NewDecoder(resp.Body).Decode(&apiKeyRes)
+				require.NoError(t, err, "failed to decode api key response")
+
+				return apiKeyRes.Encoded
 			},
 		},
 		{
@@ -233,6 +286,10 @@ tls:
 			}
 
 			waitForElasticsearch(t, pool, client, pollURL)
+
+			if tc.createToken != nil {
+				configArgs = append(configArgs, tc.createToken(port))
+			}
 
 			connectOutput(t, tc.configYAML(configArgs))
 		})

--- a/internal/impl/elasticsearch/output_v2.go
+++ b/internal/impl/elasticsearch/output_v2.go
@@ -30,6 +30,7 @@ const (
 	esoV2FieldTimeout               = "timeout"
 	esoV2FieldTLS                   = "tls"
 	esoV2FieldAuth                  = "basic_auth"
+	esoV2FieldAPIKey                = "api_key"
 	esoV2FieldAuthEnabled           = "enabled"
 	esoV2FieldAuthUsername          = "username"
 	esoV2FieldAuthPassword          = "password"
@@ -100,6 +101,9 @@ Both the `+"`id` and `index`"+` fields can be dynamically set using function int
 				Default("5s"),
 			service.NewTLSToggledField(esoV2FieldTLS),
 			service.NewOutputMaxInFlightField(),
+			service.NewStringField(esoV2FieldAPIKey).
+				Description("Allows you to specify a Base64-encoded token for authorization; if set, overrides basic auth.").
+				Optional(),
 			service.NewObjectField(esoV2FieldAuth,
 				service.NewBoolField(esoV2FieldAuthEnabled).
 					Description("Whether to use basic authentication in requests.").
@@ -209,6 +213,11 @@ func esoV2ConfigFromParsed(pConf *service.ParsedConfig) (conf esoV2Config, err e
 	if tlsEnabled {
 		conf.clientConfig.Transport = &http.Transport{
 			TLSClientConfig: tlsConf,
+		}
+	}
+	if pConf.Contains(esoV2FieldAPIKey) {
+		if conf.clientConfig.APIKey, err = pConf.FieldString(esoV2FieldAPIKey); err != nil {
+			return
 		}
 	}
 

--- a/website/docs/components/outputs/elasticsearch_v2.md
+++ b/website/docs/components/outputs/elasticsearch_v2.md
@@ -41,6 +41,7 @@ output:
     discover_nodes_on_start: false
     discover_nodes_interval: 0s
     max_in_flight: 64
+    api_key: "" # No default (optional)
     batching:
       count: 0
       byte_size: 0
@@ -78,6 +79,7 @@ output:
       root_cas_file: ""
       client_certs: []
     max_in_flight: 64
+    api_key: "" # No default (optional)
     basic_auth:
       enabled: false
       username: ""
@@ -337,6 +339,13 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 Type: `int`  
 Default: `64`  
+
+### `api_key`
+
+Allows you to specify a Base64-encoded token for authorization; if set, overrides basic auth.
+
+
+Type: `string`  
 
 ### `basic_auth`
 


### PR DESCRIPTION
This will add the option to use an elastcsearch API key to authenticate to a cluster, allowing a user to avoid the use of basic auth if they wish. 