### PR TITLE
move test helper code to _test.go files

### DIFF
--- a/internal/impl/aws/integration_helpers_test.go
+++ b/internal/impl/aws/integration_helpers_test.go
@@ -18,6 +18,7 @@ import (
 
 // TODO: Add config + options pattern or use an already existing library like https://github.com/elgohr/go-localstack
 func GetLocalStack(t testing.TB, envVars []string, readyFns ...func(port string) error) (port string) {
+	t.Helper()
 	portInt, err := integration.GetFreePort()
 	require.NoError(t, err)
 

--- a/internal/impl/elasticsearch/aws/integration_test.go
+++ b/internal/impl/elasticsearch/aws/integration_test.go
@@ -6,15 +6,20 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/olivere/elastic/v7"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	es "github.com/aws/aws-sdk-go-v2/service/elasticsearchservice"
-	baws "github.com/warpstreamlabs/bento/internal/impl/aws"
 	"github.com/warpstreamlabs/bento/internal/impl/elasticsearch"
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"
@@ -138,7 +143,7 @@ aws:
 	}
 
 	envs := []string{"OPENSEARCH_ENDPOINT_STRATEGY=path"}
-	servicePort := baws.GetLocalStack(t, envs, setupESCluster, setupClient)
+	servicePort := GetLocalStack(t, envs, setupESCluster, setupClient)
 	template := `
 output:
   elasticsearch:
@@ -188,4 +193,76 @@ output:
 		t, template,
 		integration.StreamTestOptPort(servicePort),
 	)
+}
+
+// TODO: Add config + options pattern or use an already existing library like https://github.com/elgohr/go-localstack
+func GetLocalStack(t testing.TB, envVars []string, readyFns ...func(port string) error) (port string) {
+	t.Helper()
+	portInt, err := integration.GetFreePort()
+	require.NoError(t, err)
+
+	port = strconv.Itoa(portInt)
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	lsImageName := "localstack/localstack"
+	var env []string
+	env = append(env, envVars...)
+
+	// If an auth token is provided, use the pro-image
+	if authToken, isPro := os.LookupEnv("LOCALSTACK_AUTH_TOKEN"); isPro && authToken != "" {
+		env = append(env, "LOCALSTACK_AUTH_TOKEN="+authToken)
+		lsImageName = lsImageName + "-pro"
+	}
+	env = append(env, "LS_LOG=debug")
+
+	pool.MaxWait = time.Minute * 300
+
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository:   lsImageName,
+		Tag:          "4.9.2", // pinning version: latest needs a license.
+		ExposedPorts: []string{"4566/tcp"},
+		PortBindings: map[docker.Port][]docker.PortBinding{
+			docker.Port(port + "/tcp"): {
+				docker.PortBinding{HostIP: "", HostPort: port},
+			},
+		},
+		Env: env,
+	})
+	port = resource.GetPort("4566/tcp")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, pool.Purge(resource))
+	})
+
+	_ = resource.Expire(900)
+
+	require.NoError(t, pool.Retry(func() error {
+		var err error
+		defer func() {
+			if err != nil {
+				t.Logf("localstack probe error: %v", err)
+			}
+		}()
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%s/_localstack/health", port))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return errors.New("cannot connect to LocalStack")
+		}
+
+		return nil
+	}))
+
+	for _, readyFn := range readyFns {
+		require.NoError(t, pool.Retry(func() error {
+			return readyFn(port)
+		}))
+	}
+
+	return
 }


### PR DESCRIPTION
fixes govulncheck github action: https://github.com/jem-davies/bento/actions/runs/25389666982

govulncheck will ignore any source code for test cases - this PR moves 2 remaining CVEs to _test.go files .