### PR TITLE
send_ack Option in NATS Core Input

### DIFF
--- a/internal/cli/blobl/core.go
+++ b/internal/cli/blobl/core.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Jeffail/gabs/v2"
+
 	"github.com/warpstreamlabs/bento/internal/bloblang"
 	"github.com/warpstreamlabs/bento/internal/bloblang/mapping"
 	"github.com/warpstreamlabs/bento/internal/bloblang/parser"

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/icholy/digest"
 	"github.com/lublak/go-spnego"
+
 	"github.com/warpstreamlabs/bento/internal/old/util/throttle"
 	"github.com/warpstreamlabs/bento/internal/tracing/v2"
 	"github.com/warpstreamlabs/bento/public/service"

--- a/internal/impl/aws/integration_helpers_test.go
+++ b/internal/impl/aws/integration_helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service/integration"
 )
 

--- a/internal/impl/aws/output_dynamodb_integration_test.go
+++ b/internal/impl/aws/output_dynamodb_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"
 

--- a/internal/impl/aws/processor_dynamodb_partiql_integration_test.go
+++ b/internal/impl/aws/processor_dynamodb_partiql_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"
 

--- a/internal/impl/cypher/input_cypher.go
+++ b/internal/impl/cypher/input_cypher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Jeffail/shutdown"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
+
 	"github.com/warpstreamlabs/bento/internal/component"
 	"github.com/warpstreamlabs/bento/public/service"
 )

--- a/internal/impl/cypher/input_cypher_test.go
+++ b/internal/impl/cypher/input_cypher_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/internal/component/input"
 	"github.com/warpstreamlabs/bento/internal/component/testutil"
 	"github.com/warpstreamlabs/bento/internal/manager/mock"

--- a/internal/impl/cypher/output_cypher.go
+++ b/internal/impl/cypher/output_cypher.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/cypher/output_cypher_test.go
+++ b/internal/impl/cypher/output_cypher_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/internal/component/output"
 	"github.com/warpstreamlabs/bento/internal/component/testutil"
 	"github.com/warpstreamlabs/bento/internal/manager/mock"

--- a/internal/impl/datadog/output_datadog_logs.go
+++ b/internal/impl/datadog/output_datadog_logs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/Jeffail/shutdown"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/elasticsearch/aws/integration_test.go
+++ b/internal/impl/elasticsearch/aws/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	es "github.com/aws/aws-sdk-go-v2/service/elasticsearchservice"
+
 	"github.com/warpstreamlabs/bento/internal/impl/elasticsearch"
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"

--- a/internal/impl/elasticsearch/integration_v2_test.go
+++ b/internal/impl/elasticsearch/integration_v2_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v9"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"
 )

--- a/internal/impl/elasticsearch/output_v2.go
+++ b/internal/impl/elasticsearch/output_v2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/elastic/go-elasticsearch/v9"
 	"github.com/elastic/go-elasticsearch/v9/esutil"
+
 	"github.com/warpstreamlabs/bento/internal/retries"
 	"github.com/warpstreamlabs/bento/public/service"
 )

--- a/internal/impl/elasticsearch/writer_v2_integration_test.go
+++ b/internal/impl/elasticsearch/writer_v2_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/internal/impl/elasticsearch"
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"

--- a/internal/impl/gcp/input_spanner_cdc.go
+++ b/internal/impl/gcp/input_spanner_cdc.go
@@ -12,10 +12,11 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"github.com/Jeffail/shutdown"
-	types "github.com/warpstreamlabs/bento/internal/impl/gcp/types"
-	"github.com/warpstreamlabs/bento/public/service"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
+
+	types "github.com/warpstreamlabs/bento/internal/impl/gcp/types"
+	"github.com/warpstreamlabs/bento/public/service"
 )
 
 // TODO(gregfurman): Implement caching and checkpointing mechanism

--- a/internal/impl/gcp/input_spanner_cdc_test.go
+++ b/internal/impl/gcp/input_spanner_cdc_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	types "github.com/warpstreamlabs/bento/internal/impl/gcp/types"
-	"github.com/warpstreamlabs/bento/public/service"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	types "github.com/warpstreamlabs/bento/internal/impl/gcp/types"
+	"github.com/warpstreamlabs/bento/public/service"
 )
 
 func TestCDCConfigFromParsed(t *testing.T) {

--- a/internal/impl/gcp/integration_spanner_cdc_test.go
+++ b/internal/impl/gcp/integration_spanner_cdc_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
+
 	. "github.com/warpstreamlabs/bento/internal/impl/gcp/tests"
 	_ "github.com/warpstreamlabs/bento/public/components/sql"
 	"github.com/warpstreamlabs/bento/public/service/integration"

--- a/internal/impl/gcp/output_bigtable.go
+++ b/internal/impl/gcp/output_bigtable.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"cloud.google.com/go/bigtable"
+
 	"github.com/warpstreamlabs/bento/public/bloblang"
 	"github.com/warpstreamlabs/bento/public/service"
 )

--- a/internal/impl/gcp/output_bigtable_test.go
+++ b/internal/impl/gcp/output_bigtable_test.go
@@ -10,6 +10,7 @@ import (
 	"cloud.google.com/go/bigtable"
 	"cloud.google.com/go/bigtable/bttest"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"
 )

--- a/internal/impl/gcp/tests/helpers.go
+++ b/internal/impl/gcp/tests/helpers.go
@@ -8,6 +8,7 @@ import (
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
 	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+
 	_ "github.com/warpstreamlabs/bento/public/components/sql"
 )
 

--- a/internal/impl/grpc/common.go
+++ b/internal/impl/grpc/common.go
@@ -10,13 +10,14 @@ import (
 	"github.com/jhump/protoreflect/desc/protoparse"
 	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
 	"github.com/jhump/protoreflect/grpcreflect"
-	"github.com/warpstreamlabs/bento/public/service"
 	"golang.org/x/oauth2/clientcredentials"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/oauth"
 	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/warpstreamlabs/bento/public/service"
 )
 
 const (

--- a/internal/impl/grpc/grpc_test_server/helloworld/helloworld.pb.go
+++ b/internal/impl/grpc/grpc_test_server/helloworld/helloworld.pb.go
@@ -21,11 +21,12 @@
 package helloworld
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/internal/impl/grpc/grpc_test_server/helloworld/helloworld_grpc.pb.go
+++ b/internal/impl/grpc/grpc_test_server/helloworld/helloworld_grpc.pb.go
@@ -22,6 +22,7 @@ package helloworld
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/internal/impl/grpc/grpc_test_server/test_server/test_server.go
+++ b/internal/impl/grpc/grpc_test_server/test_server/test_server.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	test_server "github.com/warpstreamlabs/bento/internal/impl/grpc/grpc_test_server/helloworld"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -25,6 +24,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 	status "google.golang.org/grpc/status"
+
+	test_server "github.com/warpstreamlabs/bento/internal/impl/grpc/grpc_test_server/helloworld"
 )
 
 type TestServer struct {

--- a/internal/impl/grpc/input_grpc_client.go
+++ b/internal/impl/grpc/input_grpc_client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jhump/protoreflect/dynamic"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/grpc/input_grpc_client_test.go
+++ b/internal/impl/grpc/input_grpc_client_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/internal/component/testutil"
 	"github.com/warpstreamlabs/bento/internal/manager/mock"
 	"github.com/warpstreamlabs/bento/internal/message"

--- a/internal/impl/grpc/output_grpc_client.go
+++ b/internal/impl/grpc/output_grpc_client.go
@@ -6,9 +6,10 @@ import (
 	"io"
 
 	"github.com/jhump/protoreflect/dynamic"
-	"github.com/warpstreamlabs/bento/public/service"
 	_ "google.golang.org/grpc/health"
 	grpcmd "google.golang.org/grpc/metadata"
+
+	"github.com/warpstreamlabs/bento/public/service"
 )
 
 const (

--- a/internal/impl/grpc/output_grpc_client_test.go
+++ b/internal/impl/grpc/output_grpc_client_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/internal/component/testutil"
 	"github.com/warpstreamlabs/bento/internal/manager/mock"
 	"github.com/warpstreamlabs/bento/internal/message"

--- a/internal/impl/huggingface/processor_test.go
+++ b/internal/impl/huggingface/processor_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/knights-analytics/hugot"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/io/input_file_tail.go
+++ b/internal/impl/io/input_file_tail.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Jeffail/shutdown"
+
 	"github.com/warpstreamlabs/bento/internal/filepath/ifs"
 	"github.com/warpstreamlabs/bento/public/service"
 )

--- a/internal/impl/io/input_file_tail_test.go
+++ b/internal/impl/io/input_file_tail_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/internal/component/testutil"
 	"github.com/warpstreamlabs/bento/internal/filepath/ifs"
 	"github.com/warpstreamlabs/bento/internal/manager/mock"

--- a/internal/impl/kafka/aws/aws.go
+++ b/internal/impl/kafka/aws/aws.go
@@ -6,6 +6,7 @@ import (
 	"github.com/IBM/sarama"
 	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
 	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/warpstreamlabs/bento/internal/impl/kafka"
 	"github.com/warpstreamlabs/bento/public/service"
 

--- a/internal/impl/kafka/franz_sasl_test.go
+++ b/internal/impl/kafka/franz_sasl_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/kafka/input_kafka_franz_test.go
+++ b/internal/impl/kafka/input_kafka_franz_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
+
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"
 )

--- a/internal/impl/kafka/integration_sasl_oauth_test.go
+++ b/internal/impl/kafka/integration_sasl_oauth_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sasl/oauth"
+
 	"github.com/warpstreamlabs/bento/public/service/integration"
 )
 

--- a/internal/impl/kubernetes/auth_test.go
+++ b/internal/impl/kubernetes/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/kubernetes/input_watch_test.go
+++ b/internal/impl/kubernetes/input_watch_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/Jeffail/shutdown"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/warpstreamlabs/bento/public/service"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/warpstreamlabs/bento/public/service"
 )
 
 func TestKubernetesWatchConfigParse(t *testing.T) {

--- a/internal/impl/nats/input.go
+++ b/internal/impl/nats/input.go
@@ -69,7 +69,8 @@ output:
 		Field(service.NewBoolField("send_ack").
 			Description("Whether to send an acknowledgement back to the input subject's reply address after consuming a message.").
 			Default(true).
-			Advanced()).
+			Advanced().
+			Version("1.19.0")).
 		Fields(connectionTailFields()...).
 		Fields(inputTracingDocs()...)
 }

--- a/internal/impl/nats/input.go
+++ b/internal/impl/nats/input.go
@@ -66,6 +66,10 @@ output:
 			Advanced().
 			Default(nats.DefaultSubPendingMsgsLimit).
 			LintRule(`root = if this < 0 { ["prefetch count must be greater than or equal to zero"] }`)).
+		Field(service.NewBoolField("send_ack").
+			Description("Whether to send an acknowledgement back to the input subject's reply address after consuming a message.").
+			Default(true).
+			Advanced()).
 		Fields(connectionTailFields()...).
 		Fields(inputTracingDocs()...)
 }
@@ -97,6 +101,7 @@ type natsReader struct {
 	queue         string
 	prefetchCount int
 	nakDelay      time.Duration
+	sendAck       bool
 
 	log *service.Logger
 
@@ -128,6 +133,10 @@ func newNATSReader(conf *service.ParsedConfig, mgr *service.Resources) (*natsRea
 		return nil, err
 	}
 
+	if n.sendAck, err = conf.FieldBool("send_ack"); err != nil {
+		return nil, err
+	}
+
 	if n.prefetchCount < 0 {
 		return nil, errors.New("prefetch count must be greater than or equal to zero")
 	}
@@ -143,6 +152,7 @@ func newNATSReader(conf *service.ParsedConfig, mgr *service.Resources) (*natsRea
 			return nil, err
 		}
 	}
+
 	return &n, nil
 }
 
@@ -247,10 +257,10 @@ func (n *natsReader) Read(ctx context.Context) (*service.Message, service.AckFun
 					return err
 				}
 				ackErr = msg.RespondMsg(replyMsg)
-			} else {
+			} else if n.sendAck {
 				ackErr = msg.Ack()
 			}
-		} else {
+		} else if n.sendAck {
 			ackErr = msg.Ack()
 		}
 		if errors.Is(ackErr, nats.ErrMsgNoReply) {

--- a/internal/impl/nats/input.go
+++ b/internal/impl/nats/input.go
@@ -67,10 +67,10 @@ output:
 			Default(nats.DefaultSubPendingMsgsLimit).
 			LintRule(`root = if this < 0 { ["prefetch count must be greater than or equal to zero"] }`)).
 		Field(service.NewBoolField("send_ack").
-			Description("Whether to send an acknowledgement back to the input subject's reply address after consuming a message.").
+			Description("Whether to send an acknowledgement back to the input subject's reply address after delivering a message.").
 			Default(true).
 			Advanced().
-			Version("1.19.0")).
+			Version("1.21.0")).
 		Fields(connectionTailFields()...).
 		Fields(inputTracingDocs()...)
 }

--- a/internal/impl/nats/input_os.go
+++ b/internal/impl/nats/input_os.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Jeffail/shutdown"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/nats/integration_os_test.go
+++ b/internal/impl/nats/integration_os_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/integration"
 )

--- a/internal/impl/nats/output_os.go
+++ b/internal/impl/nats/output_os.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Jeffail/shutdown"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/nats/processor_os.go
+++ b/internal/impl/nats/processor_os.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Jeffail/shutdown"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/opensnowcat/schema_extractor_test.go
+++ b/internal/impl/opensnowcat/schema_extractor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/pure/bloblang_cache_test.go
+++ b/internal/impl/pure/bloblang_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/internal/component/testutil"
 	"github.com/warpstreamlabs/bento/internal/manager"
 	"github.com/warpstreamlabs/bento/internal/message"

--- a/internal/impl/pure/processor_template.go
+++ b/internal/impl/pure/processor_template.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+
 	"github.com/warpstreamlabs/bento/public/bloblang"
 	"github.com/warpstreamlabs/bento/public/service"
 )

--- a/internal/impl/pure/processor_unarchive.go
+++ b/internal/impl/pure/processor_unarchive.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/clbanning/mxj/v2"
+
 	"github.com/warpstreamlabs/bento/internal/message"
 	"github.com/warpstreamlabs/bento/public/service"
 )

--- a/internal/impl/python/processor.go
+++ b/internal/impl/python/processor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+
 	"github.com/warpstreamlabs/bento/internal/impl/wasm/wasmpool"
 	"github.com/warpstreamlabs/bento/public/service"
 )

--- a/internal/impl/s2/bento.go
+++ b/internal/impl/s2/bento.go
@@ -2,6 +2,7 @@ package s2
 
 import (
 	s2bentobox "github.com/s2-streamstore/s2-sdk-go/s2-bentobox"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/s2/input.go
+++ b/internal/impl/s2/input.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	s2bentobox "github.com/s2-streamstore/s2-sdk-go/s2-bentobox"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/s2/output.go
+++ b/internal/impl/s2/output.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/s2-streamstore/s2-sdk-go/s2"
 	s2bentobox "github.com/s2-streamstore/s2-sdk-go/s2-bentobox"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/slack/output_slack_webhook.go
+++ b/internal/impl/slack/output_slack_webhook.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Jeffail/shutdown"
 	"github.com/slack-go/slack"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/slack/output_slack_webhook_test.go
+++ b/internal/impl/slack/output_slack_webhook_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slacktest"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warpstreamlabs/bento/public/service"
 )
 

--- a/internal/impl/sql/azure/azure.go
+++ b/internal/impl/sql/azure/azure.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
 	"github.com/warpstreamlabs/bento/internal/impl/sql"
 	"github.com/warpstreamlabs/bento/public/service"
 )

--- a/internal/impl/sql/output_duckdb_append.go
+++ b/internal/impl/sql/output_duckdb_append.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Jeffail/shutdown"
 	"github.com/duckdb/duckdb-go/v2"
+
 	"github.com/warpstreamlabs/bento/public/bloblang"
 	"github.com/warpstreamlabs/bento/public/service"
 )

--- a/internal/impl/sql/output_sql_deprecated.go
+++ b/internal/impl/sql/output_sql_deprecated.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/warpstreamlabs/bento/public/bloblang"
 	"github.com/warpstreamlabs/bento/public/service"
 

--- a/internal/impl/zeromq/native_output_zmq4n.go
+++ b/internal/impl/zeromq/native_output_zmq4n.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	gzmq4 "github.com/go-zeromq/zmq4"
+
 	"github.com/warpstreamlabs/bento/internal/component"
 	"github.com/warpstreamlabs/bento/public/service"
 )

--- a/internal/message/messagepb/message.pb.go
+++ b/internal/message/messagepb/message.pb.go
@@ -7,12 +7,13 @@
 package messagepb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	structpb "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
 const (

--- a/internal/message/protobuf.go
+++ b/internal/message/protobuf.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 
-	pb "github.com/warpstreamlabs/bento/internal/message/messagepb"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	pb "github.com/warpstreamlabs/bento/internal/message/messagepb"
 )
 
 func UnmarshalFromProto(b []byte) (*Part, error) {

--- a/internal/message/protobuf_test.go
+++ b/internal/message/protobuf_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	pb "github.com/warpstreamlabs/bento/internal/message/messagepb"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	pb "github.com/warpstreamlabs/bento/internal/message/messagepb"
 )
 
 type protoTestCase struct {

--- a/internal/tracing/flow.go
+++ b/internal/tracing/flow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+
 	"github.com/warpstreamlabs/bento/internal/message"
 )
 

--- a/website/docs/components/inputs/nats.md
+++ b/website/docs/components/inputs/nats.md
@@ -50,6 +50,7 @@ input:
     auto_replay_nacks: true
     nak_delay: 1m # No default (optional)
     prefetch_count: 500000
+    send_ack: true
     tls:
       enabled: false
       skip_cert_verify: false
@@ -210,6 +211,14 @@ The maximum number of messages to pull at a time.
 
 Type: `int`  
 Default: `500000`  
+
+### `send_ack`
+
+Whether to send an acknowledgement back to the input subject's reply address after consuming a message.
+
+
+Type: `bool`  
+Default: `true`  
 
 ### `tls`
 

--- a/website/docs/components/inputs/nats.md
+++ b/website/docs/components/inputs/nats.md
@@ -214,11 +214,12 @@ Default: `500000`
 
 ### `send_ack`
 
-Whether to send an acknowledgement back to the input subject's reply address after consuming a message.
+Whether to send an acknowledgement back to the input subject's reply address after delivering a message.
 
 
 Type: `bool`  
 Default: `true`  
+Requires version 1.21.0 or newer  
 
 ### `tls`
 


### PR DESCRIPTION
## Overview

This PR adds support for the additional NATS input boolean parameter `send_ack`.

In [NATS core](https://docs.nats.io/nats-concepts/core-nats/reqreply), message acknowledgements are not natively supported, they are more often associated with [NATS JetStream](https://docs.nats.io/nats-concepts/jetstream/streams). This parameter (`send_ack`) allows the user to turn off acknowledgements when using the NATS core input component within Bento.

This parameter is already supported by one of the alternatives to Bento, [RedPanda Connect ](https://docs.redpanda.com/connect/components/inputs/nats/#send_ack).

Despite acknowledgements not being native to NATS core, the default of the `send_ack` parameter was set to `True` to align with previous versions of Bento if left out of the configuration.

## Contribution Details

Have ran the following commands and everything completed with no errors:

-`make fmt`
-`make docs`
-`golangci-lint run ./internal/impl/nats/...`
-`go test -timeout 3m ./internal/impl/nats/...`
-`go test -run 'TestIntegration' -timeout 5m ./internal/impl/nats/...`