### PR TITLE
chore(lint): Remove ref to deprecated http2/h2c

### DIFF
--- a/internal/impl/protobuf/processor_protobuf_test.go
+++ b/internal/impl/protobuf/processor_protobuf_test.go
@@ -14,8 +14,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -439,7 +437,12 @@ func runMockBSRServer(t *testing.T) string {
 	fileDescriptorSetServer := &fileDescriptorSetServer{fileDescriptorSet: fileDescriptorSet}
 	mux.Handle(reflectv1beta1connect.NewFileDescriptorSetServiceHandler(fileDescriptorSetServer))
 	go func() {
-		if err := http.Serve(listener, h2c.NewHandler(mux, &http2.Server{})); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		srv := &http.Server{Handler: mux}
+		srv.Protocols = new(http.Protocols)
+		srv.Protocols.SetHTTP1(true)
+		srv.Protocols.SetUnencryptedHTTP2(true)
+
+		if err := http.Serve(listener, srv.Handler); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			require.NoError(t, err)
 		}
 	}()


### PR DESCRIPTION

## Motivation

Fixes failing `staticcheck` lint due to deprecated http2 server creation.

```
  Error: internal/impl/protobuf/processor_protobuf_test.go:18:2: SA1019: "golang.org/x/net/http2/h2c" is deprecated: This package is deprecated. (staticcheck)
  	"golang.org/x/net/http2/h2c"
  	^
  Error: internal/impl/protobuf/processor_protobuf_test.go:462:34: SA1019: h2c.NewHandler is deprecated: Set the [http.Server] Protocols field to use unencrypted HTTP/2 instead. (staticcheck)
  		if err := http.Serve(listener, h2c.NewHandler(mux, &http2.Server{})); err != nil && !errors.Is(err, http.ErrServerClosed) {
  		                               ^
  2 issues:
  * staticcheck: 2
```

## Changes

- Replaces h2c usage with `http/net` server for diasbling http2 traffic