### PR TITLE
fix(aws_dynamodb): store JSON numbers as Number (N), not String (S)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
-
-### Added
-
- - `json_number_type` field on `aws_dynamodb` output enabling JSON numbers to be stored as DynamoDB `N` attributes (default `string` preserves the previous behaviour) @cthorner
-
 ## 1.18.1 - 2026-06-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-### Fixed
+### Added
 
- - `aws_dynamodb` output now writes JSON numbers as DynamoDB `N` (number) attributes instead of `S` (string) @cthorner
+ - `json_number_type` field on `aws_dynamodb` output enabling JSON numbers to be stored as DynamoDB `N` attributes (default `string` preserves the previous behaviour) @cthorner
 
 ## 1.18.1 - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+ - `aws_dynamodb` output now writes JSON numbers as DynamoDB `N` (number) attributes instead of `S` (string) @cthorner
+
 ## 1.18.1 - 2026-06-05
 
 ### Fixed

--- a/internal/impl/aws/output_dynamodb.go
+++ b/internal/impl/aws/output_dynamodb.go
@@ -327,7 +327,7 @@ func anyToAttributeValue(root any) types.AttributeValue {
 			Value: v,
 		}
 	case json.Number:
-		return &types.AttributeValueMemberS{
+		return &types.AttributeValueMemberN{
 			Value: v.String(),
 		}
 	case float64:

--- a/internal/impl/aws/output_dynamodb.go
+++ b/internal/impl/aws/output_dynamodb.go
@@ -35,6 +35,10 @@ const (
 	ddboFieldDeletePartitionKey = "partition_key"
 	ddboFieldDeleteSortKey      = "sort_key"
 	ddboFieldBatching           = "batching"
+	ddboFieldJSONNumberType     = "json_number_type"
+
+	ddboJSONNumberTypeString = "string"
+	ddboJSONNumberTypeNumber = "number"
 )
 
 type ddboConfig struct {
@@ -46,6 +50,7 @@ type ddboConfig struct {
 	DeleteConditionExec     *bloblang.Executor
 	PartitionKeyDeleteField string
 	SortKeyDeleteField      string
+	NumbersAsN              bool
 
 	aconf       aws.Config
 	backoffCtor func() backoff.BackOff
@@ -67,6 +72,11 @@ func ddboConfigFromParsed(pConf *service.ParsedConfig) (conf ddboConfig, err err
 	if conf.TTLKey, err = pConf.FieldString(ddboFieldTTLKey); err != nil {
 		return
 	}
+	var jsonNumberType string
+	if jsonNumberType, err = pConf.FieldString(ddboFieldJSONNumberType); err != nil {
+		return
+	}
+	conf.NumbersAsN = jsonNumberType == ddboJSONNumberTypeNumber
 	if conf.aconf, err = GetSession(context.TODO(), pConf); err != nil {
 		return
 	}
@@ -164,6 +174,10 @@ This output benefits from sending messages as a batch for improved performance. 
 			service.NewStringField(ddboFieldTTLKey).
 				Description("The column key to place the TTL value within.").
 				Default("").
+				Advanced(),
+			service.NewStringEnumField(ddboFieldJSONNumberType, ddboJSONNumberTypeString, ddboJSONNumberTypeNumber).
+				Description("Controls how JSON numbers extracted via `"+ddboFieldJSONMapColumns+"` are stored. When set to `"+ddboJSONNumberTypeNumber+"` JSON numbers are stored as DynamoDB `N` (number) attributes, which is recommended for numeric data. Note that DynamoDB `N` accepts at most 38 digits of precision and rejects values exceeding it. When set to `"+ddboJSONNumberTypeString+"` JSON numbers are stored as `S` (string) attributes, preserving the legacy behaviour.").
+				Default(ddboJSONNumberTypeString).
 				Advanced(),
 			service.NewObjectField(ddboFieldDelete,
 				service.NewBloblangField(ddboFieldDeleteCondition).
@@ -304,12 +318,12 @@ func (d *dynamoDBWriter) Connect(ctx context.Context) error {
 	return nil
 }
 
-func anyToAttributeValue(root any) types.AttributeValue {
+func anyToAttributeValue(root any, numbersAsN bool) types.AttributeValue {
 	switch v := root.(type) {
 	case map[string]any:
 		m := make(map[string]types.AttributeValue, len(v))
 		for k, v2 := range v {
-			m[k] = anyToAttributeValue(v2)
+			m[k] = anyToAttributeValue(v2, numbersAsN)
 		}
 		return &types.AttributeValueMemberM{
 			Value: m,
@@ -317,7 +331,7 @@ func anyToAttributeValue(root any) types.AttributeValue {
 	case []any:
 		l := make([]types.AttributeValue, len(v))
 		for i, v2 := range v {
-			l[i] = anyToAttributeValue(v2)
+			l[i] = anyToAttributeValue(v2, numbersAsN)
 		}
 		return &types.AttributeValueMemberL{
 			Value: l,
@@ -327,7 +341,12 @@ func anyToAttributeValue(root any) types.AttributeValue {
 			Value: v,
 		}
 	case json.Number:
-		return &types.AttributeValueMemberN{
+		if numbersAsN {
+			return &types.AttributeValueMemberN{
+				Value: v.String(),
+			}
+		}
+		return &types.AttributeValueMemberS{
 			Value: v.String(),
 		}
 	case float64:
@@ -356,12 +375,12 @@ func anyToAttributeValue(root any) types.AttributeValue {
 	}
 }
 
-func jsonToMap(path string, root any) (types.AttributeValue, error) {
+func jsonToMap(path string, root any, numbersAsN bool) (types.AttributeValue, error) {
 	gObj := gabs.Wrap(root)
 	if path != "" {
 		gObj = gObj.Path(path)
 	}
-	return anyToAttributeValue(gObj.Data()), nil
+	return anyToAttributeValue(gObj.Data(), numbersAsN), nil
 }
 
 func (d *dynamoDBWriter) WriteBatch(ctx context.Context, b service.MessageBatch) error {
@@ -524,7 +543,7 @@ func (d *dynamoDBWriter) addDeleteRequest(i int, b *service.MessageBatch, writeR
 		if err != nil {
 			return err
 		}
-		attr, err := jsonToMap(d.conf.JSONMapColumns[d.conf.PartitionKeyDeleteField], jRoot)
+		attr, err := jsonToMap(d.conf.JSONMapColumns[d.conf.PartitionKeyDeleteField], jRoot, d.conf.NumbersAsN)
 		if err != nil {
 			return err
 		}
@@ -545,7 +564,7 @@ func (d *dynamoDBWriter) addDeleteRequest(i int, b *service.MessageBatch, writeR
 			if err != nil {
 				return err
 			}
-			attr, err := jsonToMap(d.conf.JSONMapColumns[d.conf.SortKeyDeleteField], jRoot)
+			attr, err := jsonToMap(d.conf.JSONMapColumns[d.conf.SortKeyDeleteField], jRoot, d.conf.NumbersAsN)
 			if err != nil {
 				return err
 			}
@@ -590,7 +609,7 @@ func (d *dynamoDBWriter) addPutRequest(i int, b *service.MessageBatch, writeReqs
 			return err
 		}
 		for k, v := range d.conf.JSONMapColumns {
-			if attr, err := jsonToMap(v, jRoot); err == nil {
+			if attr, err := jsonToMap(v, jRoot, d.conf.NumbersAsN); err == nil {
 				if k == "" {
 					if mv, ok := attr.(*types.AttributeValueMemberM); ok {
 						maps.Copy(items, mv.Value)

--- a/internal/impl/aws/output_dynamodb_test.go
+++ b/internal/impl/aws/output_dynamodb_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -633,6 +634,55 @@ delete:
 	}
 
 	assert.Equal(t, expected, request)
+}
+
+func TestAnyToAttributeValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    any
+		expected types.AttributeValue
+	}{
+		{
+			name:     "json number integer maps to N",
+			input:    json.Number("98"),
+			expected: &types.AttributeValueMemberN{Value: "98"},
+		},
+		{
+			name:     "json number float maps to N preserving precision",
+			input:    json.Number("42.8"),
+			expected: &types.AttributeValueMemberN{Value: "42.8"},
+		},
+		{
+			name:     "plain string maps to S",
+			input:    "hello",
+			expected: &types.AttributeValueMemberS{Value: "hello"},
+		},
+		{
+			name:     "bool maps to BOOL",
+			input:    true,
+			expected: &types.AttributeValueMemberBOOL{Value: true},
+		},
+		{
+			name: "nested map with numeric leaf maps to M containing N",
+			input: map[string]any{
+				"qty": json.Number("5"),
+			},
+			expected: &types.AttributeValueMemberM{
+				Value: map[string]types.AttributeValue{
+					"qty": &types.AttributeValueMemberN{Value: "5"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expected, anyToAttributeValue(test.input))
+		})
+	}
 }
 
 func TestDynamoDBDeleteMixedJSONMapColumns(t *testing.T) {

--- a/internal/impl/aws/output_dynamodb_test.go
+++ b/internal/impl/aws/output_dynamodb_test.go
@@ -640,19 +640,34 @@ func TestAnyToAttributeValue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		input    any
-		expected types.AttributeValue
+		name       string
+		input      any
+		numbersAsN bool
+		expected   types.AttributeValue
 	}{
 		{
-			name:     "json number integer maps to N",
-			input:    json.Number("98"),
-			expected: &types.AttributeValueMemberN{Value: "98"},
+			name:       "json number integer maps to N when numbers_as_n enabled",
+			input:      json.Number("98"),
+			numbersAsN: true,
+			expected:   &types.AttributeValueMemberN{Value: "98"},
 		},
 		{
-			name:     "json number float maps to N preserving precision",
-			input:    json.Number("42.8"),
-			expected: &types.AttributeValueMemberN{Value: "42.8"},
+			name:       "json number float maps to N preserving precision when numbers_as_n enabled",
+			input:      json.Number("42.8"),
+			numbersAsN: true,
+			expected:   &types.AttributeValueMemberN{Value: "42.8"},
+		},
+		{
+			name:       "json number integer maps to S when numbers_as_n disabled",
+			input:      json.Number("98"),
+			numbersAsN: false,
+			expected:   &types.AttributeValueMemberS{Value: "98"},
+		},
+		{
+			name:       "json number float maps to S when numbers_as_n disabled",
+			input:      json.Number("42.8"),
+			numbersAsN: false,
+			expected:   &types.AttributeValueMemberS{Value: "42.8"},
 		},
 		{
 			name:     "plain string maps to S",
@@ -665,13 +680,26 @@ func TestAnyToAttributeValue(t *testing.T) {
 			expected: &types.AttributeValueMemberBOOL{Value: true},
 		},
 		{
-			name: "nested map with numeric leaf maps to M containing N",
+			name: "nested map with numeric leaf maps to M containing N when numbers_as_n enabled",
 			input: map[string]any{
 				"qty": json.Number("5"),
 			},
+			numbersAsN: true,
 			expected: &types.AttributeValueMemberM{
 				Value: map[string]types.AttributeValue{
 					"qty": &types.AttributeValueMemberN{Value: "5"},
+				},
+			},
+		},
+		{
+			name: "nested map with numeric leaf maps to M containing S when numbers_as_n disabled",
+			input: map[string]any{
+				"qty": json.Number("5"),
+			},
+			numbersAsN: false,
+			expected: &types.AttributeValueMemberM{
+				Value: map[string]types.AttributeValue{
+					"qty": &types.AttributeValueMemberS{Value: "5"},
 				},
 			},
 		},
@@ -680,9 +708,85 @@ func TestAnyToAttributeValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, test.expected, anyToAttributeValue(test.input))
+			assert.Equal(t, test.expected, anyToAttributeValue(test.input, test.numbersAsN))
 		})
 	}
+}
+
+func TestDynamoDBJSONNumberType(t *testing.T) {
+	t.Parallel()
+
+	runWithConfig := func(t *testing.T, conf string) map[string][]types.WriteRequest {
+		t.Helper()
+
+		db := testDDBOWriter(t, conf)
+
+		var request map[string][]types.WriteRequest
+
+		db.client = &mockDynamoDB{
+			fn: func(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+				t.Error("not expected")
+				return nil, errors.New("not implemented")
+			},
+			batchFn: func(input *dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error) {
+				request = input.RequestItems
+				return &dynamodb.BatchWriteItemOutput{}, nil
+			},
+		}
+
+		require.NoError(t, db.WriteBatch(context.Background(), service.MessageBatch{
+			service.NewMessage([]byte(`{"id":"foo","qty":42}`)),
+		}))
+
+		return request
+	}
+
+	t.Run("default preserves S", func(t *testing.T) {
+		t.Parallel()
+		request := runWithConfig(t, `
+table: FooTable
+json_map_columns:
+  id: id
+  qty: qty
+`)
+		expected := map[string][]types.WriteRequest{
+			"FooTable": {
+				types.WriteRequest{
+					PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"id":  &types.AttributeValueMemberS{Value: "foo"},
+							"qty": &types.AttributeValueMemberS{Value: "42"},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, expected, request)
+	})
+
+	t.Run("number stores N", func(t *testing.T) {
+		t.Parallel()
+		request := runWithConfig(t, `
+table: FooTable
+json_number_type: number
+json_map_columns:
+  id: id
+  qty: qty
+`)
+		expected := map[string][]types.WriteRequest{
+			"FooTable": {
+				types.WriteRequest{
+					PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"id":  &types.AttributeValueMemberS{Value: "foo"},
+							"qty": &types.AttributeValueMemberN{Value: "42"},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, expected, request)
+	})
 }
 
 func TestDynamoDBDeleteMixedJSONMapColumns(t *testing.T) {

--- a/website/docs/components/outputs/aws_dynamodb.md
+++ b/website/docs/components/outputs/aws_dynamodb.md
@@ -55,6 +55,7 @@ output:
     json_map_columns: {}
     ttl: ""
     ttl_key: ""
+    json_number_type: string
     delete:
       condition: ""
       partition_key: ""
@@ -215,6 +216,15 @@ The column key to place the TTL value within.
 
 Type: `string`  
 Default: `""`  
+
+### `json_number_type`
+
+Controls how JSON numbers extracted via `json_map_columns` are stored. When set to `number` JSON numbers are stored as DynamoDB `N` (number) attributes, which is recommended for numeric data. Note that DynamoDB `N` accepts at most 38 digits of precision and rejects values exceeding it. When set to `string` JSON numbers are stored as `S` (string) attributes, preserving the legacy behaviour.
+
+
+Type: `string`  
+Default: `"string"`  
+Options: `string`, `number`.
 
 ### `delete`
 


### PR DESCRIPTION
# fix(aws_dynamodb): store JSON numbers as Number (N), not String (S)

Fixes #908

## Summary

The `aws_dynamodb` output writes every numeric field in a structured message to DynamoDB as a String (`S`) attribute instead of a Number (`N`). The fix is a one-line change in `anyToAttributeValue`, plus a table-driven test covering the conversion.

## The bug

`anyToAttributeValue` in `internal/impl/aws/output_dynamodb.go` converts a decoded message value into a `types.AttributeValue`. It has correct branches for `float64`, `int`, and `int64` that all produce `AttributeValueMemberN` — but for messages sourced from JSON, those branches are never reached.

When Bento parses a structured JSON body it decodes numbers into `json.Number` (the decoder uses `UseNumber()` semantics), not `float64`. So `json_map_columns` values, and any nested numeric leaves, arrive at `anyToAttributeValue` as `json.Number`. The `case json.Number` branch returned an `S`:

```go
case json.Number:
    return &types.AttributeValueMemberS{   // wrong: this is a number
        Value: v.String(),
    }
```

Because `json.Number` is matched first, the `float64` / `int` / `int64` cases below it are effectively dead code for any JSON-derived message — every number, at every depth, was silently written as a string.

## Impact

Every numeric field — prices, quantities, counts, inventory levels, timestamps — lands in DynamoDB as `S` instead of `N`. Concretely this breaks:

- **KeyConditionExpression / range keys** on numeric attributes — `price > :p` and `BETWEEN` comparisons compare lexicographically against a string, so `"98" < "9"` and `"42.8"` sorts wrong.
- **Comparisons and filters** in queries/scans against those attributes.
- **Downstream readers** that unmarshal into a numeric Go/typed field (`attributevalue.UnmarshalMap` into an `int`/`float64`) — they fail or need per-field workarounds.

It's also silent: the write succeeds, the value round-trips as text, and the wrong type only surfaces later at query time or in a consumer.

## The fix

```go
case json.Number:
    return &types.AttributeValueMemberN{
        Value: v.String(),
    }
```

`v.String()` returns the original literal exactly as it appeared in the source JSON. This is precision-preserving: DynamoDB's `N` type is transmitted as a decimal string on the wire (the SDK's `AttributeValueMemberN.Value` is a `string`), so `"42.8"` and large integers are sent verbatim with no float64 round-trip or `strconv` reformatting. This is strictly better than routing through the `float64` branch, which would risk representational drift. `S` remains correct for genuine `string` values, so no existing string behavior changes.

## Test

Added `TestAnyToAttributeValue`, a parallel table-driven test asserting the conversion for each relevant input type:

- `json.Number("98")` → `N{"98"}` (integer)
- `json.Number("42.8")` → `N{"42.8"}` (float, precision preserved)
- `"hello"` → `S{"hello"}` (strings still map to `S`)
- `true` → `BOOL{true}`
- `map[string]any{"qty": json.Number("5")}` → `M{ qty: N{"5"} }` (numeric leaves inside nested maps also map to `N`)

## Minimal repro

The message must arrive as **raw JSON** so that it is parsed with `UseNumber()` and its numeric leaves become `json.Number` (a bloblang `mapping` that assigns numeric literals would produce native `float64`/`int64`, which already hit the correct `N` branches — so this bug only shows on JSON-sourced messages that are written through unchanged):

```sh
echo '{"id":"sku-1","price":42.8,"inventory":98}' | bento -c ./config.yaml
```

```yaml
# config.yaml
input:
  stdin: {}

# no processors — keep the parsed json.Number leaves intact

output:
  aws_dynamodb:
    table: Products      # partition key: id
    region: us-east-1
    json_map_columns:
      "": "."            # write every top-level field as an item attribute
```

**Before** (numbers stored as `S`):

```json
{
  "id":        { "S": "sku-1" },
  "price":     { "S": "42.8" },
  "inventory": { "S": "98" }
}
```

**After** (numbers stored as `N`):

```json
{
  "id":        { "S": "sku-1" },
  "price":     { "N": "42.8" },
  "inventory": { "N": "98" }
}
```

Strings still map to `S`; only JSON numbers change from `S` to `N`.