### PR TITLE
fix(avro): call Scan() before Read() in OCF batch scanner

### DIFF
--- a/internal/impl/avro/scanner.go
+++ b/internal/impl/avro/scanner.go
@@ -101,6 +101,14 @@ func (c *avroScanner) NextBatch(ctx context.Context) (service.MessageBatch, erro
 		return nil, io.EOF
 	}
 
+	// Scan() must be called before each Read() — omitting it causes
+	// every read to fail with "Read called without successful Scan".
+	if !c.ocf.Scan() {
+		if err := c.ocf.Err(); err != nil {
+			return nil, err
+		}
+		return nil, io.EOF
+	}
 	datum, err := c.ocf.Read()
 	if err != nil {
 		return nil, err

--- a/internal/impl/avro/scanner.go
+++ b/internal/impl/avro/scanner.go
@@ -101,7 +101,7 @@ func (c *avroScanner) NextBatch(ctx context.Context) (service.MessageBatch, erro
 		return nil, io.EOF
 	}
 
-	// Scan returns true when there is at least one more data item 
+	// Scan returns true when there is at least one more data item
 	// to be read from the Avro OCF. Omitting it causes every read
 	// to fail with "Read called without successful Scan".
 	// See https://github.com/linkedin/goavro/blob/c69e26ce467683269036725e0832d712f67fa672/ocf_reader.go#L125-L128

--- a/internal/impl/avro/scanner.go
+++ b/internal/impl/avro/scanner.go
@@ -101,8 +101,10 @@ func (c *avroScanner) NextBatch(ctx context.Context) (service.MessageBatch, erro
 		return nil, io.EOF
 	}
 
-	// Scan() must be called before each Read() — omitting it causes
-	// every read to fail with "Read called without successful Scan".
+	// Scan returns true when there is at least one more data item 
+	// to be read from the Avro OCF. Omitting it causes every read
+	// to fail with "Read called without successful Scan".
+	// See https://github.com/linkedin/goavro/blob/c69e26ce467683269036725e0832d712f67fa672/ocf_reader.go#L125-L128
 	if !c.ocf.Scan() {
 		if err := c.ocf.Err(); err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

The goavro `OCFReader` API requires `Scan()` to advance the reader to the next datum before `Read()` can safely be called. The current implementation calls `Read()` directly, causing every Avro OCF file read to fail with:

```
Read called without successful Scan
```

- Add `ocf.Scan()` call before each `ocf.Read()` in `NextBatch()`
- Fix EOF detection: when `Scan()` returns `false` and `Err()` is `nil`, the stream is exhausted — now returns `io.EOF` instead of surfacing a misleading error from `Read()`

## Root cause

From the [goavro docs](https://pkg.go.dev/github.com/linkedin/goavro/v2#OCFReader.Read):

> Read returns the datum read by a previous call to Scan.

The pattern must be:
```go
for ocf.Scan() {
    datum, err := ocf.Read()
    // ...
}
```

## Test plan

- [x] `go build ./internal/impl/avro/...` — compiles cleanly
- [x] `go test ./internal/impl/avro/...` — all existing tests pass

Discovered while using the avro scanner in a Bento S3 pipeline where every file read was failing with the error above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)