### PR TITLE
feat(protobuf): Add emit_unpopulated option to protobuf processor

### DIFF
--- a/internal/impl/protobuf/processor_protobuf.go
+++ b/internal/impl/protobuf/processor_protobuf.go
@@ -32,6 +32,8 @@ const (
 	fieldBsrVersion = "version"
 )
 
+const fieldEmitUnpopulated = "emit_unpopulated"
+
 func protobufProcessorSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Stable().
@@ -62,6 +64,9 @@ Attempts to create a target protobuf message from a generic JSON structure.
 			Default(false),
 		service.NewBoolField(fieldUseProtoNames).
 			Description("If `true`, the `to_json` operator deserializes fields exactly as named in schema file.").
+			Default(false),
+		service.NewBoolField(fieldEmitUnpopulated).
+			Description("If `true`, the `to_json` operator emits unpopulated fields with their default JSON values.").
 			Default(false),
 		service.NewStringListField(fieldImportPaths).
 			Description("A list of directories containing .proto files or list of file paths, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported. Either this field or `bsr` must be populated.").
@@ -259,7 +264,7 @@ func init() {
 
 type protobufOperator func(part *service.Message) error
 
-func newProtobufToJSONOperator(f fs.FS, msg string, importPaths []string, useProtoNames bool) (protobufOperator, error) {
+func newProtobufToJSONOperator(f fs.FS, msg string, importPaths []string, useProtoNames, emitUnpopulated bool) (protobufOperator, error) {
 	if msg == "" {
 		return nil, errors.New("message field must not be empty")
 	}
@@ -294,6 +299,7 @@ func newProtobufToJSONOperator(f fs.FS, msg string, importPaths []string, usePro
 			Resolver:      types,
 			UseProtoNames: useProtoNames,
 		}
+		opts.EmitUnpopulated = emitUnpopulated
 		data, err := opts.Marshal(dynMsg)
 		if err != nil {
 			return fmt.Errorf("failed to unmarshal JSON protobuf message '%v': %w", msg, err)
@@ -304,7 +310,7 @@ func newProtobufToJSONOperator(f fs.FS, msg string, importPaths []string, usePro
 	}, nil
 }
 
-func newProtobufToJSONBSROperator(multiModuleWatcher *MultiModuleWatcher, msg string, useProtoNames bool) (protobufOperator, error) {
+func newProtobufToJSONBSROperator(multiModuleWatcher *MultiModuleWatcher, msg string, useProtoNames, emitUnpopulated bool) (protobufOperator, error) {
 	if msg == "" {
 		return nil, errors.New("message field must not be empty")
 	}
@@ -329,6 +335,7 @@ func newProtobufToJSONBSROperator(multiModuleWatcher *MultiModuleWatcher, msg st
 			Resolver:      multiModuleWatcher,
 			UseProtoNames: useProtoNames,
 		}
+		opts.EmitUnpopulated = emitUnpopulated
 		data, err := opts.Marshal(dynMsg)
 		if err != nil {
 			return fmt.Errorf("failed to marshal JSON protobuf message '%v': %w", msg, err)
@@ -420,20 +427,20 @@ func newProtobufFromJSONBSROperator(multiModuleWatcher *MultiModuleWatcher, msg 
 	}, nil
 }
 
-func strToProtobufOperator(f fs.FS, opStr, message string, importPaths []string, discardUnknown, useProtoNames bool) (protobufOperator, error) {
+func strToProtobufOperator(f fs.FS, opStr, message string, importPaths []string, discardUnknown, useProtoNames, emitUnpopulated bool) (protobufOperator, error) {
 	switch opStr {
 	case "to_json":
-		return newProtobufToJSONOperator(f, message, importPaths, useProtoNames)
+		return newProtobufToJSONOperator(f, message, importPaths, useProtoNames, emitUnpopulated)
 	case "from_json":
 		return newProtobufFromJSONOperator(f, message, importPaths, discardUnknown)
 	}
 	return nil, fmt.Errorf("operator not recognised: %v", opStr)
 }
 
-func strToProtobufBSROperator(multiModuleWatcher *MultiModuleWatcher, opStr, message string, discardUnknown, useProtoNames bool) (protobufOperator, error) {
+func strToProtobufBSROperator(multiModuleWatcher *MultiModuleWatcher, opStr, message string, discardUnknown, useProtoNames, emitUnpopulated bool) (protobufOperator, error) {
 	switch opStr {
 	case "to_json":
-		return newProtobufToJSONBSROperator(multiModuleWatcher, message, useProtoNames)
+		return newProtobufToJSONBSROperator(multiModuleWatcher, message, useProtoNames, emitUnpopulated)
 	case "from_json":
 		return newProtobufFromJSONBSROperator(multiModuleWatcher, message, discardUnknown)
 	}
@@ -500,6 +507,11 @@ func newProtobuf(conf *service.ParsedConfig, mgr *service.Resources) (*protobufP
 		return nil, err
 	}
 
+	var emitUnpopulated bool
+	if emitUnpopulated, err = conf.FieldBool(fieldEmitUnpopulated); err != nil {
+		return nil, err
+	}
+
 	// Load BSR config
 	var bsrModules []*service.ParsedConfig
 	if bsrModules, err = conf.FieldObjectList(fieldBsrConfig); err != nil {
@@ -513,7 +525,7 @@ func newProtobuf(conf *service.ParsedConfig, mgr *service.Resources) (*protobufP
 			return nil, fmt.Errorf("failed to create MultiModuleWatcher: %w", err)
 		}
 
-		if p.operator, err = strToProtobufBSROperator(p.multiModuleWatcher, operatorStr, message, discardUnknown, useProtoNames); err != nil {
+		if p.operator, err = strToProtobufBSROperator(p.multiModuleWatcher, operatorStr, message, discardUnknown, useProtoNames, emitUnpopulated); err != nil {
 			return nil, err
 		}
 	} else {
@@ -522,7 +534,7 @@ func newProtobuf(conf *service.ParsedConfig, mgr *service.Resources) (*protobufP
 		if importPaths, err = conf.FieldStringList(fieldImportPaths); err != nil {
 			return nil, err
 		}
-		if p.operator, err = strToProtobufOperator(mgr.FS(), operatorStr, message, importPaths, discardUnknown, useProtoNames); err != nil {
+		if p.operator, err = strToProtobufOperator(mgr.FS(), operatorStr, message, importPaths, discardUnknown, useProtoNames, emitUnpopulated); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/impl/protobuf/processor_protobuf.go
+++ b/internal/impl/protobuf/processor_protobuf.go
@@ -18,11 +18,12 @@ import (
 )
 
 const (
-	fieldOperator       = "operator"
-	fieldMessage        = "message"
-	fieldImportPaths    = "import_paths"
-	fieldDiscardUnknown = "discard_unknown"
-	fieldUseProtoNames  = "use_proto_names"
+	fieldOperator        = "operator"
+	fieldMessage         = "message"
+	fieldImportPaths     = "import_paths"
+	fieldDiscardUnknown  = "discard_unknown"
+	fieldUseProtoNames   = "use_proto_names"
+	fieldEmitUnpopulated = "emit_unpopulated"
 
 	// BSR Config
 	fieldBsrConfig  = "bsr"
@@ -31,8 +32,6 @@ const (
 	fieldBsrAPIKey  = "api_key"
 	fieldBsrVersion = "version"
 )
-
-const fieldEmitUnpopulated = "emit_unpopulated"
 
 func protobufProcessorSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
@@ -296,10 +295,10 @@ func newProtobufToJSONOperator(f fs.FS, msg string, importPaths []string, usePro
 		}
 
 		opts := protojson.MarshalOptions{
-			Resolver:      types,
-			UseProtoNames: useProtoNames,
+			Resolver:        types,
+			UseProtoNames:   useProtoNames,
+			EmitUnpopulated: emitUnpopulated,
 		}
-		opts.EmitUnpopulated = emitUnpopulated
 		data, err := opts.Marshal(dynMsg)
 		if err != nil {
 			return fmt.Errorf("failed to unmarshal JSON protobuf message '%v': %w", msg, err)
@@ -332,10 +331,10 @@ func newProtobufToJSONBSROperator(multiModuleWatcher *MultiModuleWatcher, msg st
 		}
 
 		opts := protojson.MarshalOptions{
-			Resolver:      multiModuleWatcher,
-			UseProtoNames: useProtoNames,
+			Resolver:        multiModuleWatcher,
+			UseProtoNames:   useProtoNames,
+			EmitUnpopulated: emitUnpopulated,
 		}
-		opts.EmitUnpopulated = emitUnpopulated
 		data, err := opts.Marshal(dynMsg)
 		if err != nil {
 			return fmt.Errorf("failed to marshal JSON protobuf message '%v': %w", msg, err)

--- a/internal/impl/protobuf/processor_protobuf_test.go
+++ b/internal/impl/protobuf/processor_protobuf_test.go
@@ -142,11 +142,12 @@ discard_unknown: %t
 func TestProtobufToJSONImportPaths(t *testing.T) {
 
 	type testCase struct {
-		name          string
-		message       string
-		input         []byte
-		output        string
-		useProtoNames bool
+		name            string
+		message         string
+		input           []byte
+		output          string
+		useProtoNames   bool
+		emitUnpopulated bool
 	}
 
 	var testCases = []testCase{
@@ -171,6 +172,23 @@ func TestProtobufToJSONImportPaths(t *testing.T) {
 				0x6d,
 			},
 			output: `{"firstName":"caleb","lastName":"quaye","email":"caleb@myspace.com"}`,
+		},
+		{
+			name:    "protobuf to json with emit_unpopulated",
+			message: "testing.Person",
+			emitUnpopulated: true,
+			input: []byte{
+				0x0a, 0x05, 0x63, 0x61, 0x6c, 0x65, 0x62, 0x12, 0x05, 0x71, 0x75, 0x61, 0x79, 0x65, 0x32, 0x11,
+				0x63, 0x61, 0x6c, 0x65, 0x62, 0x40, 0x6d, 0x79, 0x73, 0x70, 0x61, 0x63, 0x65, 0x2e, 0x63, 0x6f,
+				0x6d,
+			},
+			output: `{"firstName":"caleb","lastName":"quaye","fullName":"","age":0,"id":0,"email":"caleb@myspace.com","lastUpdated":null}`,
+		},
+		{
+			name:            "protobuf to json with emit_unpopulated and empty message",
+			message:         "testing.Person",
+			emitUnpopulated: true,
+			output:          `{"firstName":"","lastName":"","fullName":"","age":0,"id":0,"email":"","lastUpdated":null}`,
 		},
 		{
 			name:          "protobuf to json with use_proto_names",
@@ -211,7 +229,8 @@ operator: to_json
 message: %v
 import_paths: [ %v ]
 use_proto_names: %t
-`, test.message, protosPath, test.useProtoNames), nil)
+emit_unpopulated: %t
+`, test.message, protosPath, test.useProtoNames, test.emitUnpopulated), nil)
 			require.NoError(t, err)
 
 			proc, err := newProtobuf(conf, service.MockResources())
@@ -238,7 +257,8 @@ bsr:
   - module: "testing"
     url: %s
 use_proto_names: %t
-`, test.message, "http://"+mockBSRServerAddress, test.useProtoNames), nil)
+emit_unpopulated: %t
+`, test.message, "http://"+mockBSRServerAddress, test.useProtoNames, test.emitUnpopulated), nil)
 			require.NoError(t, err)
 
 			proc, err := newProtobuf(conf, service.MockResources())

--- a/internal/impl/protobuf/processor_protobuf_test.go
+++ b/internal/impl/protobuf/processor_protobuf_test.go
@@ -174,8 +174,8 @@ func TestProtobufToJSONImportPaths(t *testing.T) {
 			output: `{"firstName":"caleb","lastName":"quaye","email":"caleb@myspace.com"}`,
 		},
 		{
-			name:    "protobuf to json with emit_unpopulated",
-			message: "testing.Person",
+			name:            "protobuf to json with emit_unpopulated",
+			message:         "testing.Person",
 			emitUnpopulated: true,
 			input: []byte{
 				0x0a, 0x05, 0x63, 0x61, 0x6c, 0x65, 0x62, 0x12, 0x05, 0x71, 0x75, 0x61, 0x79, 0x65, 0x32, 0x11,

--- a/website/docs/components/processors/protobuf.md
+++ b/website/docs/components/processors/protobuf.md
@@ -27,6 +27,7 @@ protobuf:
   message: "" # No default (required)
   discard_unknown: false
   use_proto_names: false
+  emit_unpopulated: false
   import_paths: []
   bsr: []
 ```
@@ -268,6 +269,14 @@ Default: `false`
 ### `use_proto_names`
 
 If `true`, the `to_json` operator deserializes fields exactly as named in schema file.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `emit_unpopulated`
+
+If `true`, the `to_json` operator emits unpopulated fields with their default JSON values.
 
 
 Type: `bool`  


### PR DESCRIPTION
Adds `emit_unpopulated` as an option to the protobuf processor which allows for protobuf fields that are not set to be present with their default values in the JSON output of the `to_json` option. `false` by default so no existing behaviour is changed.
closes #496 