### PR TITLE
feat(gcp_bigtable): Support cell timestamps

### DIFF
--- a/internal/impl/gcp/output_bigtable.go
+++ b/internal/impl/gcp/output_bigtable.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"cloud.google.com/go/bigtable"
+	"github.com/warpstreamlabs/bento/public/bloblang"
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
@@ -16,6 +18,7 @@ const (
 	btoFieldColumn      = "column"
 	btoFieldRowKey      = "row_key"
 	btoFieldFamily      = "family"
+	btoFieldTimestamp   = "timestamp"
 	btoFieldBatching    = "batching"
 	btoFieldMaxInFlight = "max_in_flight"
 )
@@ -85,6 +88,13 @@ This output benefits from sending messages as a batch for improved performance. 
 				Description("The column family to write into.").
 				Example("cf1").
 				Example(`${!metadata("family")}`),
+			service.NewBloblangField(btoFieldTimestamp).
+				Description("Expression for the timestamp of the record. If this resolves to `-1`, then the BigTable server's timestamp is used. Otherwise, defaults to the local current time.").
+				Default("").
+				Optional().
+				Example(`metadata("timestamp")`).
+				Example("this.event_ts_ms * 1000 + stable_hash(this.event_id) % 1000").
+				Example(`-1`),
 			service.NewBatchPolicyField(btoFieldBatching),
 			service.NewOutputMaxInFlightField(),
 		)
@@ -99,6 +109,8 @@ type gcpBigTableOutputConfig struct {
 	RowKey       *service.InterpolatedString
 	ColumnName   *service.InterpolatedString
 	ColumnFamily *service.InterpolatedString
+
+	Timestamp *bloblang.Executor
 }
 
 func gcpBigTableOutputConfigFromParsed(conf *service.ParsedConfig) (gconf gcpBigTableOutputConfig, err error) {
@@ -126,6 +138,22 @@ func gcpBigTableOutputConfigFromParsed(conf *service.ParsedConfig) (gconf gcpBig
 		return
 	}
 
+	if conf.Contains(btoFieldTimestamp) {
+		var expression string
+		if expression, err = conf.FieldString(btoFieldTimestamp); err != nil {
+			return
+		}
+
+		// NOTE: if empty string is passed, do not set the executor.
+		if expression != "" {
+			if gconf.Timestamp, err = bloblang.Parse(expression); err != nil {
+				return
+			}
+
+		}
+
+	}
+
 	return
 }
 
@@ -141,6 +169,30 @@ func newGCPBigTableOutput(conf gcpBigTableOutputConfig) (*gcpBigTableOutput, err
 		conf: conf,
 		mu:   sync.RWMutex{},
 	}, nil
+}
+
+func getTimestamp(exec *service.MessageBatchBloblangExecutor, i int) (bigtable.Timestamp, error) {
+	if exec == nil {
+		return bigtable.Time(time.Now()), nil
+	}
+
+	val, err := exec.QueryValue(i)
+	if err != nil {
+		return 0, err
+	}
+
+	// A value of -1 signals that the BigTable server should assign
+	// its own timestamp to the cell at write time.
+	if iv, ok := val.(int64); ok && iv == -1 {
+		return bigtable.ServerTime, nil
+	}
+
+	t, err := bloblang.ValueAsTimestamp(val)
+	if err != nil {
+		return 0, err
+	}
+
+	return bigtable.Time(t), nil
 }
 
 func (g *gcpBigTableOutput) Connect(ctx context.Context) error {
@@ -182,6 +234,11 @@ func (g *gcpBigTableOutput) WriteBatch(ctx context.Context, batch service.Messag
 	columnExec := batch.InterpolationExecutor(g.conf.ColumnName)
 	rowKeyExec := batch.InterpolationExecutor(g.conf.RowKey)
 
+	var timestampExec *service.MessageBatchBloblangExecutor
+	if g.conf.Timestamp != nil {
+		timestampExec = batch.BloblangExecutor(g.conf.Timestamp)
+	}
+
 	tbl := g.client.Open(tableName)
 	g.mu.RUnlock()
 
@@ -211,8 +268,28 @@ func (g *gcpBigTableOutput) WriteBatch(ctx context.Context, batch service.Messag
 			return err
 		}
 
+		ts := bigtable.Now()
+		if timestampExec != nil {
+			val, err := timestampExec.QueryValue(i)
+			if err != nil {
+				return err
+			}
+
+			if iv, ok := val.(int64); ok && iv == -1 {
+				// A value of -1 signals that the BigTable server should
+				// assign its own timestamp to the cell at write time.
+				ts = bigtable.ServerTime
+			} else {
+				t, err := bloblang.ValueAsTimestamp(val)
+				if err != nil {
+					return err
+				}
+				ts = bigtable.Time(t)
+			}
+		}
+
 		rowKeys[i] = rowKey
-		mut.Set(family, col, bigtable.Now(), contents)
+		mut.Set(family, col, ts.TruncateToMilliseconds(), contents)
 		muts[i] = mut
 	}
 

--- a/internal/impl/gcp/output_bigtable.go
+++ b/internal/impl/gcp/output_bigtable.go
@@ -88,11 +88,11 @@ This output benefits from sending messages as a batch for improved performance. 
 				Example("cf1").
 				Example(`${!metadata("family")}`),
 			service.NewBloblangField(btoFieldTimestamp).
-				Description("Expression for the timestamp of the record. Expects either a UNIX timestamp in seconds (fractional values for sub-second precision), or a string value as `RFC3339Nano`. Timestamps are truncated to millisecond granularity. Otherwise, defaults to the local current time.").Default("").
+				Description("Expression for the timestamp of the record. Expects either a UNIX timestamp in seconds (fractional values for sub-second precision), or a string value as `RFC3339Nano`. Timestamps are truncated to millisecond granularity. Otherwise, defaults to the local current time.").
 				Optional().
 				Example(`metadata("timestamp")`).
-				Example(`root = this.event_ts_ms / 1000`).
-				Example(`root = this.created_at.ts_parse("2006-01-02 15:04:05")`),
+				Example(`json("event_ts_ms").number() / 1000`).
+				Example(`json("created_at").ts_parse("2006-01-02 15:04:05")`),
 			service.NewBatchPolicyField(btoFieldBatching),
 			service.NewOutputMaxInFlightField(),
 		)
@@ -137,19 +137,9 @@ func gcpBigTableOutputConfigFromParsed(conf *service.ParsedConfig) (gconf gcpBig
 	}
 
 	if conf.Contains(btoFieldTimestamp) {
-		var expression string
-		if expression, err = conf.FieldString(btoFieldTimestamp); err != nil {
+		if gconf.Timestamp, err = conf.FieldBloblang(btoFieldTimestamp); err != nil {
 			return
 		}
-
-		// NOTE: if empty string is passed, do not set the executor.
-		if expression != "" {
-			if gconf.Timestamp, err = bloblang.Parse(expression); err != nil {
-				return
-			}
-
-		}
-
 	}
 
 	return

--- a/internal/impl/gcp/output_bigtable.go
+++ b/internal/impl/gcp/output_bigtable.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"cloud.google.com/go/bigtable"
 	"github.com/warpstreamlabs/bento/public/bloblang"
@@ -89,12 +88,11 @@ This output benefits from sending messages as a batch for improved performance. 
 				Example("cf1").
 				Example(`${!metadata("family")}`),
 			service.NewBloblangField(btoFieldTimestamp).
-				Description("Expression for the timestamp of the record. If this resolves to `-1`, then the BigTable server's timestamp is used. Otherwise, defaults to the local current time.").
+				Description("Expression for the timestamp of the record. Otherwise, defaults to the local current time.").
 				Default("").
 				Optional().
 				Example(`metadata("timestamp")`).
-				Example("this.event_ts_ms * 1000 + stable_hash(this.event_id) % 1000").
-				Example(`-1`),
+				Example("root = this.event_ts_ms * 1000 + stable_hash(this.event_id) % 1000"),
 			service.NewBatchPolicyField(btoFieldBatching),
 			service.NewOutputMaxInFlightField(),
 		)
@@ -169,30 +167,6 @@ func newGCPBigTableOutput(conf gcpBigTableOutputConfig) (*gcpBigTableOutput, err
 		conf: conf,
 		mu:   sync.RWMutex{},
 	}, nil
-}
-
-func getTimestamp(exec *service.MessageBatchBloblangExecutor, i int) (bigtable.Timestamp, error) {
-	if exec == nil {
-		return bigtable.Time(time.Now()), nil
-	}
-
-	val, err := exec.QueryValue(i)
-	if err != nil {
-		return 0, err
-	}
-
-	// A value of -1 signals that the BigTable server should assign
-	// its own timestamp to the cell at write time.
-	if iv, ok := val.(int64); ok && iv == -1 {
-		return bigtable.ServerTime, nil
-	}
-
-	t, err := bloblang.ValueAsTimestamp(val)
-	if err != nil {
-		return 0, err
-	}
-
-	return bigtable.Time(t), nil
 }
 
 func (g *gcpBigTableOutput) Connect(ctx context.Context) error {
@@ -275,17 +249,11 @@ func (g *gcpBigTableOutput) WriteBatch(ctx context.Context, batch service.Messag
 				return err
 			}
 
-			if iv, ok := val.(int64); ok && iv == -1 {
-				// A value of -1 signals that the BigTable server should
-				// assign its own timestamp to the cell at write time.
-				ts = bigtable.ServerTime
-			} else {
-				t, err := bloblang.ValueAsTimestamp(val)
-				if err != nil {
-					return err
-				}
-				ts = bigtable.Time(t)
+			t, err := bloblang.ValueAsTimestamp(val)
+			if err != nil {
+				return err
 			}
+			ts = bigtable.Time(t)
 		}
 
 		rowKeys[i] = rowKey

--- a/internal/impl/gcp/output_bigtable.go
+++ b/internal/impl/gcp/output_bigtable.go
@@ -88,11 +88,11 @@ This output benefits from sending messages as a batch for improved performance. 
 				Example("cf1").
 				Example(`${!metadata("family")}`),
 			service.NewBloblangField(btoFieldTimestamp).
-				Description("Expression for the timestamp of the record. Otherwise, defaults to the local current time.").
-				Default("").
+				Description("Expression for the timestamp of the record. Expects either a UNIX timestamp in seconds (fractional values for sub-second precision), or a string value as `RFC3339Nano`. Timestamps are truncated to millisecond granularity. Otherwise, defaults to the local current time.").Default("").
 				Optional().
 				Example(`metadata("timestamp")`).
-				Example("root = this.event_ts_ms * 1000 + stable_hash(this.event_id) % 1000"),
+				Example(`root = this.event_ts_ms / 1000`).
+				Example(`root = this.created_at.ts_parse("2006-01-02 15:04:05")`),
 			service.NewBatchPolicyField(btoFieldBatching),
 			service.NewOutputMaxInFlightField(),
 		)

--- a/internal/impl/gcp/output_bigtable_test.go
+++ b/internal/impl/gcp/output_bigtable_test.go
@@ -196,14 +196,14 @@ func TestBigTableOutputTimestamp(t *testing.T) {
 	}{
 		{
 			name:      "static unix timestamp",
-			timestamp: fmt.Sprintf("'%d'", staticTime.Unix()),
+			timestamp: fmt.Sprintf("timestamp: '%d'", staticTime.Unix()),
 			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
 				require.Equal(t, bigtable.Time(staticTime), ts)
 			},
 		},
 		{
 			name:      "timestamp from metadata",
-			timestamp: `'metadata("ts")'`,
+			timestamp: `timestamp: 'metadata("ts")'`,
 			prepMsg: func(msg *service.Message) {
 				msg.MetaSetMut("ts", staticTime.Unix())
 			},
@@ -220,7 +220,7 @@ func TestBigTableOutputTimestamp(t *testing.T) {
 		},
 		{
 			name:      "rfc3339 string from metadata",
-			timestamp: `'metadata("ts")'`,
+			timestamp: `timestamp: 'metadata("ts")'`,
 			prepMsg: func(msg *service.Message) {
 				msg.MetaSetMut("ts", staticTime.Format(time.RFC3339Nano))
 			},
@@ -230,14 +230,44 @@ func TestBigTableOutputTimestamp(t *testing.T) {
 		},
 		{
 			name:      "ts_parse custom format",
-			timestamp: `'"2024-06-01 12:00:00".ts_parse("2006-01-02 15:04:05")'`,
+			timestamp: `timestamp: '"2024-06-01 12:00:00".ts_parse("2006-01-02 15:04:05")'`,
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				require.Equal(t, bigtable.Time(staticTime), ts)
+			},
+		},
+		{
+			name:      "example metadata timestamp",
+			timestamp: `timestamp: 'metadata("timestamp")'`,
+			prepMsg: func(msg *service.Message) {
+				msg.MetaSetMut("timestamp", staticTime.Unix())
+			},
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				require.Equal(t, bigtable.Time(staticTime), ts)
+			},
+		},
+		{
+			name:      "example json millis to seconds",
+			timestamp: `timestamp: 'json("event_ts_ms").number() / 1000'`,
+			prepMsg: func(msg *service.Message) {
+				msg.SetBytes([]byte(fmt.Sprintf(`{"event_ts_ms": %d}`, staticTime.UnixMilli())))
+			},
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				require.Equal(t, bigtable.Time(staticTime), ts)
+			},
+		},
+		{
+			name:      "example json ts_parse custom format",
+			timestamp: `timestamp: 'json("created_at").ts_parse("2006-01-02 15:04:05")'`,
+			prepMsg: func(msg *service.Message) {
+				msg.SetBytes([]byte(`{"created_at": "2024-06-01 12:00:00"}`))
+			},
 			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
 				require.Equal(t, bigtable.Time(staticTime), ts)
 			},
 		},
 		{
 			name:      "sub-millisecond precision truncated",
-			timestamp: fmt.Sprintf("'%q'", staticTime.Add(123456*time.Microsecond).Format(time.RFC3339Nano)),
+			timestamp: fmt.Sprintf("timestamp: '%q'", staticTime.Add(123456*time.Microsecond).Format(time.RFC3339Nano)),
 			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
 				require.Equal(t, bigtable.Time(staticTime.Add(123*time.Millisecond)), ts)
 				require.Zero(t, int64(ts)%1000, "cell timestamp must be ms-aligned")
@@ -245,7 +275,7 @@ func TestBigTableOutputTimestamp(t *testing.T) {
 		},
 		{
 			name:      "integer millis misinterpreted as seconds",
-			timestamp: fmt.Sprintf("'%d'", staticTime.UnixMilli()),
+			timestamp: fmt.Sprintf("timestamp: '%d'", staticTime.UnixMilli()),
 			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
 				want := bigtable.Time(time.Unix(staticTime.UnixMilli(), 0)).TruncateToMilliseconds()
 				require.Equal(t, want, ts)
@@ -253,7 +283,7 @@ func TestBigTableOutputTimestamp(t *testing.T) {
 		},
 		{
 			name:      "invalid timestamp value",
-			timestamp: `'"not-a-timestamp"'`,
+			timestamp: `timestamp: '"not-a-timestamp"'`,
 			wantErr:   true,
 		},
 	}
@@ -283,7 +313,7 @@ table: %s
 column: col
 family: %s
 row_key: key
-timestamp: %s
+%s
 `, projectID, instanceID, tableID, columnFamily, tc.timestamp), nil)
 			require.NoError(t, err)
 

--- a/internal/impl/gcp/output_bigtable_test.go
+++ b/internal/impl/gcp/output_bigtable_test.go
@@ -219,13 +219,6 @@ func TestBigTableOutputTimestamp(t *testing.T) {
 			},
 		},
 		{
-			name:      "defaults to server time when -1",
-			timestamp: "-1",
-			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
-				require.WithinDuration(t, time.Now(), ts.Time(), time.Minute)
-			},
-		},
-		{
 			name:      "invalid timestamp value",
 			timestamp: `'"not-a-timestamp"'`,
 			wantErr:   true,

--- a/internal/impl/gcp/output_bigtable_test.go
+++ b/internal/impl/gcp/output_bigtable_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/bigtable"
 	"cloud.google.com/go/bigtable/bttest"
@@ -179,6 +180,117 @@ row_key: key
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestBigTableOutputTimestamp(t *testing.T) {
+	staticTime := time.Date(2024, time.June, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		timestamp string
+		prepMsg   func(msg *service.Message)
+		checkTS   func(t *testing.T, ts bigtable.Timestamp)
+		wantErr   bool
+	}{
+		{
+			name:      "static unix timestamp",
+			timestamp: fmt.Sprintf("'%d'", staticTime.Unix()),
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				require.Equal(t, bigtable.Time(staticTime), ts)
+			},
+		},
+		{
+			name:      "timestamp from metadata",
+			timestamp: `'metadata("ts")'`,
+			prepMsg: func(msg *service.Message) {
+				msg.MetaSetMut("ts", staticTime.Unix())
+			},
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				require.Equal(t, bigtable.Time(staticTime), ts)
+			},
+		},
+		{
+			name:      "defaults to wall clock when unset",
+			timestamp: "",
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				require.WithinDuration(t, time.Now(), ts.Time(), time.Minute)
+			},
+		},
+		{
+			name:      "defaults to server time when -1",
+			timestamp: "-1",
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				require.WithinDuration(t, time.Now(), ts.Time(), time.Minute)
+			},
+		},
+		{
+			name:      "invalid timestamp value",
+			timestamp: `'"not-a-timestamp"'`,
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, err := setupBigTableEmulator(t)
+			require.NoError(t, err)
+			defer server.Close()
+
+			tableID := fmt.Sprintf("ts-table-%s", strings.ReplaceAll(tc.name, " ", "-"))
+			columnFamily := "test-family"
+
+			err = setupTableInstance(t.Context(), &bigtable.TableConf{
+				TableID: tableID,
+				ColumnFamilies: map[string]bigtable.Family{
+					columnFamily: {GCPolicy: bigtable.NoGcPolicy()},
+				},
+			})
+			require.NoError(t, err)
+
+			spec := gcpBigTableOutputSpec()
+			parsedConf, err := spec.ParseYAML(fmt.Sprintf(`
+project: %s
+instance: %s
+table: %s
+column: col
+family: %s
+row_key: key
+timestamp: %s
+`, projectID, instanceID, tableID, columnFamily, tc.timestamp), nil)
+			require.NoError(t, err)
+
+			conf, err := gcpBigTableOutputConfigFromParsed(parsedConf)
+			require.NoError(t, err)
+
+			output, err := newGCPBigTableOutput(conf)
+			require.NoError(t, err)
+
+			err = output.Connect(t.Context())
+			require.NoError(t, err)
+			defer output.Close(t.Context())
+
+			msg := service.NewMessage([]byte("value"))
+			if tc.prepMsg != nil {
+				tc.prepMsg(msg)
+			}
+
+			err = output.WriteBatch(t.Context(), service.MessageBatch{msg})
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			rows, err := readRows(t.Context(), "key", columnFamily, tableID)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+
+			cells := rows[0][columnFamily]
+			require.Len(t, cells, 1)
+
+			tc.checkTS(t, cells[0].Timestamp)
 		})
 	}
 }

--- a/internal/impl/gcp/output_bigtable_test.go
+++ b/internal/impl/gcp/output_bigtable_test.go
@@ -249,7 +249,7 @@ func TestBigTableOutputTimestamp(t *testing.T) {
 			name:      "example json millis to seconds",
 			timestamp: `timestamp: 'json("event_ts_ms").number() / 1000'`,
 			prepMsg: func(msg *service.Message) {
-				msg.SetBytes([]byte(fmt.Sprintf(`{"event_ts_ms": %d}`, staticTime.UnixMilli())))
+				msg.SetBytes(fmt.Appendf([]byte{}, `{"event_ts_ms": %d}`, staticTime.UnixMilli()))
 			},
 			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
 				require.Equal(t, bigtable.Time(staticTime), ts)

--- a/internal/impl/gcp/output_bigtable_test.go
+++ b/internal/impl/gcp/output_bigtable_test.go
@@ -219,6 +219,39 @@ func TestBigTableOutputTimestamp(t *testing.T) {
 			},
 		},
 		{
+			name:      "rfc3339 string from metadata",
+			timestamp: `'metadata("ts")'`,
+			prepMsg: func(msg *service.Message) {
+				msg.MetaSetMut("ts", staticTime.Format(time.RFC3339Nano))
+			},
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				require.Equal(t, bigtable.Time(staticTime), ts)
+			},
+		},
+		{
+			name:      "ts_parse custom format",
+			timestamp: `'"2024-06-01 12:00:00".ts_parse("2006-01-02 15:04:05")'`,
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				require.Equal(t, bigtable.Time(staticTime), ts)
+			},
+		},
+		{
+			name:      "sub-millisecond precision truncated",
+			timestamp: fmt.Sprintf("'%q'", staticTime.Add(123456*time.Microsecond).Format(time.RFC3339Nano)),
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				require.Equal(t, bigtable.Time(staticTime.Add(123*time.Millisecond)), ts)
+				require.Zero(t, int64(ts)%1000, "cell timestamp must be ms-aligned")
+			},
+		},
+		{
+			name:      "integer millis misinterpreted as seconds",
+			timestamp: fmt.Sprintf("'%d'", staticTime.UnixMilli()),
+			checkTS: func(t *testing.T, ts bigtable.Timestamp) {
+				want := bigtable.Time(time.Unix(staticTime.UnixMilli(), 0)).TruncateToMilliseconds()
+				require.Equal(t, want, ts)
+			},
+		},
+		{
 			name:      "invalid timestamp value",
 			timestamp: `'"not-a-timestamp"'`,
 			wantErr:   true,

--- a/website/docs/components/outputs/gcp_bigtable.md
+++ b/website/docs/components/outputs/gcp_bigtable.md
@@ -39,7 +39,7 @@ output:
     row_key: ${!metadata("kafka_key")} # No default (required)
     column: payload # No default (required)
     family: cf1 # No default (required)
-    timestamp: ""
+    timestamp: metadata("timestamp") # No default (optional)
     batching:
       count: 0
       byte_size: 0
@@ -63,7 +63,7 @@ output:
     row_key: ${!metadata("kafka_key")} # No default (required)
     column: payload # No default (required)
     family: cf1 # No default (required)
-    timestamp: ""
+    timestamp: metadata("timestamp") # No default (optional)
     batching:
       count: 0
       byte_size: 0
@@ -181,16 +181,15 @@ Expression for the timestamp of the record. Expects either a UNIX timestamp in s
 
 
 Type: `string`  
-Default: `""`  
 
 ```yml
 # Examples
 
 timestamp: metadata("timestamp")
 
-timestamp: root = this.event_ts_ms / 1000
+timestamp: json("event_ts_ms").number() / 1000
 
-timestamp: root = this.created_at.ts_parse("2006-01-02 15:04:05")
+timestamp: json("created_at").ts_parse("2006-01-02 15:04:05")
 ```
 
 ### `batching`

--- a/website/docs/components/outputs/gcp_bigtable.md
+++ b/website/docs/components/outputs/gcp_bigtable.md
@@ -177,7 +177,7 @@ family: ${!metadata("family")}
 
 ### `timestamp`
 
-Expression for the timestamp of the record. Otherwise, defaults to the local current time.
+Expression for the timestamp of the record. Expects either a UNIX timestamp in seconds (fractional values for sub-second precision), or a string value as `RFC3339Nano`. Timestamps are truncated to millisecond granularity. Otherwise, defaults to the local current time.
 
 
 Type: `string`  
@@ -188,7 +188,9 @@ Default: `""`
 
 timestamp: metadata("timestamp")
 
-timestamp: root = this.event_ts_ms * 1000 + stable_hash(this.event_id) % 1000
+timestamp: root = this.event_ts_ms / 1000
+
+timestamp: root = this.created_at.ts_parse("2006-01-02 15:04:05")
 ```
 
 ### `batching`

--- a/website/docs/components/outputs/gcp_bigtable.md
+++ b/website/docs/components/outputs/gcp_bigtable.md
@@ -39,6 +39,7 @@ output:
     row_key: ${!metadata("kafka_key")} # No default (required)
     column: payload # No default (required)
     family: cf1 # No default (required)
+    timestamp: ""
     batching:
       count: 0
       byte_size: 0
@@ -62,6 +63,7 @@ output:
     row_key: ${!metadata("kafka_key")} # No default (required)
     column: payload # No default (required)
     family: cf1 # No default (required)
+    timestamp: ""
     batching:
       count: 0
       byte_size: 0
@@ -171,6 +173,24 @@ Type: `string`
 family: cf1
 
 family: ${!metadata("family")}
+```
+
+### `timestamp`
+
+The timestamp of the record. If this resolves to `-1`, then the BigTable server's timestamp is used. Otherwise, defaults to the local current time.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+timestamp: metadata("timestamp")
+
+timestamp: this.event_ts_ms * 1000 + stable_hash(this.event_id) % 1000
+
+timestamp: "-1"
 ```
 
 ### `batching`

--- a/website/docs/components/outputs/gcp_bigtable.md
+++ b/website/docs/components/outputs/gcp_bigtable.md
@@ -177,7 +177,7 @@ family: ${!metadata("family")}
 
 ### `timestamp`
 
-The timestamp of the record. If this resolves to `-1`, then the BigTable server's timestamp is used. Otherwise, defaults to the local current time.
+Expression for the timestamp of the record. Otherwise, defaults to the local current time.
 
 
 Type: `string`  
@@ -188,9 +188,7 @@ Default: `""`
 
 timestamp: metadata("timestamp")
 
-timestamp: this.event_ts_ms * 1000 + stable_hash(this.event_id) % 1000
-
-timestamp: "-1"
+timestamp: root = this.event_ts_ms * 1000 + stable_hash(this.event_id) % 1000
 ```
 
 ### `batching`


### PR DESCRIPTION
Adds support for setting a BigTable cell's timestamp dynamically via a bloblang expression.

Here, we expect the timestamp expression to resolve to a valid value a UNIX timestamp in seconds (fractional values for sub-second precision), or a string value as `RFC3339Nano`.

Otherwise, if omitted or the expression is `""` at runtime, defaults to `time.Now()`.