### PR TITLE
feat(nats): sync response for nats input

### DIFF
--- a/internal/impl/nats/input.go
+++ b/internal/impl/nats/input.go
@@ -33,6 +33,8 @@ You can access these metadata fields using [function interpolation](/docs/config
 
 When a message arrives with a reply subject (i.e. it was sent via ` + "`nats.Request`" + `), you can reply to it by including a ` + "`sync_response`" + ` output in your pipeline. The input will forward the response payload (and its metadata as NATS headers, if supported) back to the caller automatically once the pipeline acknowledges the message.
 
+For more details, see the [Synchronous Responses guide](/docs/guides/sync_responses) and the [NATS Request-Reply example](https://natsbyexample.com/examples/messaging/request-reply/go/).
+
 ` + "```yaml" + `
 input:
   nats:

--- a/internal/impl/nats/input.go
+++ b/internal/impl/nats/input.go
@@ -29,6 +29,22 @@ This input adds the following metadata fields to each message:
 
 You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#bloblang-queries).
 
+### Request-Reply
+
+When a message arrives with a reply subject (i.e. it was sent via ` + "`nats.Request`" + `), you can reply to it by including a ` + "`sync_response`" + ` output in your pipeline. The input will forward the response payload (and its metadata as NATS headers, if supported) back to the caller automatically once the pipeline acknowledges the message.
+
+` + "```yaml" + `
+input:
+  nats:
+    urls: [ nats://localhost:4222 ]
+    subject: rpc.>
+
+output:
+  sync_response: {}
+  processors:
+    - mapping: 'root = content().uppercase()'
+` + "```" + `
+
 ` + connectionNameDescription() + authDescription()).
 		Fields(connectionHeadFields()...).
 		Field(service.NewStringField("subject").
@@ -207,6 +223,11 @@ func (n *natsReader) Read(ctx context.Context) (*service.Message, service.AckFun
 		}
 	}
 
+	// Attach a sync response store so that a sync_response output in the
+	// pipeline can provide the NATS reply payload without needing a separate
+	// nats_respond output.
+	bmsg, store := bmsg.WithSyncResponseStore()
+
 	return bmsg, func(_ context.Context, res error) error {
 		var ackErr error
 		if res != nil {
@@ -214,6 +235,18 @@ func (n *natsReader) Read(ctx context.Context) (*service.Message, service.AckFun
 				ackErr = msg.NakWithDelay(n.nakDelay)
 			} else {
 				ackErr = msg.Nak()
+			}
+		} else if msg.Reply != "" {
+			// Request-reply: if sync_response populated the store, use it as
+			// the NATS reply; otherwise fall through to the normal Ack path.
+			if responses := store.Read(); len(responses) > 0 && len(responses[0]) > 0 {
+				replyMsg, err := natsReplyFromServiceMsg(responses[0][0], natsConn.HeadersSupported())
+				if err != nil {
+					return err
+				}
+				ackErr = msg.RespondMsg(replyMsg)
+			} else {
+				ackErr = msg.Ack()
 			}
 		} else {
 			ackErr = msg.Ack()
@@ -233,4 +266,20 @@ func (n *natsReader) Close(ctx context.Context) (err error) {
 		close(n.interruptChan)
 	})
 	return
+}
+
+func natsReplyFromServiceMsg(m *service.Message, headersSupported bool) (*nats.Msg, error) {
+	data, err := m.AsBytes()
+	if err != nil {
+		return nil, err
+	}
+	reply := nats.NewMsg("")
+	reply.Data = data
+	if headersSupported {
+		_ = m.MetaWalk(func(key, value string) error {
+			reply.Header.Add(key, value)
+			return nil
+		})
+	}
+	return reply, nil
 }

--- a/internal/impl/nats/integration_nats_test.go
+++ b/internal/impl/nats/integration_nats_test.go
@@ -1,6 +1,8 @@
 package nats
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -10,12 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"
+
+	_ "github.com/warpstreamlabs/bento/public/components/io"
+	_ "github.com/warpstreamlabs/bento/public/components/pure"
 )
 
-func TestIntegrationNats(t *testing.T) {
-	integration.CheckSkip(t)
-	t.Parallel()
+func startNatsContainer(t *testing.T) *dockertest.Resource {
+	t.Helper()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -36,6 +41,15 @@ func TestIntegrationNats(t *testing.T) {
 		natsConn.Close()
 		return nil
 	}))
+
+	return resource
+}
+
+func TestIntegrationNats(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Parallel()
+
+	resource := startNatsContainer(t)
 
 	template := `
 output:
@@ -74,4 +88,68 @@ input:
 			integration.StreamTestOptMaxInFlight(10),
 		)
 	})
+}
+
+func TestIntegrationNatsSyncResponses(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Parallel()
+
+	resource := startNatsContainer(t)
+
+	sb := service.NewStreamBuilder()
+
+	err := sb.SetYAML(fmt.Sprintf(`
+input:
+  nats:
+    urls: [ nats://localhost:%v ]
+    subject: foo.*
+
+output:
+  sync_response: {}
+  processors:
+    - mapping: 'root = content().uppercase()'
+`, resource.GetPort("4222/tcp")))
+	require.NoError(t, err)
+
+	stream, err := sb.Build()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	go func() {
+		if err := stream.Run(ctx); err != nil &&
+			!errors.Is(err, context.DeadlineExceeded) &&
+			!errors.Is(err, context.Canceled) {
+			t.Errorf("stream exited: %v", err)
+		}
+	}()
+
+	// send some messages into NATS with nats.Request
+	nc, err := nats.Connect(fmt.Sprintf("nats://localhost:%v", resource.GetPort("4222/tcp")))
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, nc.Drain())
+	}()
+
+	require.Eventually(t, func() bool {
+		_, err := nc.Request("foo._ready", []byte("ping"), 100*time.Millisecond)
+		return err == nil
+	}, 5*time.Second, 100*time.Millisecond, "stream failed to become ready")
+
+	rep, err := nc.Request("foo.joe", []byte("joe"), time.Second)
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte("JOE"), rep.Data)
+
+	rep, err = nc.Request("foo.sue", []byte("sue"), time.Second)
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte("SUE"), rep.Data)
+
+	rep, err = nc.Request("foo.bob", []byte("bob"), time.Second)
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte("BOB"), rep.Data)
 }

--- a/website/docs/components/inputs/nats.md
+++ b/website/docs/components/inputs/nats.md
@@ -85,6 +85,8 @@ You can access these metadata fields using [function interpolation](/docs/config
 
 When a message arrives with a reply subject (i.e. it was sent via `nats.Request`), you can reply to it by including a `sync_response` output in your pipeline. The input will forward the response payload (and its metadata as NATS headers, if supported) back to the caller automatically once the pipeline acknowledges the message.
 
+For more details, see the [Synchronous Responses guide](/docs/guides/sync_responses) and the [NATS Request-Reply example](https://natsbyexample.com/examples/messaging/request-reply/go/).
+
 ```yaml
 input:
   nats:

--- a/website/docs/components/inputs/nats.md
+++ b/website/docs/components/inputs/nats.md
@@ -81,6 +81,22 @@ This input adds the following metadata fields to each message:
 
 You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#bloblang-queries).
 
+### Request-Reply
+
+When a message arrives with a reply subject (i.e. it was sent via `nats.Request`), you can reply to it by including a `sync_response` output in your pipeline. The input will forward the response payload (and its metadata as NATS headers, if supported) back to the caller automatically once the pipeline acknowledges the message.
+
+```yaml
+input:
+  nats:
+    urls: [ nats://localhost:4222 ]
+    subject: rpc.>
+
+output:
+  sync_response: {}
+  processors:
+    - mapping: 'root = content().uppercase()'
+```
+
 ### Connection Name
 
 When monitoring and managing a production NATS system, it is often useful to


### PR DESCRIPTION
When a message arrives with a reply subject (sent via nats.Request), the input now forwards the response payload back to the caller automatically when a sync_response output is configured in the pipeline.