### PR TITLE
feat(read_until): add config for restart backoff

### DIFF
--- a/internal/impl/pure/input_read_until.go
+++ b/internal/impl/pure/input_read_until.go
@@ -21,10 +21,11 @@ import (
 )
 
 const (
-	ruiFieldInput       = "input"
-	ruiFieldRestart     = "restart_input"
-	ruiFieldCheck       = "check"
-	ruiFieldIdleTimeout = "idle_timeout"
+	ruiFieldInput          = "input"
+	ruiFieldRestart        = "restart_input"
+	ruiFieldRestartBackoff = "restart_backoff"
+	ruiFieldCheck          = "check"
+	ruiFieldIdleTimeout    = "idle_timeout"
 )
 
 func readUntilInputSpec() *service.ConfigSpec {
@@ -88,6 +89,11 @@ input:
 		service.NewBoolField(ruiFieldRestart).
 			Description("Whether the input should be reopened if it closes itself before the condition has resolved to true.").
 			Default(false),
+		service.NewBackOffField(ruiFieldRestartBackoff, true, &backoff.ExponentialBackOff{
+			InitialInterval: time.Millisecond,
+			MaxInterval:     time.Millisecond * 100,
+			MaxElapsedTime:  0,
+		}).Description("Backoff policy for restarting the child input. Only used when `restart_input` is `true`."),
 	)
 }
 
@@ -106,7 +112,8 @@ func init() {
 }
 
 type readUntilInput struct {
-	restart bool
+	restart        bool
+	restartBackoff *backoff.ExponentialBackOff
 
 	wrappedInputLocked *atomic.Pointer[input.Streamed]
 	check              *mapping.Executor
@@ -142,6 +149,11 @@ func newReadUntilInputFromParsed(conf *service.ParsedConfig, res *service.Resour
 		return nil, err
 	}
 
+	restartBackoff, err := conf.FieldBackOff(ruiFieldRestartBackoff)
+	if err != nil {
+		return nil, err
+	}
+
 	var check *mapping.Executor
 	if checkStr, _ := conf.FieldString(ruiFieldCheck); checkStr != "" {
 		if check, err = mgr.BloblEnvironment().NewMapping(checkStr); err != nil {
@@ -163,7 +175,8 @@ func newReadUntilInputFromParsed(conf *service.ParsedConfig, res *service.Resour
 	wInputLocked := &atomic.Pointer[input.Streamed]{}
 	wInputLocked.Store(&wrapped)
 	rdr := &readUntilInput{
-		restart: restart,
+		restart:        restart,
+		restartBackoff: restartBackoff,
 
 		wrappedCtor:        wrappedCtor,
 		wrappedInputLocked: wInputLocked,
@@ -195,10 +208,8 @@ func (r *readUntilInput) loop() {
 	}()
 
 	// Prevents busy loop when an input never yields messages.
-	restartBackoff := backoff.NewExponentialBackOff()
-	restartBackoff.InitialInterval = time.Millisecond
-	restartBackoff.MaxInterval = time.Millisecond * 100
-	restartBackoff.MaxElapsedTime = 0
+	restartBackoff := *r.restartBackoff
+	restartBackoff.Reset()
 
 	var open bool
 

--- a/internal/impl/pure/input_read_until.go
+++ b/internal/impl/pure/input_read_until.go
@@ -83,17 +83,21 @@ input:
 			).
 			Optional(),
 		service.NewDurationField(ruiFieldIdleTimeout).
-			Description("The maximum amount of time without receiving new messages after which the input is closed.").
+			Description("The maximum amount of time without receiving new messages after which the input is closed or restarted, according to `restart_input`").
 			Example("5s").
 			Optional(),
 		service.NewBoolField(ruiFieldRestart).
 			Description("Whether the input should be reopened if it closes itself before the condition has resolved to true.").
 			Default(false),
-		service.NewBackOffField(ruiFieldRestartBackoff, true, &backoff.ExponentialBackOff{
-			InitialInterval: time.Millisecond,
-			MaxInterval:     time.Millisecond * 100,
-			MaxElapsedTime:  0,
-		}).Description("Backoff policy for restarting the child input. Only used when `restart_input` is `true`."),
+		service.NewObjectField(ruiFieldRestartBackoff,
+			service.NewDurationField("initial_interval").
+				Description("The initial period to wait between child input restarts.").
+				Default("1ms").Example("50ms").Example("1s"),
+			service.NewDurationField("max_interval").
+				Description("The maximum period to wait between child input restarts.").
+				Default("100ms").Example("5s").Example("1m"),
+		).Description("Backoff policy for restarting the child input. Only used when `restart_input` is `true`.").
+			Version("1.19.0"),
 	)
 }
 
@@ -149,8 +153,17 @@ func newReadUntilInputFromParsed(conf *service.ParsedConfig, res *service.Resour
 		return nil, err
 	}
 
-	restartBackoff, err := conf.FieldBackOff(ruiFieldRestartBackoff)
-	if err != nil {
+	restartBackoff := backoff.NewExponentialBackOff()
+
+	// force this backoff to be unbounded; we won't handle Stop
+	restartBackoff.MaxElapsedTime = 0
+
+	backoffNs := conf.Namespace(ruiFieldRestartBackoff)
+	if restartBackoff.InitialInterval, err = backoffNs.FieldDuration("initial_interval"); err != nil {
+		return nil, err
+	}
+
+	if restartBackoff.MaxInterval, err = backoffNs.FieldDuration("max_interval"); err != nil {
 		return nil, err
 	}
 

--- a/internal/impl/pure/input_read_until_test.go
+++ b/internal/impl/pure/input_read_until_test.go
@@ -294,3 +294,47 @@ read_until:
 	_, open = <-strm.TransactionChan()
 	require.False(t, open)
 }
+
+func TestReadUntilRestartBackoffConfig(t *testing.T) {
+	content := []byte("hello")
+
+	tmpfile, err := os.CreateTemp("", "bento_read_until_backoff_test")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tmpfile.Close())
+
+	conf, err := testutil.InputFromYAML(fmt.Sprintf(`
+read_until:
+  check: 'false'
+  restart_input: true
+  restart_backoff:
+    initial_interval: 10ms
+    max_interval: 50ms
+    max_elapsed_time: 0s
+  input:
+    file:
+      paths: [ "%v" ]
+`, tmpfile.Name()))
+	require.NoError(t, err)
+
+	ctx, done := context.WithTimeout(context.Background(), time.Second*5)
+	defer done()
+
+	in, err := bmock.NewManager().NewInput(conf)
+	require.NoError(t, err)
+
+	// Read a few messages across restarts to confirm the backoff config is accepted
+	// and the input continues to function correctly.
+	for range 3 {
+		tran, open := <-in.TransactionChan()
+		require.True(t, open)
+		assert.Equal(t, "hello", string(tran.Payload[0].AsBytes()))
+		require.NoError(t, tran.Ack(ctx, nil))
+	}
+
+	in.TriggerStopConsuming()
+	require.NoError(t, in.WaitForClose(ctx))
+}

--- a/internal/impl/pure/input_read_until_test.go
+++ b/internal/impl/pure/input_read_until_test.go
@@ -313,7 +313,6 @@ read_until:
   restart_backoff:
     initial_interval: 10ms
     max_interval: 50ms
-    max_elapsed_time: 0s
   input:
     file:
       paths: [ "%v" ]

--- a/website/docs/components/inputs/read_until.md
+++ b/website/docs/components/inputs/read_until.md
@@ -26,6 +26,10 @@ input:
     check: this.type == "foo" # No default (optional)
     idle_timeout: 5s # No default (optional)
     restart_input: false
+    restart_backoff:
+      initial_interval: 1ms
+      max_interval: 100ms
+      max_elapsed_time: 0s
 ```
 
 Messages are read continuously while the query check returns false, when the query returns true the message that triggered the check is sent out and the input is closed. Use this to define inputs where the stream should end once a certain message appears.
@@ -37,6 +41,49 @@ Sometimes inputs close themselves. For example, when the `file` input type reach
 ### Metadata
 
 A metadata key `bento_read_until` containing the value `final` is added to the first part of the message that triggers the input to stop.
+
+## Examples
+
+<Tabs defaultValue="Consume N Messages" values={[
+{ label: 'Consume N Messages', value: 'Consume N Messages', },
+{ label: 'Read from a kafka and close when empty', value: 'Read from a kafka and close when empty', },
+]}>
+
+<TabItem value="Consume N Messages">
+
+A common reason to use this input is to consume only N messages from an input and then stop. This can easily be done with the [`count` function](/docs/guides/bloblang/functions/#count):
+
+```yaml
+# Only read 100 messages, and then exit.
+input:
+  read_until:
+    check: count("messages") >= 100
+    input:
+      kafka:
+        addresses: [ TODO ]
+        topics: [ foo, bar ]
+        consumer_group: foogroup
+```
+
+</TabItem>
+<TabItem value="Read from a kafka and close when empty">
+
+A common reason to use this input is a job that consumes all messages and exits once its empty:
+
+```yaml
+# Consumes all messages and exit when the last message was consumed 5s ago.
+input:
+  read_until:
+    idle_timeout: 5s
+    input:
+      kafka:
+        addresses: [ TODO ]
+        topics: [ foo, bar ]
+        consumer_group: foogroup
+```
+
+</TabItem>
+</Tabs>
 
 ## Fields
 
@@ -83,47 +130,59 @@ Whether the input should be reopened if it closes itself before the condition ha
 Type: `bool`  
 Default: `false`  
 
-## Examples
+### `restart_backoff`
 
-<Tabs defaultValue="Consume N Messages" values={[
-{ label: 'Consume N Messages', value: 'Consume N Messages', },
-{ label: 'Read from a kafka and close when empty', value: 'Read from a kafka and close when empty', },
-]}>
+Backoff policy for restarting the child input. Only used when `restart_input` is `true`.
 
-<TabItem value="Consume N Messages">
 
-A common reason to use this input is to consume only N messages from an input and then stop. This can easily be done with the [`count` function](/docs/guides/bloblang/functions/#count):
+Type: `object`  
 
-```yaml
-# Only read 100 messages, and then exit.
-input:
-  read_until:
-    check: count("messages") >= 100
-    input:
-      kafka:
-        addresses: [ TODO ]
-        topics: [ foo, bar ]
-        consumer_group: foogroup
+### `restart_backoff.initial_interval`
+
+The initial period to wait between retry attempts.
+
+
+Type: `string`  
+Default: `"1ms"`  
+
+```yml
+# Examples
+
+initial_interval: 50ms
+
+initial_interval: 1s
 ```
 
-</TabItem>
-<TabItem value="Read from a kafka and close when empty">
+### `restart_backoff.max_interval`
 
-A common reason to use this input is a job that consumes all messages and exits once its empty:
+The maximum period to wait between retry attempts
 
-```yaml
-# Consumes all messages and exit when the last message was consumed 5s ago.
-input:
-  read_until:
-    idle_timeout: 5s
-    input:
-      kafka:
-        addresses: [ TODO ]
-        topics: [ foo, bar ]
-        consumer_group: foogroup
+
+Type: `string`  
+Default: `"100ms"`  
+
+```yml
+# Examples
+
+max_interval: 5s
+
+max_interval: 1m
 ```
 
-</TabItem>
-</Tabs>
+### `restart_backoff.max_elapsed_time`
+
+The maximum overall period of time to spend on retry attempts before the request is aborted. Setting this value to a zeroed duration (such as `0s`) will result in unbounded retries.
+
+
+Type: `string`  
+Default: `"0s"`  
+
+```yml
+# Examples
+
+max_elapsed_time: 1m
+
+max_elapsed_time: 1h
+```
 
 

--- a/website/docs/components/inputs/read_until.md
+++ b/website/docs/components/inputs/read_until.md
@@ -29,7 +29,6 @@ input:
     restart_backoff:
       initial_interval: 1ms
       max_interval: 100ms
-      max_elapsed_time: 0s
 ```
 
 Messages are read continuously while the query check returns false, when the query returns true the message that triggered the check is sent out and the input is closed. Use this to define inputs where the stream should end once a certain message appears.
@@ -111,7 +110,7 @@ check: count("messages") >= 100
 
 ### `idle_timeout`
 
-The maximum amount of time without receiving new messages after which the input is closed.
+The maximum amount of time without receiving new messages after which the input is closed or restarted, according to `restart_input`
 
 
 Type: `string`  
@@ -136,10 +135,11 @@ Backoff policy for restarting the child input. Only used when `restart_input` is
 
 
 Type: `object`  
+Requires version 1.19.0 or newer  
 
 ### `restart_backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between child input restarts.
 
 
 Type: `string`  
@@ -155,7 +155,7 @@ initial_interval: 1s
 
 ### `restart_backoff.max_interval`
 
-The maximum period to wait between retry attempts
+The maximum period to wait between child input restarts.
 
 
 Type: `string`  
@@ -167,22 +167,6 @@ Default: `"100ms"`
 max_interval: 5s
 
 max_interval: 1m
-```
-
-### `restart_backoff.max_elapsed_time`
-
-The maximum overall period of time to spend on retry attempts before the request is aborted. Setting this value to a zeroed duration (such as `0s`) will result in unbounded retries.
-
-
-Type: `string`  
-Default: `"0s"`  
-
-```yml
-# Examples
-
-max_elapsed_time: 1m
-
-max_elapsed_time: 1h
 ```
 
 


### PR DESCRIPTION
Exposes options for `restartBackoff` for the `read_until` input, for when `restart_input` is `true`.

Documentation has been updated with examples.

Use-case: some inputs can be expensive to query, such as `aws_s3` when walking a bucket. In those cases, increasing the interval to `1s` makes more sense than the default `1ms`.

Exposing `max_elapsed_time` also allows exiting a `read_until` loop after a specific time, even if the `check` condition has not passed yet.

Reference feature request from Redpanda upstream: https://github.com/redpanda-data/connect/issues/1911