### PR TITLE
feat(gcp): add custom endpoint configuration to gcp_bigquery output

### DIFF
--- a/internal/impl/gcp/output_bigquery.go
+++ b/internal/impl/gcp/output_bigquery.go
@@ -314,7 +314,7 @@ func (g *gcpBigQueryOutput) Connect(ctx context.Context) (err error) {
 	var client *bigquery.Client
 	var opts []option.ClientOption
 	if g.conf.Endpoint != "" {
-		opts = append(opts, option.WithEndpoint(g.conf.Endpoint))
+		opts = append(opts, option.WithoutAuthentication(), option.WithEndpoint(g.conf.Endpoint))
 	}
 	if client, err = g.clientURL.NewClient(context.Background(), g.conf.ProjectID, opts...); err != nil {
 		err = fmt.Errorf("error creating big query client: %w", err)

--- a/internal/impl/gcp/output_bigquery.go
+++ b/internal/impl/gcp/output_bigquery.go
@@ -51,6 +51,7 @@ type gcpBigQueryOutputConfig struct {
 	ProjectID           string
 	DatasetID           string
 	TableID             *service.InterpolatedString
+	Endpoint            string
 	Format              string
 	WriteDisposition    string
 	CreateDisposition   string
@@ -75,6 +76,9 @@ func gcpBigQueryOutputConfigFromParsed(conf *service.ParsedConfig) (gconf gcpBig
 		return
 	}
 	if gconf.TableID, err = conf.FieldInterpolatedString("table"); err != nil {
+		return
+	}
+	if gconf.Endpoint, err = conf.FieldString("endpoint"); err != nil {
 		return
 	}
 	if gconf.Format, err = conf.FieldString("format"); err != nil {
@@ -106,11 +110,11 @@ func gcpBigQueryOutputConfigFromParsed(conf *service.ParsedConfig) (gconf gcpBig
 
 type gcpBQClientURL string
 
-func (g gcpBQClientURL) NewClient(ctx context.Context, projectID string) (*bigquery.Client, error) {
-	if g == "" {
-		return bigquery.NewClient(ctx, projectID)
+func (g gcpBQClientURL) NewClient(ctx context.Context, projectID string, opts ...option.ClientOption) (*bigquery.Client, error) {
+	if g != "" {
+		opts = append(opts, option.WithoutAuthentication(), option.WithEndpoint(string(g)))
 	}
-	return bigquery.NewClient(ctx, projectID, option.WithoutAuthentication(), option.WithEndpoint(string(g)))
+	return bigquery.NewClient(ctx, projectID, opts...)
 }
 
 func gcpBigQueryConfig() *service.ConfigSpec {
@@ -159,6 +163,10 @@ For the CSV format when the field ` + "`csv.header`" + ` is specified a header r
 It is assumed that the first message in the batch will resolve the bloblang query and that string will be used for all messages in the batch.
 :::
 The table to insert messages to.`)).
+		Field(service.NewStringField("endpoint").
+			Description("An optional endpoint to override the default BigQuery API URL.").
+			Advanced().
+			Default("")).
 		Field(service.NewStringEnumField("format", string(bigquery.JSON), string(bigquery.CSV)).
 			Description("The format of each incoming message.").
 			Default(string(bigquery.JSON))).
@@ -304,7 +312,11 @@ func (g *gcpBigQueryOutput) Connect(ctx context.Context) (err error) {
 	defer g.connMut.Unlock()
 
 	var client *bigquery.Client
-	if client, err = g.clientURL.NewClient(context.Background(), g.conf.ProjectID); err != nil {
+	var opts []option.ClientOption
+	if g.conf.Endpoint != "" {
+		opts = append(opts, option.WithEndpoint(g.conf.Endpoint))
+	}
+	if client, err = g.clientURL.NewClient(context.Background(), g.conf.ProjectID, opts...); err != nil {
 		err = fmt.Errorf("error creating big query client: %w", err)
 		return
 	}

--- a/internal/impl/gcp/output_bigquery_test.go
+++ b/internal/impl/gcp/output_bigquery_test.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -417,6 +418,25 @@ table: table_meow
 	require.NoError(t, err)
 
 	output.clientURL = gcpBQClientURL(server.URL)
+
+	err = output.Connect(context.Background())
+	defer output.Close(context.Background())
+
+	require.NoError(t, err)
+}
+
+func TestGCPBigQueryOutputConnectOkEndpointConfig(t *testing.T) {
+	emulator := setupBigQueryEmulator(t, "project_meow", "dataset_meow", "table_meow", nil)
+
+	config := gcpBigQueryConfFromYAML(t, fmt.Sprintf(`
+project: project_meow
+dataset: dataset_meow
+table: table_meow
+endpoint: %s
+`, emulator.httpEndpoint))
+
+	output, err := newGCPBigQueryOutput(config, nil)
+	require.NoError(t, err)
 
 	err = output.Connect(context.Background())
 	defer output.Close(context.Background())

--- a/website/docs/components/outputs/gcp_bigquery.md
+++ b/website/docs/components/outputs/gcp_bigquery.md
@@ -58,6 +58,7 @@ output:
     project: ""
     dataset: "" # No default (required)
     table: "" # No default (required)
+    endpoint: ""
     format: NEWLINE_DELIMITED_JSON
     max_in_flight: 64
     write_disposition: WRITE_APPEND
@@ -153,6 +154,14 @@ This field supports [interpolation functions](/docs/configuration/interpolation#
 
 
 Type: `string`  
+
+### `endpoint`
+
+An optional endpoint to override the default BigQuery API URL.
+
+
+Type: `string`  
+Default: `""`  
 
 ### `format`
 


### PR DESCRIPTION
## Description
This PR introduces the `endpoint` configuration option to the `gcp_bigquery` output component. 

## Motivation and Context
Previously, the component hardcoded the default BigQuery API endpoint for production usage. Adding a configurable `endpoint` enables developers to route traffic to local BigQuery emulators during testing and development. It also unlocks support for routing through proxies or custom VPC Service Controls endpoints, aligning this component with other GCP components (like Pub/Sub and BigQuery Storage) that already support custom endpoints.