### PR TITLE
chore(ci): Optimize dependabot grouping

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,13 +4,57 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
     open-pull-requests-limit: 10
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      # All major dependencies (security or otherwise) should be updated within individual PR.
+      # Otherwise, group together minor & patch updates into bulk PRs, for security and version
+      # bumps respectively.
+      go-minor-patch: 
+        patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"
+      go-minor-patch-security:
+        applies-to: security-updates
+        patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      npm-docusaurus:
+        patterns:
+          - "@docusaurus/*"
+          - "@algolia/*"
+      npm-minor-patch:
+        patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"
+      npm-minor-patch-security:
+        applies-to: security-updates
+        patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION

## Context

Currently, dependabot is not really utilised correctly. This PR aims to group together relevant updates for both version and security updates across our Go, GH actions, and npm deps (the docs site in `./website`).

## Changes

- Groups patch/minor PRs for Go and npm version updates
- Groups security PRs (all update levels) for Go and npm
- Groups Docusaurus updates (all levels, including majors)
- Creates individual PRs for major version updates (outside the Docusaurus group)
- Groups GitHub actions updates into single PR