### PR TITLE
fix(sql): goroutine leak on Connect + nil-db panic in writeBatch

### DIFF
--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -218,6 +218,19 @@ func newSQLInsertOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resou
 		}
 	}
 
+	go func() {
+		<-s.shutSig.HardStopChan()
+
+		s.dbMut.Lock()
+		if s.db != nil {
+			_ = s.db.Close()
+			s.db = nil
+		}
+		s.dbMut.Unlock()
+
+		s.shutSig.TriggerHasStopped()
+	}()
+
 	return s, nil
 }
 
@@ -235,20 +248,6 @@ func (s *sqlInsertOutput) Connect(ctx context.Context) error {
 	}
 
 	s.connSettings.apply(ctx, s.db, s.logger)
-
-	go func() {
-		<-s.shutSig.HardStopChan()
-
-		s.dbMut.Lock()
-		defer s.dbMut.Unlock()
-
-		if s.db != nil {
-			_ = s.db.Close()
-			s.db = nil
-		}
-
-		s.shutSig.TriggerHasStopped()
-	}()
 	return nil
 }
 

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -259,7 +259,10 @@ func (s *sqlInsertOutput) WriteBatch(ctx context.Context, batch service.MessageB
 
 	if errors.Is(err, driver.ErrBadConn) || isAuthError(s.driver, err) {
 		s.dbMut.Lock()
-		s.db = nil
+		if s.db != nil {
+			_ = s.db.Close()
+			s.db = nil
+		}
 		s.dbMut.Unlock()
 		return service.ErrNotConnected
 	}

--- a/internal/impl/sql/output_sql_insert_test.go
+++ b/internal/impl/sql/output_sql_insert_test.go
@@ -2,9 +2,7 @@ package sql
 
 import (
 	"context"
-	"runtime"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -41,39 +39,18 @@ table: foo
 columns: [ id ]
 args_mapping: 'root = [ this.id ]'
 `
-	spec := sqlInsertOutputConfig()
-	parsed, err := spec.ParseYAML(conf, service.NewEnvironment())
+	parsed, err := sqlInsertOutputConfig().ParseYAML(conf, service.NewEnvironment())
 	require.NoError(t, err)
 
 	o, err := newSQLInsertOutputFromConfig(parsed, service.MockResources())
 	require.NoError(t, err)
 
-	ctx := context.Background()
-	require.NoError(t, o.Connect(ctx))
-
-	for i := 0; i < 50; i++ {
+	assertNoConnectGoroutineLeak(t, o, func() {
 		o.dbMut.Lock()
 		if o.db != nil {
 			_ = o.db.Close()
 			o.db = nil
 		}
 		o.dbMut.Unlock()
-		require.NoError(t, o.Connect(ctx))
-	}
-
-	before := runtime.NumGoroutine()
-	for i := 0; i < 50; i++ {
-		o.dbMut.Lock()
-		if o.db != nil {
-			_ = o.db.Close()
-			o.db = nil
-		}
-		o.dbMut.Unlock()
-		require.NoError(t, o.Connect(ctx))
-	}
-	time.Sleep(50 * time.Millisecond)
-	after := runtime.NumGoroutine()
-
-	require.LessOrEqual(t, after-before, 2, "Connect leaks goroutines: before=%d after=%d", before, after)
-	require.NoError(t, o.Close(ctx))
+	})
 }

--- a/internal/impl/sql/output_sql_insert_test.go
+++ b/internal/impl/sql/output_sql_insert_test.go
@@ -2,9 +2,13 @@ package sql
 
 import (
 	"context"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
 
 	"github.com/warpstreamlabs/bento/public/service"
 )
@@ -27,4 +31,49 @@ args_mapping: 'root = [ this.id ]'
 	insertOutput, err := newSQLInsertOutputFromConfig(insertConfig, service.MockResources())
 	require.NoError(t, err)
 	require.NoError(t, insertOutput.Close(context.Background()))
+}
+
+func TestSQLInsertOutputConnectNoGoroutineLeak(t *testing.T) {
+	conf := `
+driver: sqlite
+dsn: ":memory:"
+table: foo
+columns: [ id ]
+args_mapping: 'root = [ this.id ]'
+`
+	spec := sqlInsertOutputConfig()
+	parsed, err := spec.ParseYAML(conf, service.NewEnvironment())
+	require.NoError(t, err)
+
+	o, err := newSQLInsertOutputFromConfig(parsed, service.MockResources())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, o.Connect(ctx))
+
+	for i := 0; i < 50; i++ {
+		o.dbMut.Lock()
+		if o.db != nil {
+			_ = o.db.Close()
+			o.db = nil
+		}
+		o.dbMut.Unlock()
+		require.NoError(t, o.Connect(ctx))
+	}
+
+	before := runtime.NumGoroutine()
+	for i := 0; i < 50; i++ {
+		o.dbMut.Lock()
+		if o.db != nil {
+			_ = o.db.Close()
+			o.db = nil
+		}
+		o.dbMut.Unlock()
+		require.NoError(t, o.Connect(ctx))
+	}
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	require.LessOrEqual(t, after-before, 2, "Connect leaks goroutines: before=%d after=%d", before, after)
+	require.NoError(t, o.Close(ctx))
 }

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -165,7 +165,7 @@ func newSQLRawOutput(
 	connSettings *connSettings,
 	awsConf aws.Config,
 ) *sqlRawOutput {
-	return &sqlRawOutput{
+	s := &sqlRawOutput{
 		logger:       logger,
 		shutSig:      shutdown.NewSignaller(),
 		driver:       driverStr,
@@ -176,6 +176,21 @@ func newSQLRawOutput(
 		connSettings: connSettings,
 		awsConf:      awsConf,
 	}
+
+	go func() {
+		<-s.shutSig.HardStopChan()
+
+		s.dbMut.Lock()
+		if s.db != nil {
+			_ = s.db.Close()
+			s.db = nil
+		}
+		s.dbMut.Unlock()
+
+		s.shutSig.TriggerHasStopped()
+	}()
+
+	return s
 }
 
 func (s *sqlRawOutput) Connect(ctx context.Context) error {
@@ -192,16 +207,6 @@ func (s *sqlRawOutput) Connect(ctx context.Context) error {
 	}
 
 	s.connSettings.apply(ctx, s.db, s.logger)
-
-	go func() {
-		<-s.shutSig.HardStopChan()
-
-		s.dbMut.Lock()
-		_ = s.db.Close()
-		s.dbMut.Unlock()
-
-		s.shutSig.TriggerHasStopped()
-	}()
 	return nil
 }
 

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -218,7 +218,10 @@ func (s *sqlRawOutput) WriteBatch(ctx context.Context, batch service.MessageBatc
 
 	if errors.Is(err, driver.ErrBadConn) || isAuthError(s.driver, err) {
 		s.dbMut.Lock()
-		s.db = nil
+		if s.db != nil {
+			_ = s.db.Close()
+			s.db = nil
+		}
 		s.dbMut.Unlock()
 		return service.ErrNotConnected
 	}

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -225,6 +225,10 @@ func (s *sqlRawOutput) writeBatch(ctx context.Context, batch service.MessageBatc
 	s.dbMut.RLock()
 	defer s.dbMut.RUnlock()
 
+	if s.db == nil {
+		return service.ErrNotConnected
+	}
+
 	var executor *service.MessageBatchBloblangExecutor
 	if s.argsMapping != nil {
 		executor = batch.BloblangExecutor(s.argsMapping)

--- a/internal/impl/sql/output_sql_raw_test.go
+++ b/internal/impl/sql/output_sql_raw_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -90,4 +91,51 @@ func TestSQLRawOutputConcurrentNilOutRace(t *testing.T) {
 	stop.Store(true)
 	wg.Wait()
 	require.False(t, panicked.Load(), "writeBatch must not panic on nil s.db")
+}
+
+// TestSQLRawOutputConnectNoGoroutineLeak verifies that repeated
+// connect/disconnect cycles (as caused by IAM token rotation in prod)
+// don't accumulate watcher goroutines.
+func TestSQLRawOutputConnectNoGoroutineLeak(t *testing.T) {
+	conf := `
+driver: sqlite
+dsn: ":memory:"
+query: "SELECT 1"
+`
+	spec := sqlRawOutputConfig()
+	parsed, err := spec.ParseYAML(conf, service.NewEnvironment())
+	require.NoError(t, err)
+
+	o, err := newSQLRawOutputFromConfig(parsed, service.MockResources())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, o.Connect(ctx))
+
+	for i := 0; i < 50; i++ {
+		o.dbMut.Lock()
+		if o.db != nil {
+			_ = o.db.Close()
+			o.db = nil
+		}
+		o.dbMut.Unlock()
+		require.NoError(t, o.Connect(ctx))
+	}
+
+	before := runtime.NumGoroutine()
+	for i := 0; i < 50; i++ {
+		o.dbMut.Lock()
+		if o.db != nil {
+			_ = o.db.Close()
+			o.db = nil
+		}
+		o.dbMut.Unlock()
+		require.NoError(t, o.Connect(ctx))
+	}
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	require.LessOrEqual(t, after-before, 2, "Connect leaks goroutines: before=%d after=%d", before, after)
+
+	require.NoError(t, o.Close(ctx))
 }

--- a/internal/impl/sql/output_sql_raw_test.go
+++ b/internal/impl/sql/output_sql_raw_test.go
@@ -57,10 +57,8 @@ func TestSQLRawOutputConcurrentNilOutRace(t *testing.T) {
 		stop atomic.Bool
 	)
 
-	for i := 0; i < 64; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 64 {
+		wg.Go(func() {
 			defer func() {
 				if r := recover(); r != nil {
 					t.Errorf("writeBatch panicked: %v", r)
@@ -73,7 +71,7 @@ func TestSQLRawOutputConcurrentNilOutRace(t *testing.T) {
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	// Split critical sections so readers can observe db == nil between them —
@@ -129,14 +127,14 @@ func assertNoConnectGoroutineLeak(t *testing.T, o connectCloser, nilDB func()) {
 	require.NoError(t, o.Connect(ctx))
 
 	// Warm up so cgo/sqlite/finalizer goroutines settle before measuring.
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		nilDB()
 		require.NoError(t, o.Connect(ctx))
 	}
 
 	before := runtime.NumGoroutine()
 	const iterations = 10
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		nilDB()
 		require.NoError(t, o.Connect(ctx))
 	}

--- a/internal/impl/sql/output_sql_raw_test.go
+++ b/internal/impl/sql/output_sql_raw_test.go
@@ -1,0 +1,93 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Jeffail/shutdown"
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+// TestSQLRawOutputWriteBatchNilDB exercises the trivial path: writeBatch
+// must return ErrNotConnected when s.db is nil, not panic.
+func TestSQLRawOutputWriteBatchNilDB(t *testing.T) {
+	o := &sqlRawOutput{
+		driver:      "sqlite",
+		queryStatic: "SELECT 1",
+		logger:      service.MockResources().Logger(),
+		shutSig:     shutdown.NewSignaller(),
+	}
+	// s.db is nil — simulating mid-recovery after a bad-conn nil-out.
+
+	err := o.WriteBatch(context.Background(), service.MessageBatch{service.NewMessage(nil)})
+	require.ErrorIs(t, err, service.ErrNotConnected)
+}
+
+// TestSQLRawOutputConcurrentNilOutRace stresses the writeBatch path while
+// another goroutine nils and restores s.db, the way WriteBatch does on
+// ErrBadConn. Without the nil-check fix this panics with a nil-pointer
+// deref under `go test -race`.
+func TestSQLRawOutputConcurrentNilOutRace(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	o := &sqlRawOutput{
+		driver:      "sqlite",
+		queryStatic: "SELECT 1",
+		db:          db,
+		logger:      service.MockResources().Logger(),
+		shutSig:     shutdown.NewSignaller(),
+	}
+
+	batch := service.MessageBatch{service.NewMessage(nil)}
+
+	var (
+		wg       sync.WaitGroup
+		stop     atomic.Bool
+		panicked atomic.Bool
+	)
+
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicked.Store(true)
+					t.Errorf("writeBatch panicked: %v", r)
+				}
+			}()
+			for !stop.Load() {
+				err := o.WriteBatch(context.Background(), batch)
+				if err != nil && !errors.Is(err, service.ErrNotConnected) {
+					t.Errorf("unexpected writeBatch error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		o.dbMut.Lock()
+		o.db = nil
+		o.dbMut.Unlock()
+		o.dbMut.Lock()
+		o.db = db
+		o.dbMut.Unlock()
+	}
+
+	stop.Store(true)
+	wg.Wait()
+	require.False(t, panicked.Load(), "writeBatch must not panic on nil s.db")
+}

--- a/internal/impl/sql/output_sql_raw_test.go
+++ b/internal/impl/sql/output_sql_raw_test.go
@@ -53,9 +53,8 @@ func TestSQLRawOutputConcurrentNilOutRace(t *testing.T) {
 	batch := service.MessageBatch{service.NewMessage(nil)}
 
 	var (
-		wg       sync.WaitGroup
-		stop     atomic.Bool
-		panicked atomic.Bool
+		wg   sync.WaitGroup
+		stop atomic.Bool
 	)
 
 	for i := 0; i < 64; i++ {
@@ -64,7 +63,6 @@ func TestSQLRawOutputConcurrentNilOutRace(t *testing.T) {
 			defer wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
-					panicked.Store(true)
 					t.Errorf("writeBatch panicked: %v", r)
 				}
 			}()
@@ -78,6 +76,8 @@ func TestSQLRawOutputConcurrentNilOutRace(t *testing.T) {
 		}()
 	}
 
+	// Split critical sections so readers can observe db == nil between them —
+	// merging into one lock would never let the nil branch fire.
 	deadline := time.Now().Add(200 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		o.dbMut.Lock()
@@ -90,52 +90,62 @@ func TestSQLRawOutputConcurrentNilOutRace(t *testing.T) {
 
 	stop.Store(true)
 	wg.Wait()
-	require.False(t, panicked.Load(), "writeBatch must not panic on nil s.db")
 }
 
-// TestSQLRawOutputConnectNoGoroutineLeak verifies that repeated
-// connect/disconnect cycles (as caused by IAM token rotation in prod)
-// don't accumulate watcher goroutines.
 func TestSQLRawOutputConnectNoGoroutineLeak(t *testing.T) {
 	conf := `
 driver: sqlite
 dsn: ":memory:"
 query: "SELECT 1"
 `
-	spec := sqlRawOutputConfig()
-	parsed, err := spec.ParseYAML(conf, service.NewEnvironment())
+	parsed, err := sqlRawOutputConfig().ParseYAML(conf, service.NewEnvironment())
 	require.NoError(t, err)
 
 	o, err := newSQLRawOutputFromConfig(parsed, service.MockResources())
 	require.NoError(t, err)
 
-	ctx := context.Background()
-	require.NoError(t, o.Connect(ctx))
-
-	for i := 0; i < 50; i++ {
+	assertNoConnectGoroutineLeak(t, o, func() {
 		o.dbMut.Lock()
 		if o.db != nil {
 			_ = o.db.Close()
 			o.db = nil
 		}
 		o.dbMut.Unlock()
+	})
+}
+
+// connectCloser is satisfied by *sqlRawOutput and *sqlInsertOutput.
+type connectCloser interface {
+	Connect(ctx context.Context) error
+	Close(ctx context.Context) error
+}
+
+// assertNoConnectGoroutineLeak runs repeated reconnect cycles and asserts the
+// goroutine count does not scale with iteration count — guards against the
+// pre-fix regression where Connect spawned a new watcher each call.
+func assertNoConnectGoroutineLeak(t *testing.T, o connectCloser, nilDB func()) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, o.Connect(ctx))
+
+	// Warm up so cgo/sqlite/finalizer goroutines settle before measuring.
+	for i := 0; i < 5; i++ {
+		nilDB()
 		require.NoError(t, o.Connect(ctx))
 	}
 
 	before := runtime.NumGoroutine()
-	for i := 0; i < 50; i++ {
-		o.dbMut.Lock()
-		if o.db != nil {
-			_ = o.db.Close()
-			o.db = nil
-		}
-		o.dbMut.Unlock()
+	const iterations = 10
+	for i := 0; i < iterations; i++ {
+		nilDB()
 		require.NoError(t, o.Connect(ctx))
 	}
-	time.Sleep(50 * time.Millisecond)
-	after := runtime.NumGoroutine()
 
-	require.LessOrEqual(t, after-before, 2, "Connect leaks goroutines: before=%d after=%d", before, after)
+	// A real per-Connect leak would push the delta to ~iterations.
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine()-before <= 2
+	}, time.Second, 5*time.Millisecond,
+		"Connect leaks goroutines: before=%d current=%d", before, runtime.NumGoroutine())
 
 	require.NoError(t, o.Close(ctx))
 }


### PR DESCRIPTION
## Summary

Fixes two related issues in `sql_raw` and `sql_insert` outputs that surfaced under IAM-token rotation, where the framework calls `Connect()` repeatedly to refresh credentials.

- **Goroutine leak (`sql_raw`, `sql_insert`)**: the shutdown-watcher goroutine was spawned inside `Connect()`. Each reconnect spawned a new watcher that lived for the rest of the process. Moved the watcher into the constructor (`newSQLRawOutput` / `newSQLInsertOutputFromConfig`) so it spawns exactly once.
- **Nil-pointer panic in `writeBatch` (`sql_raw`)**: `WriteBatch`'s `ErrBadConn` recovery path nils out `s.db` before reopening. A concurrent `writeBatch` taking the RLock could observe `s.db == nil` and panic on dereference. Added `if s.db == nil { return service.ErrNotConnected }` under the existing RLock — matches the pattern already used in `input_sql_raw.go` and `input_sql_select.go`.
