### PR TITLE
Handle deprecation of optional in cuegen.

### DIFF
--- a/internal/cuegen/cue.go
+++ b/internal/cuegen/cue.go
@@ -103,9 +103,9 @@ func doFieldSpec(spec docs.FieldSpec) (*ast.Field, error) {
 
 func doScalarField(spec docs.FieldSpec) (*ast.Field, error) {
 	label := ast.NewIdent(spec.Name)
-	optionalMark := token.Blank.Pos()
+	optionalMark := token.OPTION
 
-	var optional token.Pos
+	var optional token.Token
 	var val ast.Expr
 
 	switch spec.Type {
@@ -164,9 +164,9 @@ func doScalarField(spec docs.FieldSpec) (*ast.Field, error) {
 	}
 
 	return &ast.Field{
-		Label:    label,
-		Value:    val,
-		Optional: optional,
+		Label:      label,
+		Value:      val,
+		Constraint: optional,
 	}, nil
 }
 


### PR DESCRIPTION
Deprecation described here:
https://github.com/cue-lang/cue/commit/0265d7d62829c1002e3ea58dd6c5b992fea5f2e3

As far as I can tell, this is causing the build failures when upgrading in #843