### PR TITLE
chore(sentry): Update sentry to v0.47.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a
-	github.com/getsentry/sentry-go v0.27.0
+	github.com/getsentry/sentry-go v0.47.0
 	github.com/go-faker/faker/v4 v4.3.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/go-zeromq/zmq4 v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -1120,6 +1120,8 @@ github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a h1:J8FuFJ
 github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a/go.mod h1:ms6iGk40n2YQrbM9Sr6onzwYBD1q5D0T5DQmcaye6uU=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go v0.47.0 h1:AnSMSyrYA5qZCIN/2xpgAAwv63sVULV+vBq37ajouc8=
+github.com/getsentry/sentry-go v0.47.0/go.mod h1:h+b4VHpKnK7aUXB5wc+KDnPgp9ZtfliRD4eV85FbiSA=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=

--- a/go.sum
+++ b/go.sum
@@ -1118,8 +1118,6 @@ github.com/gabriel-vasile/mimetype v1.4.7/go.mod h1:GDlAgAyIRT27BhFl53XNAFtfjzOk
 github.com/gdamore/optopia v0.2.0/go.mod h1:YKYEwo5C1Pa617H7NlPcmQXl+vG6YnSSNB44n8dNL0Q=
 github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a h1:J8FuFJ7K+Hiwkla2kT9fVIVix+EZhAlDsZwRlfFI3MA=
 github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a/go.mod h1:ms6iGk40n2YQrbM9Sr6onzwYBD1q5D0T5DQmcaye6uU=
-github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
-github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/getsentry/sentry-go v0.47.0 h1:AnSMSyrYA5qZCIN/2xpgAAwv63sVULV+vBq37ajouc8=
 github.com/getsentry/sentry-go v0.47.0/go.mod h1:h+b4VHpKnK7aUXB5wc+KDnPgp9ZtfliRD4eV85FbiSA=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/internal/impl/sentry/processor_capture.go
+++ b/internal/impl/sentry/processor_capture.go
@@ -245,9 +245,16 @@ func (proc *captureProcessor) Process(ctx context.Context, msg *service.Message)
 }
 
 func (proc *captureProcessor) Close(ctx context.Context) error {
-	if flushed := proc.hub.Flush(proc.flushTimeout); !flushed {
+
+	tctx, cancel := context.WithTimeout(ctx, proc.flushTimeout)
+	defer cancel()
+
+	if flushed := proc.hub.FlushWithContext(tctx); !flushed {
 		return errors.New("failed to flush sentry events before timeout")
 	}
+
+	// TODO: Should this always happen?
+	proc.hub.Client().Close()
 
 	return nil
 }
@@ -292,7 +299,8 @@ func (proc *captureProcessor) queryContext(msg *service.Message) (map[string]sen
 
 		// Print a useful warning if user is going to override one of the context
 		// keys that sentry-go automatically populates for each event.
-		if key == "device" || key == "os" || key == "runtime" {
+		switch key {
+		case "device", "os", "runtime", "trace":
 			proc.logger.Warnf("sentry context mapping will override a built-in context: %s", key)
 		}
 

--- a/internal/impl/sentry/processor_capture_test.go
+++ b/internal/impl/sentry/processor_capture_test.go
@@ -3,7 +3,6 @@ package sentry
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/stretchr/testify/mock"
@@ -36,7 +35,8 @@ func TestCaptureProcessor(t *testing.T) {
 		rawEvent = args.Get(0)
 	})
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -83,7 +83,8 @@ func TestCaptureProcessor_Sync(t *testing.T) {
 		rawEvent = args.Get(0)
 	})
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -119,7 +120,8 @@ func TestCaptureProcessor_InvalidMessage(t *testing.T) {
 
 	transport := &mockTransport{}
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -154,7 +156,8 @@ func TestCaptureProcessor_NoSampling(t *testing.T) {
 
 	transport := &mockTransport{}
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -174,9 +177,6 @@ func TestCaptureProcessor_FlushOnClose(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	d, err := time.ParseDuration("3s")
-	require.NoError(t, err, "bad flush timeout duration")
-
 	spec := newCaptureProcessorConfig()
 	conf, err := spec.ParseYAML(`
   flush_timeout: 3s
@@ -191,7 +191,8 @@ func TestCaptureProcessor_FlushOnClose(t *testing.T) {
 
 	transport := &mockTransport{}
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", d).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -216,7 +217,7 @@ func TestCaptureProcessor_FlushFailed(t *testing.T) {
 
 	transport := &mockTransport{}
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(false)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(false)
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -245,7 +246,8 @@ func TestCaptureProcessor_EmptyContext(t *testing.T) {
 		rawEvent = args.Get(0)
 	})
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -267,8 +269,8 @@ func TestCaptureProcessor_EmptyContext(t *testing.T) {
 	for k := range event.Contexts {
 		contextKeys = append(contextKeys, k)
 	}
-	require.Len(t, contextKeys, 3, "wrong number of context keys found")
-	require.ElementsMatch(t, []string{"device", "os", "runtime"}, contextKeys)
+	require.Len(t, contextKeys, 4, "wrong number of context keys found")
+	require.ElementsMatch(t, []string{"device", "os", "runtime", "trace"}, contextKeys)
 }
 
 // TestCaptureProcessor_NoContext checks that leaving context config unset
@@ -289,7 +291,8 @@ func TestCaptureProcessor_NoContext(t *testing.T) {
 		rawEvent = args.Get(0)
 	})
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -311,8 +314,8 @@ func TestCaptureProcessor_NoContext(t *testing.T) {
 	for k := range event.Contexts {
 		contextKeys = append(contextKeys, k)
 	}
-	require.Len(t, contextKeys, 3, "wrong number of context keys found")
-	require.ElementsMatch(t, []string{"device", "os", "runtime"}, contextKeys)
+	require.Len(t, contextKeys, 4, "wrong number of context keys found")
+	require.ElementsMatch(t, []string{"device", "os", "runtime", "trace"}, contextKeys)
 }
 
 func TestCaptureProcessor_NilContextValue(t *testing.T) {
@@ -333,7 +336,8 @@ func TestCaptureProcessor_NilContextValue(t *testing.T) {
 		rawEvent = args.Get(0)
 	})
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -355,8 +359,8 @@ func TestCaptureProcessor_NilContextValue(t *testing.T) {
 	for k := range event.Contexts {
 		contextKeys = append(contextKeys, k)
 	}
-	require.Len(t, contextKeys, 3, "wrong number of context keys found")
-	require.ElementsMatch(t, []string{"device", "os", "runtime"}, contextKeys)
+	require.Len(t, contextKeys, 4, "wrong number of context keys found")
+	require.ElementsMatch(t, []string{"device", "os", "runtime", "trace"}, contextKeys)
 }
 
 func TestCaptureProcessor_InvalidContext(t *testing.T) {
@@ -373,7 +377,8 @@ func TestCaptureProcessor_InvalidContext(t *testing.T) {
 
 	transport := &mockTransport{}
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -402,7 +407,8 @@ func TestCaptureProcessor_ContextNotStructured(t *testing.T) {
 
 	transport := &mockTransport{}
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -431,7 +437,8 @@ func TestCaptureProcessor_ContextNotMap(t *testing.T) {
 
 	transport := &mockTransport{}
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -460,7 +467,8 @@ func TestCaptureProcessor_ContextValueNotMap(t *testing.T) {
 
 	transport := &mockTransport{}
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))
@@ -489,7 +497,8 @@ func TestCaptureProcessor_InvalidTag(t *testing.T) {
 
 	transport := &mockTransport{}
 	transport.On("Configure", mock.Anything).Return()
-	transport.On("Flush", mock.Anything).Return(true)
+	transport.On("FlushWithContext", mock.AnythingOfType("time.Duration")).Return(true)
+	transport.On("Close").Return()
 	t.Cleanup(func() { transport.AssertExpectations(t) })
 
 	proc, err := newCaptureProcessor(conf, service.MockResources(), withTransport(transport))

--- a/internal/impl/sentry/transport_mock_test.go
+++ b/internal/impl/sentry/transport_mock_test.go
@@ -1,11 +1,14 @@
 package sentry
 
 import (
+	"context"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/stretchr/testify/mock"
 )
+
+var _ sentry.Transport = &mockTransport{}
 
 var argEvent = mock.AnythingOfType("*sentry.Event")
 
@@ -19,10 +22,23 @@ func (t *mockTransport) Flush(timeout time.Duration) bool {
 	return args.Bool(0)
 }
 
+func (t *mockTransport) FlushWithContext(ctx context.Context) bool {
+	var timeout time.Duration
+	if deadline, ok := ctx.Deadline(); ok {
+		timeout = time.Until(deadline)
+	}
+	args := t.Called(timeout)
+	return args.Bool(0)
+}
+
 func (t *mockTransport) Configure(options sentry.ClientOptions) {
 	t.Called(options)
 }
 
 func (t *mockTransport) SendEvent(event *sentry.Event) {
 	t.Called(event)
+}
+
+func (t *mockTransport) Close() {
+	t.Called()
 }


### PR DESCRIPTION
## Motivation

Updates sentry to the latest minor version `v0.47.0`, which introduces the following:

- Closing the entire `Transport` via a `Close` method
- Flushing a `Transport` with context using `FlushWithContext`

This should also unblock dependabot since this sentry upgrading is causing build + lint failures https://github.com/warpstreamlabs/bento/pull/892/

## Changes

- The processor now closes a `Transport` if `FlushWithContext` occurs within the ctx deadline -- in accordance with the `flush_timeout` duration value.
- Updates the mocks to now include `Close` and `FlushWithContext` instead of just `Flush`

