### PR TITLE
feat(redis_scan): hash value + raw support

### DIFF
--- a/internal/impl/redis/input_scan.go
+++ b/internal/impl/redis/input_scan.go
@@ -24,7 +24,18 @@ func init() {
 	}
 }
 
-const matchFieldName = "match"
+const (
+	matchFieldName         = "match"
+	dataTypeFieldName      = "data_type"
+	scanCountFieldName     = "scan_count"
+	hashScanCountFieldName = "hash_scan_count"
+
+	redisScanDataTypeString = "string"
+	redisScanDataTypeHash   = "hash"
+
+	redisScanMetaKey       = "redis_key"
+	redisScanMetaHashField = "redis_hash_field"
+)
 
 func redisScanInputConfig() *service.ConfigSpec {
 	spec := service.NewConfigSpec().
@@ -39,6 +50,10 @@ This input generates a message for each key value pair in the following format:
 ` + "```json" + `
 {"key":"foo","value":"bar"}
 ` + "```" + `
+
+When ` + "`data_type`" + ` is set to ` + "`hash`" + ` this input treats matched keys as Redis hashes. It uses HSCAN to discover fields,
+fetches each field value with HGET, and generates a raw message payload for each hash field value. The Redis key is set in metadata
+` + "`redis_key`" + ` and the hash field is set in metadata ` + "`redis_hash_field`" + `.
 `).
 		Categories("Services")
 	for _, f := range clientFields() {
@@ -54,7 +69,18 @@ This input generates a message for each key value pair in the following format:
 			Example("foo*").
 			Example("foo").
 			Example("*4*").
-			Default(""))
+			Default("")).
+		Field(service.NewStringEnumField(dataTypeFieldName, redisScanDataTypeString, redisScanDataTypeHash).
+			Description("The Redis data type to read for each matched key. When set to `hash`, matched keys are scanned with HSCAN and each hash field value is emitted as an individual message payload.").
+			Default(redisScanDataTypeString)).
+		Field(service.NewIntField(scanCountFieldName).
+			Description("An optional Redis SCAN count hint for key scanning. A value of 0 preserves the Redis default scan behaviour.").
+			Default(0).
+			Advanced()).
+		Field(service.NewIntField(hashScanCountFieldName).
+			Description("An optional Redis HSCAN count hint for hash field scanning. A value of 0 preserves the Redis default scan behaviour.").
+			Default(0).
+			Advanced())
 }
 
 func newRedisScanInputFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
@@ -66,19 +92,42 @@ func newRedisScanInputFromConfig(conf *service.ParsedConfig, mgr *service.Resour
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving %s: %v", matchFieldName, err)
 	}
+	dataType, err := conf.FieldString(dataTypeFieldName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving %s: %v", dataTypeFieldName, err)
+	}
+	scanCount, err := conf.FieldInt(scanCountFieldName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving %s: %v", scanCountFieldName, err)
+	}
+	hashScanCount, err := conf.FieldInt(hashScanCountFieldName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving %s: %v", hashScanCountFieldName, err)
+	}
 	r := &redisScanReader{
-		client: client,
-		match:  match,
-		log:    mgr.Logger(),
+		client:        client,
+		match:         match,
+		dataType:      dataType,
+		scanCount:     int64(scanCount),
+		hashScanCount: int64(hashScanCount),
+		log:           mgr.Logger(),
 	}
 	return r, nil
 }
 
 type redisScanReader struct {
-	match  string
+	match         string
+	dataType      string
+	scanCount     int64
+	hashScanCount int64
+
 	client redis.UniversalClient
-	iter   *redis.ScanIterator
-	log    *service.Logger
+
+	iter           *redis.ScanIterator
+	hashIter       *redis.ScanIterator
+	currentHashKey string
+
+	log *service.Logger
 }
 
 func (r *redisScanReader) Connect(ctx context.Context) error {
@@ -86,11 +135,24 @@ func (r *redisScanReader) Connect(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	r.iter = r.client.Scan(context.Background(), 0, r.match, 0).Iterator()
+	r.iter = r.client.Scan(context.Background(), 0, r.match, r.scanCount).Iterator()
 	return r.iter.Err()
 }
 
 func (r *redisScanReader) Read(ctx context.Context) (*service.Message, service.AckFunc, error) {
+	if r.dataType == redisScanDataTypeHash {
+		return r.readHash(ctx)
+	}
+	return r.readString(ctx)
+}
+
+// readString preserves the original redis_scan output shape for backwards
+// compatibility. This means values are stored inside a structured message as
+// the "value" field rather than becoming the message payload. That shape works
+// well for text Redis string values, but can be awkward for arbitrary binary
+// values such as protobuf bytes because downstream binary decoders usually
+// expect the message payload itself to contain the encoded bytes.
+func (r *redisScanReader) readString(ctx context.Context) (*service.Message, service.AckFunc, error) {
 	if r.iter.Next(ctx) {
 		key := r.iter.Val()
 
@@ -109,6 +171,59 @@ func (r *redisScanReader) Read(ctx context.Context) (*service.Message, service.A
 		}, nil
 	}
 	return nil, nil, service.ErrEndOfInput
+}
+
+// readHash emits each hash field value as the raw message payload in order to
+// preserve binary values exactly. This differs from the legacy string mode
+// above, which wraps values in a structured {"key":"...","value":"..."} object.
+// A future compatibility-safe improvement could expose an explicit output-shape
+// option so both Redis string and hash scans can choose between structured
+// envelopes and raw value payloads.
+func (r *redisScanReader) readHash(ctx context.Context) (*service.Message, service.AckFunc, error) {
+	for {
+		if r.hashIter != nil {
+			if r.hashIter.Next(ctx) {
+				field := r.hashIter.Val()
+				if !r.hashIter.Next(ctx) {
+					if err := r.hashIter.Err(); err != nil {
+						return nil, nil, err
+					}
+					return nil, nil, fmt.Errorf("redis HSCAN returned field without value for key %q", r.currentHashKey)
+				}
+
+				res := r.client.HGet(ctx, r.currentHashKey, field)
+				valueBytes, err := res.Bytes()
+				if err != nil {
+					return nil, nil, err
+				}
+
+				msg := service.NewMessage(valueBytes)
+				msg.MetaSetMut(redisScanMetaKey, r.currentHashKey)
+				msg.MetaSetMut(redisScanMetaHashField, field)
+				return msg, func(ctx context.Context, err error) error {
+					return err
+				}, nil
+			}
+			if err := r.hashIter.Err(); err != nil {
+				return nil, nil, err
+			}
+			r.hashIter = nil
+			r.currentHashKey = ""
+		}
+
+		if !r.iter.Next(ctx) {
+			if err := r.iter.Err(); err != nil {
+				return nil, nil, err
+			}
+			return nil, nil, service.ErrEndOfInput
+		}
+
+		r.currentHashKey = r.iter.Val()
+		r.hashIter = r.client.HScan(ctx, r.currentHashKey, 0, "", r.hashScanCount).Iterator()
+		if err := r.hashIter.Err(); err != nil {
+			return nil, nil, err
+		}
+	}
 }
 
 func (r *redisScanReader) Close(ctx context.Context) (err error) {

--- a/internal/impl/redis/input_scan.go
+++ b/internal/impl/redis/input_scan.go
@@ -55,8 +55,8 @@ This input generates a message for each key value pair in the following format:
 {"key":"foo","value":"bar"}
 ` + "```" + `
 
-When ` + "`data_type`" + ` is set to ` + "`hash`" + ` this input treats matched keys as Redis hashes. It uses HSCAN to discover fields,
-and fetches each field value with HGET.
+When ` + "`data_type`" + ` is set to ` + "`hash`" + ` this input treats matched keys as Redis hashes. It uses HSCAN to
+iterate over each field and its value.
 
 By default, ` + "`value_format`" + ` is ` + "`structured`" + ` in order to preserve the original ` + "`redis_scan`" + ` message shape
 of ` + "`{\"key\":\"...\",\"value\":\"...\"}`" + `. Set it to ` + "`raw`" + ` to emit Redis values as raw message payloads.
@@ -170,25 +170,26 @@ func (r *redisScanReader) Read(ctx context.Context) (*service.Message, service.A
 // decoders usually expect the message payload itself to contain the encoded
 // bytes.
 func (r *redisScanReader) readString(ctx context.Context) (*service.Message, service.AckFunc, error) {
-	if r.iter.Next(ctx) {
-		key := r.iter.Val()
-
-		res := r.client.Get(ctx, key)
-		if err := res.Err(); err != nil {
+	if !r.iter.Next(ctx) {
+		if err := r.iter.Err(); err != nil {
 			return nil, nil, err
 		}
-
-		return r.newStringMessage(key, res)
+		return nil, nil, service.ErrEndOfInput
 	}
-	return nil, nil, service.ErrEndOfInput
+	key := r.iter.Val()
+	res := r.client.Get(ctx, key)
+	if err := res.Err(); err != nil {
+		return nil, nil, err
+	}
+	return r.newStringMessage(key, res.Val())
 }
 
-func (r *redisScanReader) newStringMessage(key string, res *redis.StringCmd) (*service.Message, service.AckFunc, error) {
+func (r *redisScanReader) newStringMessage(key, value string) (*service.Message, service.AckFunc, error) {
 	return r.newValueMessage(
-		res,
+		value,
 		map[string]any{
 			"key":   key,
-			"value": res.Val(),
+			"value": value,
 		},
 		map[string]string{
 			redisScanMetaKey: key,
@@ -212,12 +213,12 @@ func (r *redisScanReader) readHash(ctx context.Context) (*service.Message, servi
 					return nil, nil, fmt.Errorf("redis HSCAN returned field without value for key %q", r.currentHashKey)
 				}
 
-				res := r.client.HGet(ctx, r.currentHashKey, field)
-				if err := res.Err(); err != nil {
-					return nil, nil, err
-				}
-
-				return r.newHashMessage(r.currentHashKey, field, res)
+				// HSCAN returns field/value pairs, so the value is the next
+				// iterator element. It's read via the same proto reader as
+				// HGET, so it's byte-exact for binary values (e.g. protobuf) —
+				// no need for a separate HGET round-trip per field.
+				value := r.hashIter.Val()
+				return r.newHashMessage(r.currentHashKey, field, value)
 			}
 			if err := r.hashIter.Err(); err != nil {
 				return nil, nil, err
@@ -241,13 +242,13 @@ func (r *redisScanReader) readHash(ctx context.Context) (*service.Message, servi
 	}
 }
 
-func (r *redisScanReader) newHashMessage(key, field string, res *redis.StringCmd) (*service.Message, service.AckFunc, error) {
+func (r *redisScanReader) newHashMessage(key, field, value string) (*service.Message, service.AckFunc, error) {
 	return r.newValueMessage(
-		res,
+		value,
 		map[string]any{
 			"key":   key,
 			"field": field,
-			"value": res.Val(),
+			"value": value,
 		},
 		map[string]string{
 			redisScanMetaKey:       key,
@@ -256,14 +257,10 @@ func (r *redisScanReader) newHashMessage(key, field string, res *redis.StringCmd
 	)
 }
 
-func (r *redisScanReader) newValueMessage(res *redis.StringCmd, structured map[string]any, metadata map[string]string) (*service.Message, service.AckFunc, error) {
+func (r *redisScanReader) newValueMessage(value string, structured map[string]any, metadata map[string]string) (*service.Message, service.AckFunc, error) {
 	var msg *service.Message
 	if r.valueFormat == redisScanValueFormatRaw {
-		valueBytes, err := res.Bytes()
-		if err != nil {
-			return nil, nil, err
-		}
-		msg = service.NewMessage(valueBytes)
+		msg = service.NewMessage([]byte(value))
 		for k, v := range metadata {
 			msg.MetaSetMut(k, v)
 		}

--- a/internal/impl/redis/input_scan.go
+++ b/internal/impl/redis/input_scan.go
@@ -184,24 +184,16 @@ func (r *redisScanReader) readString(ctx context.Context) (*service.Message, ser
 }
 
 func (r *redisScanReader) newStringMessage(key string, res *redis.StringCmd) (*service.Message, service.AckFunc, error) {
-	var msg *service.Message
-	if r.valueFormat == redisScanValueFormatRaw {
-		valueBytes, err := res.Bytes()
-		if err != nil {
-			return nil, nil, err
-		}
-		msg = service.NewMessage(valueBytes)
-		msg.MetaSetMut(redisScanMetaKey, key)
-	} else {
-		msg = service.NewMessage(nil)
-		msg.SetStructuredMut(map[string]any{
+	return r.newValueMessage(
+		res,
+		map[string]any{
 			"key":   key,
 			"value": res.Val(),
-		})
-	}
-	return msg, func(ctx context.Context, err error) error {
-		return err
-	}, nil
+		},
+		map[string]string{
+			redisScanMetaKey: key,
+		},
+	)
 }
 
 // readHash can emit each hash field as either a structured object or as a raw
@@ -250,6 +242,21 @@ func (r *redisScanReader) readHash(ctx context.Context) (*service.Message, servi
 }
 
 func (r *redisScanReader) newHashMessage(key, field string, res *redis.StringCmd) (*service.Message, service.AckFunc, error) {
+	return r.newValueMessage(
+		res,
+		map[string]any{
+			"key":   key,
+			"field": field,
+			"value": res.Val(),
+		},
+		map[string]string{
+			redisScanMetaKey:       key,
+			redisScanMetaHashField: field,
+		},
+	)
+}
+
+func (r *redisScanReader) newValueMessage(res *redis.StringCmd, structured map[string]any, metadata map[string]string) (*service.Message, service.AckFunc, error) {
 	var msg *service.Message
 	if r.valueFormat == redisScanValueFormatRaw {
 		valueBytes, err := res.Bytes()
@@ -257,15 +264,12 @@ func (r *redisScanReader) newHashMessage(key, field string, res *redis.StringCmd
 			return nil, nil, err
 		}
 		msg = service.NewMessage(valueBytes)
-		msg.MetaSetMut(redisScanMetaKey, key)
-		msg.MetaSetMut(redisScanMetaHashField, field)
+		for k, v := range metadata {
+			msg.MetaSetMut(k, v)
+		}
 	} else {
 		msg = service.NewMessage(nil)
-		msg.SetStructuredMut(map[string]any{
-			"key":   key,
-			"field": field,
-			"value": res.Val(),
-		})
+		msg.SetStructuredMut(structured)
 	}
 	return msg, func(ctx context.Context, err error) error {
 		return err

--- a/internal/impl/redis/input_scan.go
+++ b/internal/impl/redis/input_scan.go
@@ -44,19 +44,20 @@ const (
 func redisScanInputConfig() *service.ConfigSpec {
 	spec := service.NewConfigSpec().
 		Stable().
-		Summary(`Scans the set of keys in the current selected database and gets their values, using the Scan and Get commands.`).
+		Summary(`Scans the set of keys in the current selected database and emits Redis string or hash values.`).
 		Description(`Optionally, iterates only elements matching a blob-style pattern. For example:
 - ` + "`*foo*`" + ` iterates only keys which contain ` + "`foo`" + ` in it.
 - ` + "`foo*`" + ` iterates only keys starting with ` + "`foo`" + `.
 
-This input generates a message for each key value pair in the following format:
+By default this input treats matched keys as Redis string data type keys, reads them with GET, and generates a message
+for each key value pair in the following format:
 
 ` + "```json" + `
 {"key":"foo","value":"bar"}
 ` + "```" + `
 
-When ` + "`data_type`" + ` is set to ` + "`hash`" + ` this input treats matched keys as Redis hashes. It uses HSCAN to
-iterate over each field and its value.
+When ` + "`data_type`" + ` is set to ` + "`hash`" + ` this input treats matched keys as Redis hash data type keys. It uses HSCAN
+to iterate over each field and its value.
 
 By default, ` + "`value_format`" + ` is ` + "`structured`" + ` in order to preserve the original ` + "`redis_scan`" + ` message shape
 of ` + "`{\"key\":\"...\",\"value\":\"...\"}`" + `. Set it to ` + "`raw`" + ` to emit Redis values as raw message payloads.
@@ -79,7 +80,7 @@ Raw messages set Redis identity fields as metadata, using ` + "`redis_key`" + ` 
 			Example("*4*").
 			Default("")).
 		Field(service.NewStringEnumField(dataTypeFieldName, redisScanDataTypeString, redisScanDataTypeHash).
-			Description("The Redis data type to read for each matched key. When set to `hash`, matched keys are scanned with HSCAN and each hash field value is emitted as an individual message.").
+			Description("The Redis data type to read for each matched key. `string` reads matched keys with GET. `hash` scans matched keys with HSCAN and emits each hash field value as an individual message.").
 			Default(redisScanDataTypeString)).
 		Field(service.NewStringEnumField(valueFormatFieldName, redisScanValueFormatStructured, redisScanValueFormatRaw).
 			Description("The Bento message shape to emit for Redis values. The `structured` format preserves the original redis_scan key/value object shape, while `raw` emits Redis values as message payloads and stores Redis identity in metadata.").

--- a/internal/impl/redis/input_scan.go
+++ b/internal/impl/redis/input_scan.go
@@ -27,11 +27,15 @@ func init() {
 const (
 	matchFieldName         = "match"
 	dataTypeFieldName      = "data_type"
+	valueFormatFieldName   = "value_format"
 	scanCountFieldName     = "scan_count"
 	hashScanCountFieldName = "hash_scan_count"
 
 	redisScanDataTypeString = "string"
 	redisScanDataTypeHash   = "hash"
+
+	redisScanValueFormatStructured = "structured"
+	redisScanValueFormatRaw        = "raw"
 
 	redisScanMetaKey       = "redis_key"
 	redisScanMetaHashField = "redis_hash_field"
@@ -52,8 +56,12 @@ This input generates a message for each key value pair in the following format:
 ` + "```" + `
 
 When ` + "`data_type`" + ` is set to ` + "`hash`" + ` this input treats matched keys as Redis hashes. It uses HSCAN to discover fields,
-fetches each field value with HGET, and generates a raw message payload for each hash field value. The Redis key is set in metadata
-` + "`redis_key`" + ` and the hash field is set in metadata ` + "`redis_hash_field`" + `.
+and fetches each field value with HGET.
+
+By default, ` + "`value_format`" + ` is ` + "`structured`" + ` in order to preserve the original ` + "`redis_scan`" + ` message shape
+of ` + "`{\"key\":\"...\",\"value\":\"...\"}`" + `. Set it to ` + "`raw`" + ` to emit Redis values as raw message payloads.
+Raw messages set Redis identity fields as metadata, using ` + "`redis_key`" + ` for Redis keys and
+` + "`redis_hash_field`" + ` for hash fields.
 `).
 		Categories("Services")
 	for _, f := range clientFields() {
@@ -71,8 +79,11 @@ fetches each field value with HGET, and generates a raw message payload for each
 			Example("*4*").
 			Default("")).
 		Field(service.NewStringEnumField(dataTypeFieldName, redisScanDataTypeString, redisScanDataTypeHash).
-			Description("The Redis data type to read for each matched key. When set to `hash`, matched keys are scanned with HSCAN and each hash field value is emitted as an individual message payload.").
+			Description("The Redis data type to read for each matched key. When set to `hash`, matched keys are scanned with HSCAN and each hash field value is emitted as an individual message.").
 			Default(redisScanDataTypeString)).
+		Field(service.NewStringEnumField(valueFormatFieldName, redisScanValueFormatStructured, redisScanValueFormatRaw).
+			Description("The Bento message shape to emit for Redis values. The `structured` format preserves the original redis_scan key/value object shape, while `raw` emits Redis values as message payloads and stores Redis identity in metadata.").
+			Default(redisScanValueFormatStructured)).
 		Field(service.NewIntField(scanCountFieldName).
 			Description("An optional Redis SCAN count hint for key scanning. A value of 0 preserves the Redis default scan behaviour.").
 			Default(0).
@@ -96,6 +107,10 @@ func newRedisScanInputFromConfig(conf *service.ParsedConfig, mgr *service.Resour
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving %s: %v", dataTypeFieldName, err)
 	}
+	valueFormat, err := conf.FieldString(valueFormatFieldName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving %s: %v", valueFormatFieldName, err)
+	}
 	scanCount, err := conf.FieldInt(scanCountFieldName)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving %s: %v", scanCountFieldName, err)
@@ -108,6 +123,7 @@ func newRedisScanInputFromConfig(conf *service.ParsedConfig, mgr *service.Resour
 		client:        client,
 		match:         match,
 		dataType:      dataType,
+		valueFormat:   valueFormat,
 		scanCount:     int64(scanCount),
 		hashScanCount: int64(hashScanCount),
 		log:           mgr.Logger(),
@@ -118,6 +134,7 @@ func newRedisScanInputFromConfig(conf *service.ParsedConfig, mgr *service.Resour
 type redisScanReader struct {
 	match         string
 	dataType      string
+	valueFormat   string
 	scanCount     int64
 	hashScanCount int64
 
@@ -146,12 +163,12 @@ func (r *redisScanReader) Read(ctx context.Context) (*service.Message, service.A
 	return r.readString(ctx)
 }
 
-// readString preserves the original redis_scan output shape for backwards
-// compatibility. This means values are stored inside a structured message as
-// the "value" field rather than becoming the message payload. That shape works
-// well for text Redis string values, but can be awkward for arbitrary binary
-// values such as protobuf bytes because downstream binary decoders usually
-// expect the message payload itself to contain the encoded bytes.
+// readString preserves the original redis_scan output shape by default for
+// backwards compatibility: a structured object of {"key":"...","value":"..."}.
+// That shape works well for text Redis string values, but can be awkward for
+// arbitrary binary values such as protobuf bytes because downstream binary
+// decoders usually expect the message payload itself to contain the encoded
+// bytes.
 func (r *redisScanReader) readString(ctx context.Context) (*service.Message, service.AckFunc, error) {
 	if r.iter.Next(ctx) {
 		key := r.iter.Val()
@@ -161,24 +178,36 @@ func (r *redisScanReader) readString(ctx context.Context) (*service.Message, ser
 			return nil, nil, err
 		}
 
-		msg := service.NewMessage(nil)
-		msg.SetStructuredMut(map[string]any{
-			"key":   key,
-			"value": res.Val(),
-		})
-		return msg, func(ctx context.Context, err error) error {
-			return err
-		}, nil
+		return r.newStringMessage(key, res)
 	}
 	return nil, nil, service.ErrEndOfInput
 }
 
-// readHash emits each hash field value as the raw message payload in order to
-// preserve binary values exactly. This differs from the legacy string mode
-// above, which wraps values in a structured {"key":"...","value":"..."} object.
-// A future compatibility-safe improvement could expose an explicit output-shape
-// option so both Redis string and hash scans can choose between structured
-// envelopes and raw value payloads.
+func (r *redisScanReader) newStringMessage(key string, res *redis.StringCmd) (*service.Message, service.AckFunc, error) {
+	var msg *service.Message
+	if r.valueFormat == redisScanValueFormatRaw {
+		valueBytes, err := res.Bytes()
+		if err != nil {
+			return nil, nil, err
+		}
+		msg = service.NewMessage(valueBytes)
+		msg.MetaSetMut(redisScanMetaKey, key)
+	} else {
+		msg = service.NewMessage(nil)
+		msg.SetStructuredMut(map[string]any{
+			"key":   key,
+			"value": res.Val(),
+		})
+	}
+	return msg, func(ctx context.Context, err error) error {
+		return err
+	}, nil
+}
+
+// readHash can emit each hash field as either a structured object or as a raw
+// value payload. Raw output aligns with Redis list/pubsub inputs and preserves
+// binary values exactly, while structured output gives text values an envelope
+// close to the legacy {"key":"...","value":"..."} redis_scan shape.
 func (r *redisScanReader) readHash(ctx context.Context) (*service.Message, service.AckFunc, error) {
 	for {
 		if r.hashIter != nil {
@@ -192,17 +221,11 @@ func (r *redisScanReader) readHash(ctx context.Context) (*service.Message, servi
 				}
 
 				res := r.client.HGet(ctx, r.currentHashKey, field)
-				valueBytes, err := res.Bytes()
-				if err != nil {
+				if err := res.Err(); err != nil {
 					return nil, nil, err
 				}
 
-				msg := service.NewMessage(valueBytes)
-				msg.MetaSetMut(redisScanMetaKey, r.currentHashKey)
-				msg.MetaSetMut(redisScanMetaHashField, field)
-				return msg, func(ctx context.Context, err error) error {
-					return err
-				}, nil
+				return r.newHashMessage(r.currentHashKey, field, res)
 			}
 			if err := r.hashIter.Err(); err != nil {
 				return nil, nil, err
@@ -224,6 +247,29 @@ func (r *redisScanReader) readHash(ctx context.Context) (*service.Message, servi
 			return nil, nil, err
 		}
 	}
+}
+
+func (r *redisScanReader) newHashMessage(key, field string, res *redis.StringCmd) (*service.Message, service.AckFunc, error) {
+	var msg *service.Message
+	if r.valueFormat == redisScanValueFormatRaw {
+		valueBytes, err := res.Bytes()
+		if err != nil {
+			return nil, nil, err
+		}
+		msg = service.NewMessage(valueBytes)
+		msg.MetaSetMut(redisScanMetaKey, key)
+		msg.MetaSetMut(redisScanMetaHashField, field)
+	} else {
+		msg = service.NewMessage(nil)
+		msg.SetStructuredMut(map[string]any{
+			"key":   key,
+			"field": field,
+			"value": res.Val(),
+		})
+	}
+	return msg, func(ctx context.Context, err error) error {
+		return err
+	}, nil
 }
 
 func (r *redisScanReader) Close(ctx context.Context) (err error) {

--- a/internal/impl/redis/integration_test.go
+++ b/internal/impl/redis/integration_test.go
@@ -198,7 +198,7 @@ input:
 input:
   redis_scan:
     url: 'tcp://localhost:$PORT'
-    match: '*'
+    match: 'foo-*'
   processors:
     - mapping: 'root = this.value'
 
@@ -223,53 +223,160 @@ cache_resources:
 		)
 	})
 
-	t.Run("scan hash fields", func(t *testing.T) {
+	t.Run("scan value formats", func(t *testing.T) {
 		ctx := context.Background()
-		prefix := "bento_test_redis_scan_hash"
-		require.NoError(t, client.Del(ctx, prefix+":foo", prefix+":bar", "bento_test_redis_scan_hash_ignore").Err())
-		require.NoError(t, client.HSet(ctx, prefix+":foo", "field_a", []byte{0x00, 0x01, 0x02}, "field_b", []byte("payload-b")).Err())
-		require.NoError(t, client.HSet(ctx, prefix+":bar", "field_c", []byte{0xff, 0x00, 0x10}).Err())
-		require.NoError(t, client.HSet(ctx, "bento_test_redis_scan_hash_ignore", "field_z", []byte("ignored")).Err())
 
-		conf, err := redisScanInputConfig().ParseYAML(fmt.Sprintf(`
+		newInput := func(t *testing.T, confStr string) service.Input {
+			t.Helper()
+
+			conf, err := redisScanInputConfig().ParseYAML(confStr, nil)
+			require.NoError(t, err)
+
+			input, err := newRedisScanInputFromConfig(conf, service.MockResources())
+			require.NoError(t, err)
+			require.NoError(t, input.Connect(ctx))
+			t.Cleanup(func() {
+				assert.NoError(t, input.Close(ctx))
+			})
+
+			return input
+		}
+
+		readStructured := func(t *testing.T, input service.Input) map[string]map[string]any {
+			t.Helper()
+
+			actual := map[string]map[string]any{}
+			for {
+				msg, ackFn, err := input.Read(ctx)
+				if errors.Is(err, service.ErrEndOfInput) {
+					break
+				}
+				require.NoError(t, err)
+				require.NoError(t, ackFn(ctx, nil))
+
+				structured, err := msg.AsStructured()
+				require.NoError(t, err)
+				obj, ok := structured.(map[string]any)
+				require.True(t, ok)
+
+				id := fmt.Sprintf("%v", obj["key"])
+				if field, exists := obj["field"]; exists {
+					id += "|" + fmt.Sprintf("%v", field)
+				}
+				actual[id] = obj
+			}
+			return actual
+		}
+
+		readRaw := func(t *testing.T, input service.Input) map[string][]byte {
+			t.Helper()
+
+			actual := map[string][]byte{}
+			for {
+				msg, ackFn, err := input.Read(ctx)
+				if errors.Is(err, service.ErrEndOfInput) {
+					break
+				}
+				require.NoError(t, err)
+				require.NoError(t, ackFn(ctx, nil))
+
+				key, exists := msg.MetaGet(redisScanMetaKey)
+				require.True(t, exists)
+				id := key
+				if field, exists := msg.MetaGet(redisScanMetaHashField); exists {
+					id += "|" + field
+				}
+				payload, err := msg.AsBytes()
+				require.NoError(t, err)
+				actual[id] = payload
+			}
+			return actual
+		}
+
+		stringStructuredPrefix := "bento_test_redis_scan_string_structured"
+		require.NoError(t, client.Del(ctx, stringStructuredPrefix+":foo", stringStructuredPrefix+":bar").Err())
+		require.NoError(t, client.Set(ctx, stringStructuredPrefix+":foo", "payload-a", 0).Err())
+		require.NoError(t, client.Set(ctx, stringStructuredPrefix+":bar", "payload-b", 0).Err())
+		stringStructuredInput := newInput(t, fmt.Sprintf(`
+url: tcp://localhost:%v
+match: %s:*
+scan_count: 1
+`, resource.GetPort("6379/tcp"), stringStructuredPrefix))
+		assert.Equal(t, map[string]map[string]any{
+			stringStructuredPrefix + ":foo": {
+				"key":   stringStructuredPrefix + ":foo",
+				"value": "payload-a",
+			},
+			stringStructuredPrefix + ":bar": {
+				"key":   stringStructuredPrefix + ":bar",
+				"value": "payload-b",
+			},
+		}, readStructured(t, stringStructuredInput))
+
+		stringRawPrefix := "bento_test_redis_scan_string_raw"
+		require.NoError(t, client.Del(ctx, stringRawPrefix+":foo", stringRawPrefix+":bar").Err())
+		require.NoError(t, client.Set(ctx, stringRawPrefix+":foo", []byte{0x00, 0x01, 0x02}, 0).Err())
+		require.NoError(t, client.Set(ctx, stringRawPrefix+":bar", []byte("payload-b"), 0).Err())
+		stringRawInput := newInput(t, fmt.Sprintf(`
+url: tcp://localhost:%v
+match: %s:*
+data_type: string
+value_format: raw
+scan_count: 1
+`, resource.GetPort("6379/tcp"), stringRawPrefix))
+		assert.Equal(t, map[string][]byte{
+			stringRawPrefix + ":foo": {0x00, 0x01, 0x02},
+			stringRawPrefix + ":bar": []byte("payload-b"),
+		}, readRaw(t, stringRawInput))
+
+		hashStructuredPrefix := "bento_test_redis_scan_hash_structured"
+		require.NoError(t, client.Del(ctx, hashStructuredPrefix+":foo", hashStructuredPrefix+":bar").Err())
+		require.NoError(t, client.HSet(ctx, hashStructuredPrefix+":foo", "field_a", "payload-a", "field_b", "payload-b").Err())
+		require.NoError(t, client.HSet(ctx, hashStructuredPrefix+":bar", "field_c", "payload-c").Err())
+		hashStructuredInput := newInput(t, fmt.Sprintf(`
 url: tcp://localhost:%v
 match: %s:*
 data_type: hash
+value_format: structured
 scan_count: 1
 hash_scan_count: 1
-`, resource.GetPort("6379/tcp"), prefix), nil)
-		require.NoError(t, err)
+`, resource.GetPort("6379/tcp"), hashStructuredPrefix))
+		assert.Equal(t, map[string]map[string]any{
+			hashStructuredPrefix + ":foo|field_a": {
+				"key":   hashStructuredPrefix + ":foo",
+				"field": "field_a",
+				"value": "payload-a",
+			},
+			hashStructuredPrefix + ":foo|field_b": {
+				"key":   hashStructuredPrefix + ":foo",
+				"field": "field_b",
+				"value": "payload-b",
+			},
+			hashStructuredPrefix + ":bar|field_c": {
+				"key":   hashStructuredPrefix + ":bar",
+				"field": "field_c",
+				"value": "payload-c",
+			},
+		}, readStructured(t, hashStructuredInput))
 
-		input, err := newRedisScanInputFromConfig(conf, service.MockResources())
-		require.NoError(t, err)
-		require.NoError(t, input.Connect(ctx))
-		t.Cleanup(func() {
-			assert.NoError(t, input.Close(ctx))
-		})
-
-		actual := map[string][]byte{}
-		for {
-			msg, ackFn, err := input.Read(ctx)
-			if errors.Is(err, service.ErrEndOfInput) {
-				break
-			}
-			require.NoError(t, err)
-			require.NoError(t, ackFn(ctx, nil))
-
-			key, exists := msg.MetaGet(redisScanMetaKey)
-			require.True(t, exists)
-			field, exists := msg.MetaGet(redisScanMetaHashField)
-			require.True(t, exists)
-			payload, err := msg.AsBytes()
-			require.NoError(t, err)
-			actual[key+"|"+field] = payload
-		}
-
+		hashRawPrefix := "bento_test_redis_scan_hash_raw"
+		require.NoError(t, client.Del(ctx, hashRawPrefix+":foo", hashRawPrefix+":bar", "bento_test_redis_scan_hash_raw_ignore").Err())
+		require.NoError(t, client.HSet(ctx, hashRawPrefix+":foo", "field_a", []byte{0x00, 0x01, 0x02}, "field_b", []byte("payload-b")).Err())
+		require.NoError(t, client.HSet(ctx, hashRawPrefix+":bar", "field_c", []byte{0xff, 0x00, 0x10}).Err())
+		require.NoError(t, client.HSet(ctx, "bento_test_redis_scan_hash_raw_ignore", "field_z", []byte("ignored")).Err())
+		hashRawInput := newInput(t, fmt.Sprintf(`
+url: tcp://localhost:%v
+match: %s:*
+data_type: hash
+value_format: raw
+scan_count: 1
+hash_scan_count: 1
+`, resource.GetPort("6379/tcp"), hashRawPrefix))
 		assert.Equal(t, map[string][]byte{
-			prefix + ":foo|field_a": {0x00, 0x01, 0x02},
-			prefix + ":foo|field_b": []byte("payload-b"),
-			prefix + ":bar|field_c": {0xff, 0x00, 0x10},
-		}, actual)
+			hashRawPrefix + ":foo|field_a": {0x00, 0x01, 0x02},
+			hashRawPrefix + ":foo|field_b": []byte("payload-b"),
+			hashRawPrefix + ":bar|field_c": {0xff, 0x00, 0x10},
+		}, readRaw(t, hashRawInput))
 	})
 
 	// HASH

--- a/internal/impl/redis/integration_test.go
+++ b/internal/impl/redis/integration_test.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/warpstreamlabs/bento/public/components/pure"
+	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"
 )
 
@@ -219,6 +221,55 @@ cache_resources:
 			integration.StreamTestOptSleepAfterOutput(100*time.Millisecond),
 			integration.StreamTestOptPort(resource.GetPort("6379/tcp")),
 		)
+	})
+
+	t.Run("scan hash fields", func(t *testing.T) {
+		ctx := context.Background()
+		prefix := "bento_test_redis_scan_hash"
+		require.NoError(t, client.Del(ctx, prefix+":foo", prefix+":bar", "bento_test_redis_scan_hash_ignore").Err())
+		require.NoError(t, client.HSet(ctx, prefix+":foo", "field_a", []byte{0x00, 0x01, 0x02}, "field_b", []byte("payload-b")).Err())
+		require.NoError(t, client.HSet(ctx, prefix+":bar", "field_c", []byte{0xff, 0x00, 0x10}).Err())
+		require.NoError(t, client.HSet(ctx, "bento_test_redis_scan_hash_ignore", "field_z", []byte("ignored")).Err())
+
+		conf, err := redisScanInputConfig().ParseYAML(fmt.Sprintf(`
+url: tcp://localhost:%v
+match: %s:*
+data_type: hash
+scan_count: 1
+hash_scan_count: 1
+`, resource.GetPort("6379/tcp"), prefix), nil)
+		require.NoError(t, err)
+
+		input, err := newRedisScanInputFromConfig(conf, service.MockResources())
+		require.NoError(t, err)
+		require.NoError(t, input.Connect(ctx))
+		t.Cleanup(func() {
+			assert.NoError(t, input.Close(ctx))
+		})
+
+		actual := map[string][]byte{}
+		for {
+			msg, ackFn, err := input.Read(ctx)
+			if errors.Is(err, service.ErrEndOfInput) {
+				break
+			}
+			require.NoError(t, err)
+			require.NoError(t, ackFn(ctx, nil))
+
+			key, exists := msg.MetaGet(redisScanMetaKey)
+			require.True(t, exists)
+			field, exists := msg.MetaGet(redisScanMetaHashField)
+			require.True(t, exists)
+			payload, err := msg.AsBytes()
+			require.NoError(t, err)
+			actual[key+"|"+field] = payload
+		}
+
+		assert.Equal(t, map[string][]byte{
+			prefix + ":foo|field_a": {0x00, 0x01, 0x02},
+			prefix + ":foo|field_b": []byte("payload-b"),
+			prefix + ":bar|field_c": {0xff, 0x00, 0x10},
+		}, actual)
 	})
 
 	// HASH

--- a/internal/impl/redis/integration_test.go
+++ b/internal/impl/redis/integration_test.go
@@ -192,6 +192,8 @@ input:
 	})
 
 	// SCAN
+	// match: 'foo-*' scopes to integration test keys so the "scan value formats"
+	// sub-test's prefixed keys don't leak into this test's expected output.
 	t.Run("scan", func(t *testing.T) {
 		t.Parallel()
 		template := `
@@ -224,6 +226,7 @@ cache_resources:
 	})
 
 	t.Run("scan value formats", func(t *testing.T) {
+		t.Parallel()
 		ctx := context.Background()
 
 		newInput := func(t *testing.T, confStr string) service.Input {

--- a/website/docs/components/inputs/redis_scan.md
+++ b/website/docs/components/inputs/redis_scan.md
@@ -33,6 +33,7 @@ input:
     url: redis://:6397 # No default (required)
     auto_replay_nacks: true
     match: ""
+    data_type: string
 ```
 
 </TabItem>
@@ -55,6 +56,9 @@ input:
       client_certs: []
     auto_replay_nacks: true
     match: ""
+    data_type: string
+    scan_count: 0
+    hash_scan_count: 0
 ```
 
 </TabItem>
@@ -69,6 +73,10 @@ This input generates a message for each key value pair in the following format:
 ```json
 {"key":"foo","value":"bar"}
 ```
+
+When `data_type` is set to `hash` this input treats matched keys as Redis hashes. It uses HSCAN to discover fields,
+fetches each field value with HGET, and generates a raw message payload for each hash field value. The Redis key is set in metadata
+`redis_key` and the hash field is set in metadata `redis_hash_field`.
 
 
 ## Fields
@@ -292,5 +300,30 @@ match: foo
 
 match: '*4*'
 ```
+
+### `data_type`
+
+The Redis data type to read for each matched key. When set to `hash`, matched keys are scanned with HSCAN and each hash field value is emitted as an individual message payload.
+
+
+Type: `string`  
+Default: `"string"`  
+Options: `string`, `hash`.
+
+### `scan_count`
+
+An optional Redis SCAN count hint for key scanning. A value of 0 preserves the Redis default scan behaviour.
+
+
+Type: `int`  
+Default: `0`  
+
+### `hash_scan_count`
+
+An optional Redis HSCAN count hint for hash field scanning. A value of 0 preserves the Redis default scan behaviour.
+
+
+Type: `int`  
+Default: `0`  
 
 

--- a/website/docs/components/inputs/redis_scan.md
+++ b/website/docs/components/inputs/redis_scan.md
@@ -34,6 +34,7 @@ input:
     auto_replay_nacks: true
     match: ""
     data_type: string
+    value_format: structured
 ```
 
 </TabItem>
@@ -57,6 +58,7 @@ input:
     auto_replay_nacks: true
     match: ""
     data_type: string
+    value_format: structured
     scan_count: 0
     hash_scan_count: 0
 ```
@@ -75,8 +77,12 @@ This input generates a message for each key value pair in the following format:
 ```
 
 When `data_type` is set to `hash` this input treats matched keys as Redis hashes. It uses HSCAN to discover fields,
-fetches each field value with HGET, and generates a raw message payload for each hash field value. The Redis key is set in metadata
-`redis_key` and the hash field is set in metadata `redis_hash_field`.
+and fetches each field value with HGET.
+
+By default, `value_format` is `structured` in order to preserve the original `redis_scan` message shape
+of `{"key":"...","value":"..."}`. Set it to `raw` to emit Redis values as raw message payloads.
+Raw messages set Redis identity fields as metadata, using `redis_key` for Redis keys and
+`redis_hash_field` for hash fields.
 
 
 ## Fields
@@ -303,12 +309,21 @@ match: '*4*'
 
 ### `data_type`
 
-The Redis data type to read for each matched key. When set to `hash`, matched keys are scanned with HSCAN and each hash field value is emitted as an individual message payload.
+The Redis data type to read for each matched key. When set to `hash`, matched keys are scanned with HSCAN and each hash field value is emitted as an individual message.
 
 
 Type: `string`  
 Default: `"string"`  
 Options: `string`, `hash`.
+
+### `value_format`
+
+The Bento message shape to emit for Redis values. The `structured` format preserves the original redis_scan key/value object shape, while `raw` emits Redis values as message payloads and stores Redis identity in metadata.
+
+
+Type: `string`  
+Default: `"structured"`  
+Options: `structured`, `raw`.
 
 ### `scan_count`
 

--- a/website/docs/components/inputs/redis_scan.md
+++ b/website/docs/components/inputs/redis_scan.md
@@ -15,7 +15,7 @@ categories: ["Services"]
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Scans the set of keys in the current selected database and gets their values, using the Scan and Get commands.
+Scans the set of keys in the current selected database and emits Redis string or hash values.
 
 
 <Tabs defaultValue="common" values={[
@@ -70,14 +70,15 @@ Optionally, iterates only elements matching a blob-style pattern. For example:
 - `*foo*` iterates only keys which contain `foo` in it.
 - `foo*` iterates only keys starting with `foo`.
 
-This input generates a message for each key value pair in the following format:
+By default this input treats matched keys as Redis string data type keys, reads them with GET, and generates a message
+for each key value pair in the following format:
 
 ```json
 {"key":"foo","value":"bar"}
 ```
 
-When `data_type` is set to `hash` this input treats matched keys as Redis hashes. It uses HSCAN to discover fields,
-and fetches each field value with HGET.
+When `data_type` is set to `hash` this input treats matched keys as Redis hash data type keys. It uses HSCAN
+to iterate over each field and its value.
 
 By default, `value_format` is `structured` in order to preserve the original `redis_scan` message shape
 of `{"key":"...","value":"..."}`. Set it to `raw` to emit Redis values as raw message payloads.
@@ -309,7 +310,7 @@ match: '*4*'
 
 ### `data_type`
 
-The Redis data type to read for each matched key. When set to `hash`, matched keys are scanned with HSCAN and each hash field value is emitted as an individual message.
+The Redis data type to read for each matched key. `string` reads matched keys with GET. `hash` scans matched keys with HSCAN and emits each hash field value as an individual message.
 
 
 Type: `string`  


### PR DESCRIPTION
Expands `redis_scan` support beyond simple values to support redis [`hash` data type](https://redis.io/docs/latest/develop/data-types/hashes/). Also adds support for emitting raw values, rather than original structured key/value object shape.

Originally discussed [on slack](https://warpstreamlab-uwt2030.slack.com/archives/C0768UE3NEM/p1779967847965779).