### PR TITLE
feat(parquet): Support nested N-D lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Nested list-of-list support to `parquet` processors @gregfurman
+
 ### Fixed
 
 - `parse_big_decimal` rejects scales above 16383 to avoid unbounded big-integer work @aratz-lasa

--- a/go.mod
+++ b/go.mod
@@ -473,4 +473,4 @@ replace github.com/hamba/avro/v2 => github.com/iskorotkov/avro/v2 v2.33.0
 
 // TODO: Resolves to a branch at github.com/warpstreamlabs/parquet-go@warpstream/dev. Once we get an official
 // release in github.com/parquet-go/parquet-go with the N-dimension list fix, we can remove this.
-replace github.com/parquet-go/parquet-go => github.com/warpstreamlabs/parquet-go v0.0.0-20260806184926-f69e607ff55d
+replace github.com/parquet-go/parquet-go => github.com/warpstreamlabs/parquet-go v0.0.0-20260806184031-adb6907aa89a

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/opensearch-project/opensearch-go/v4 v4.5.0
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/oschwald/geoip2-golang v1.9.0
-	github.com/parquet-go/parquet-go v0.29.0
+	github.com/parquet-go/parquet-go v0.30.2-0.20260713200242-a326b0cd1e5d
 	github.com/pebbe/zmq4 v1.2.11
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/pkg/sftp v1.13.7

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/opensearch-project/opensearch-go/v4 v4.5.0
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/oschwald/geoip2-golang v1.9.0
-	github.com/parquet-go/parquet-go v0.30.2-0.20260713200242-a326b0cd1e5d
+	github.com/parquet-go/parquet-go v0.29.0
 	github.com/pebbe/zmq4 v1.2.11
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/pkg/sftp v1.13.7
@@ -470,3 +470,7 @@ go 1.26.5
 // github.com/warpstreamlabs/bento/public/components/pulsar. Once fixed upstream, this can be dropped.
 // See https://github.com/warpstreamlabs/bento/issues/960.
 replace github.com/hamba/avro/v2 => github.com/iskorotkov/avro/v2 v2.33.0
+
+// TODO: Resolves to a branch at github.com/warpstreamlabs/parquet-go@warpstream/dev. Once we get an official
+// release in github.com/parquet-go/parquet-go with the N-dimension list fix, we can remove this.
+replace github.com/parquet-go/parquet-go => github.com/warpstreamlabs/parquet-go v0.0.0-20260806184926-f69e607ff55d

--- a/go.sum
+++ b/go.sum
@@ -1677,8 +1677,8 @@ github.com/parquet-go/bitpack v1.0.0 h1:AUqzlKzPPXf2bCdjfj4sTeacrUwsT7NlcYDMUQxP
 github.com/parquet-go/bitpack v1.0.0/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
 github.com/parquet-go/jsonlite v1.5.0 h1:ulS7lNWdPwiqDMLzTiXHYmIUhu99mavZh2iAVdXet3g=
 github.com/parquet-go/jsonlite v1.5.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
-github.com/parquet-go/parquet-go v0.29.0 h1:xXlPtFVR51jpSVzf+cgHnNIcb7Xet+iuvkbe0HIm90Y=
-github.com/parquet-go/parquet-go v0.29.0/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
+github.com/parquet-go/parquet-go v0.30.2-0.20260713200242-a326b0cd1e5d h1:GSL/GwCWdCKXF8WIfzrWPGM4n9lMgEIssYvnZZ16z1Q=
+github.com/parquet-go/parquet-go v0.30.2-0.20260713200242-a326b0cd1e5d/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=
 github.com/paulmach/orb v0.12.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=

--- a/go.sum
+++ b/go.sum
@@ -1887,8 +1887,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/wI2L/jsondiff v0.7.0 h1:1lH1G37GhBPqCfp/lrs91rf/2j3DktX6qYAKZkLuCQQ=
 github.com/wI2L/jsondiff v0.7.0/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
-github.com/warpstreamlabs/parquet-go v0.0.0-20260806184926-f69e607ff55d h1:SskAsqyDStUaG/yJl+okmo0ZI1dfltuVSgPh7SYxpMo=
-github.com/warpstreamlabs/parquet-go v0.0.0-20260806184926-f69e607ff55d/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
+github.com/warpstreamlabs/parquet-go v0.0.0-20260806184031-adb6907aa89a h1:reHrEgNZu9/8FLercN98gcmWE2RXr8h0XkN9hM6s7vA=
+github.com/warpstreamlabs/parquet-go v0.0.0-20260806184031-adb6907aa89a/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=

--- a/go.sum
+++ b/go.sum
@@ -1677,8 +1677,6 @@ github.com/parquet-go/bitpack v1.0.0 h1:AUqzlKzPPXf2bCdjfj4sTeacrUwsT7NlcYDMUQxP
 github.com/parquet-go/bitpack v1.0.0/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
 github.com/parquet-go/jsonlite v1.5.0 h1:ulS7lNWdPwiqDMLzTiXHYmIUhu99mavZh2iAVdXet3g=
 github.com/parquet-go/jsonlite v1.5.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
-github.com/parquet-go/parquet-go v0.30.2-0.20260713200242-a326b0cd1e5d h1:GSL/GwCWdCKXF8WIfzrWPGM4n9lMgEIssYvnZZ16z1Q=
-github.com/parquet-go/parquet-go v0.30.2-0.20260713200242-a326b0cd1e5d/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=
 github.com/paulmach/orb v0.12.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
@@ -1889,6 +1887,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/wI2L/jsondiff v0.7.0 h1:1lH1G37GhBPqCfp/lrs91rf/2j3DktX6qYAKZkLuCQQ=
 github.com/wI2L/jsondiff v0.7.0/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
+github.com/warpstreamlabs/parquet-go v0.0.0-20260806184926-f69e607ff55d h1:SskAsqyDStUaG/yJl+okmo0ZI1dfltuVSgPh7SYxpMo=
+github.com/warpstreamlabs/parquet-go v0.0.0-20260806184926-f69e607ff55d/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=

--- a/internal/impl/parquet/convert.go
+++ b/internal/impl/parquet/convert.go
@@ -372,7 +372,7 @@ func transformList(data any) any {
 	if slice, ok := data.([]any); ok {
 		wrapped := make([]any, len(slice))
 		for i, item := range slice {
-			wrapped[i] = map[string]any{"element": item}
+			wrapped[i] = map[string]any{"element": transformList(item)}
 		}
 		return map[string]any{"list": wrapped}
 	}

--- a/internal/impl/parquet/convert.go
+++ b/internal/impl/parquet/convert.go
@@ -344,7 +344,7 @@ func transformDataWithSchema(data any, fields ...parquet.Field) any {
 		for key, value := range v {
 			field := findFieldByName(fields, key)
 			if field != nil {
-				if lt := field.Type().LogicalType(); lt != nil && lt.Value.FieldID() == 3 {
+				if lt := field.Type().LogicalType(); lt != nil && lt.List != nil {
 					result[key] = transformList(value)
 				} else {
 					result[key] = transformDataWithSchema(value, field.Fields()...)

--- a/internal/impl/parquet/convert.go
+++ b/internal/impl/parquet/convert.go
@@ -344,7 +344,7 @@ func transformDataWithSchema(data any, fields ...parquet.Field) any {
 		for key, value := range v {
 			field := findFieldByName(fields, key)
 			if field != nil {
-				if lt := field.Type().LogicalType(); lt != nil && lt.List != nil {
+				if lt := field.Type().LogicalType(); lt != nil && lt.Value.FieldID() == 3 {
 					result[key] = transformList(value)
 				} else {
 					result[key] = transformDataWithSchema(value, field.Fields()...)

--- a/internal/impl/parquet/processor_encode_test.go
+++ b/internal/impl/parquet/processor_encode_test.go
@@ -637,6 +637,16 @@ schema:
         type: LIST
         fields:
           - { name: element, type: FLOAT }
+  - name: list_of_list_of_lists
+    type: LIST
+    fields:
+      - name: element
+        type: LIST
+        fields:
+          - name: element
+            type: LIST
+            fields:
+              - { name: element, type: INT32 }
 `, nil)
 	require.NoError(t, err)
 
@@ -651,30 +661,74 @@ schema:
 		{
 			name: "empty lists",
 			input: `{
-  "normal_list": [],
-  "nullable_list": null,
-  "list_of_lists": []
-}`,
+		  "normal_list": [],
+		  "nullable_list": null,
+		  "list_of_lists": [],
+		  "list_of_list_of_lists": []
+		}`,
 			expected: `{
-  "normal_list": {"list": []},
-  "nullable_list": null,
-  "list_of_lists": {"list": []}
-}`,
+		  "normal_list": {"list": []},
+		  "nullable_list": null,
+		  "list_of_lists": {"list": []},
+		  "list_of_list_of_lists": {"list": []}
+		}`,
 		},
 		{
 			name: "nested lists",
 			input: `{
+		  "normal_list": ["a"],
+		  "nullable_list": [1, 2],
+		  "list_of_lists": [[1.1, 2.2], [3.3]],
+		  "list_of_list_of_lists": []
+		}`,
+			expected: `{
+		  "normal_list": {"list": [{"element": "a"}]},
+		  "nullable_list": {"list": [{"element": 1}, {"element": 2}]},
+		  "list_of_lists": {
+		    "list": [
+		      {"element": {"list": [{"element": 1.1}, {"element": 2.2}]}},
+		      {"element": {"list": [{"element": 3.3}]}}
+		    ]
+		  },
+		  "list_of_list_of_lists": {"list": []}
+		}`,
+		},
+		{
+			name: "3d lists",
+			input: `{
   "normal_list": ["a"],
-  "nullable_list": [1, 2],
-  "list_of_lists": [[1.1, 2.2], [3.3]]
+  "nullable_list": null,
+  "list_of_lists": [],
+  "list_of_list_of_lists": [
+    [[1, 2], [3]],
+    [[4, 5, 6]],
+    []
+  ]
 }`,
 			expected: `{
   "normal_list": {"list": [{"element": "a"}]},
-  "nullable_list": {"list": [{"element": 1}, {"element": 2}]},
-  "list_of_lists": {
+  "nullable_list": null,
+  "list_of_lists": {"list": []},
+  "list_of_list_of_lists": {
     "list": [
-      {"element": {"list": [{"element": 1.1}, {"element": 2.2}]}},
-      {"element": {"list": [{"element": 3.3}]}}
+      {
+        "element": {
+          "list": [
+            {"element": {"list": [{"element": 1}, {"element": 2}]}},
+            {"element": {"list": [{"element": 3}]}}
+          ]
+        }
+      },
+      {
+        "element": {
+          "list": [
+            {"element": {"list": [{"element": 4}, {"element": 5}, {"element": 6}]}}
+          ]
+        }
+      },
+      {
+        "element": {"list": []}
+      }
     ]
   }
 }`,

--- a/internal/impl/parquet/processor_encode_test.go
+++ b/internal/impl/parquet/processor_encode_test.go
@@ -617,10 +617,7 @@ use_parquet_list_format: false
 }
 
 func TestParquetDecodeListFormatEdgeCases(t *testing.T) {
-	// FIXME: Close https://github.com/warpstreamlabs/bento/issues/360 when 2D array support added to parquet-go.
-	t.Skip("2D slices are not currently supported by parquet encoder.")
-
-	tctx := context.Background()
+	tctx := t.Context()
 
 	encodeConf, err := parquetEncodeProcessorConfig().ParseYAML(`
 schema:

--- a/internal/impl/parquet/processor_encode_test.go
+++ b/internal/impl/parquet/processor_encode_test.go
@@ -647,6 +647,19 @@ schema:
             type: LIST
             fields:
               - { name: element, type: INT32 }
+  - name: list_of_list_of_list_of_lists
+    type: LIST
+    fields:
+      - name: element
+        type: LIST
+        fields:
+          - name: element
+            type: LIST
+            fields:
+              - name: element
+                type: LIST
+                fields:
+                  - { name: element, type: INT32 }
 `, nil)
 	require.NoError(t, err)
 
@@ -664,13 +677,15 @@ schema:
 		  "normal_list": [],
 		  "nullable_list": null,
 		  "list_of_lists": [],
-		  "list_of_list_of_lists": []
+		  "list_of_list_of_lists": [],
+		  "list_of_list_of_list_of_lists": []
 		}`,
 			expected: `{
 		  "normal_list": {"list": []},
 		  "nullable_list": null,
 		  "list_of_lists": {"list": []},
-		  "list_of_list_of_lists": {"list": []}
+		  "list_of_list_of_lists": {"list": []},
+		  "list_of_list_of_list_of_lists": {"list": []}
 		}`,
 		},
 		{
@@ -679,7 +694,8 @@ schema:
 		  "normal_list": ["a"],
 		  "nullable_list": [1, 2],
 		  "list_of_lists": [[1.1, 2.2], [3.3]],
-		  "list_of_list_of_lists": []
+		  "list_of_list_of_lists": [],
+		  "list_of_list_of_list_of_lists": []
 		}`,
 			expected: `{
 		  "normal_list": {"list": [{"element": "a"}]},
@@ -690,7 +706,8 @@ schema:
 		      {"element": {"list": [{"element": 3.3}]}}
 		    ]
 		  },
-		  "list_of_list_of_lists": {"list": []}
+		  "list_of_list_of_lists": {"list": []},
+		  "list_of_list_of_list_of_lists": {"list": []}
 		}`,
 		},
 		{
@@ -703,7 +720,8 @@ schema:
     [[1, 2], [3]],
     [[4, 5, 6]],
     []
-  ]
+  ],
+  "list_of_list_of_list_of_lists": []
 }`,
 			expected: `{
   "normal_list": {"list": [{"element": "a"}]},
@@ -723,6 +741,75 @@ schema:
         "element": {
           "list": [
             {"element": {"list": [{"element": 4}, {"element": 5}, {"element": 6}]}}
+          ]
+        }
+      },
+      {
+        "element": {"list": []}
+      }
+    ]
+  },
+  "list_of_list_of_list_of_lists": {"list": []}
+}`,
+		},
+		{
+			name: "4d lists",
+			input: `{
+  "normal_list": ["a"],
+  "nullable_list": null,
+  "list_of_lists": [],
+  "list_of_list_of_lists": [],
+  "list_of_list_of_list_of_lists": [
+    [
+      [[1, 2], [3]],
+      [[4, 5, 6]]
+    ],
+    [
+      [],
+      [[7]]
+    ],
+    []
+  ]
+}`,
+			expected: `{
+  "normal_list": {"list": [{"element": "a"}]},
+  "nullable_list": null,
+  "list_of_lists": {"list": []},
+  "list_of_list_of_lists": {"list": []},
+  "list_of_list_of_list_of_lists": {
+    "list": [
+      {
+        "element": {
+          "list": [
+            {
+              "element": {
+                "list": [
+                  {"element": {"list": [{"element": 1}, {"element": 2}]}},
+                  {"element": {"list": [{"element": 3}]}}
+                ]
+              }
+            },
+            {
+              "element": {
+                "list": [
+                  {"element": {"list": [{"element": 4}, {"element": 5}, {"element": 6}]}}
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "element": {
+          "list": [
+            {"element": {"list": []}},
+            {
+              "element": {
+                "list": [
+                  {"element": {"list": [{"element": 7}]}}
+                ]
+              }
+            }
           ]
         }
       },

--- a/internal/impl/parquet/schema.go
+++ b/internal/impl/parquet/schema.go
@@ -28,6 +28,18 @@ func GenerateStructType(
 	return generateStructTypeFromFields(fields, schemaOpts)
 }
 
+type tags []struct {
+	name, value string
+}
+
+func (t tags) String() string {
+	res := make([]string, len(t))
+	for i, tg := range t {
+		res[i] = fmt.Sprintf(`%s:%q`, tg.name, tg.value)
+	}
+	return strings.Join(res, " ")
+}
+
 func generateStructTypeFromFields(
 	fields []*service.ParsedConfig,
 	schemaOpts schemaOpts,
@@ -105,13 +117,23 @@ func generateStructTypeFromFields(
 
 		parquetTag := strings.Join(components, ",")
 
+		tt := tags{
+			{"parquet", parquetTag},
+			{"json", name},
+		}
+
+		if isListOfLists(field) {
+			// includes a 'parquet-element' tag, to associate a list of elements
+			// See https://pkg.go.dev/github.com/parquet-go/parquet-go#SchemaOf
+			tt = append(tt, struct{ name, value string }{"parquet-element", ",list"})
+		}
+
 		structField := reflect.StructField{
 			Name: exportedName,
 			Type: fieldType,
-			Tag: reflect.StructTag(fmt.Sprintf(
-				`parquet:"%s" json:"%s"`,
-				parquetTag, name)),
+			Tag:  reflect.StructTag(tt.String()),
 		}
+
 		structFields = append(structFields, structField)
 	}
 
@@ -298,6 +320,21 @@ func wrapType(
 	}
 
 	return baseType, nil
+}
+
+func isListOfLists(field *service.ParsedConfig) bool {
+	typeStr, _ := field.FieldString("type")
+	if typeStr != "LIST" {
+		return false
+	}
+
+	subfields, _ := field.FieldAnyList("fields")
+	if len(subfields) != 1 {
+		return false
+	}
+
+	typeStr, _ = subfields[0].FieldString("type")
+	return typeStr == "LIST"
 }
 
 func isDeltaLengthByteArrayEncodable(typeStr string) bool {


### PR DESCRIPTION
## Motivation

Adds support for nested N-D lists in the parquet processors.

Fixes https://github.com/warpstreamlabs/bento/issues/360

## Changes

- Updates `parquet-go` to fork branch at https://github.com/warpstreamlabs/parquet-go/tree/warpstream/dev, which includes support for N-D lists.
- Ensures nested schema structs are created with the new `parquet-element` tag.
- Unskips `TestParquetDecodeListFormatEdgeCases` and includes higher dimensional tests (3D, and 4D) as support has been added.