### PR TITLE
fix(kafka_franz): Align logger levels & always set on input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,6 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
-## 1.17.1 - 2026-05-23
-
-### Fixed 
-
-- `kafka_franz` input to attach logger regardless of consumer group being set @gregfurman
-
-### Changed
-
-- `kafka_franz` franz-go logs to surface at `ERROR/WARN/INFO/DEBUG` instead of `ERROR/WARN/DEBUG/TRACE` @gregfurman
-
 ## 1.17.0 - 2026-04-15
 
 ### Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 1.17.1 - 2026-05-23
+
+### Fixed 
+
+- `kafka_franz` input to attach logger regardless of consumer group being set @gregfurman
+
+### Changed
+
+- `kafka_franz` franz-go logs to surface at `ERROR/WARN/INFO/DEBUG` instead of `ERROR/WARN/DEBUG/TRACE` @gregfurman
+
 ## 1.17.0 - 2026-04-15
 
 ### Added 

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -862,6 +862,8 @@ func (f *franzKafkaReader) Connect(ctx context.Context) error {
 		kgo.FetchMaxWait(f.fetchMaxWait),
 		kgo.ConsumePreferringLagFn(f.preferringLagFn),
 		kgo.Balancers(f.balancers...),
+
+		kgo.WithLogger(&kgoLogger{f.log}),
 	}
 	if f.reconnectOnUnknownTopic {
 		clientOpts = append(clientOpts, kgo.KeepRetryableFetchErrors())
@@ -881,7 +883,6 @@ func (f *franzKafkaReader) Connect(ctx context.Context) error {
 			}),
 			kgo.AutoCommitMarks(),
 			kgo.AutoCommitInterval(f.commitPeriod),
-			kgo.WithLogger(&kgoLogger{f.log}),
 		)
 	}
 

--- a/internal/impl/kafka/logger.go
+++ b/internal/impl/kafka/logger.go
@@ -26,8 +26,8 @@ func (k *kgoLogger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
 	case kgo.LogLevelWarn:
 		tmpL.Warn(msg)
 	case kgo.LogLevelInfo:
-		tmpL.Debug(msg)
+		tmpL.Info(msg)
 	case kgo.LogLevelDebug:
-		tmpL.Trace(msg)
+		tmpL.Debug(msg)
 	}
 }


### PR DESCRIPTION
## Changes

- kgo `INFO` and `DEBUG` logging now happens at the specified levels, instead of mapping to `DEBUG` and `TRACE` respectively.
- Ensures the kafka logger is always set for input component, regardless of whether consumer group attribute is set.