### PR TITLE
fix(kinesis): Pagination when NextToken is defined

### DIFF
--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -715,8 +715,12 @@ func isShardFinished(s types.Shard) bool {
 
 func collectShards(ctx context.Context, arn string, svc *kinesis.Client) ([]types.Shard, error) {
 	listShardFn := func(token *string) ([]types.Shard, *string, error) {
+		var streamARN *string
+		if token == nil {
+			streamARN = aws.String(arn)
+		}
 		shardsRes, err := svc.ListShards(ctx, &kinesis.ListShardsInput{
-			StreamARN: aws.String(arn),
+			StreamARN: streamARN,
 			NextToken: token,
 		})
 		return shardsRes.Shards, shardsRes.NextToken, err


### PR DESCRIPTION
## Context

When paginating using the `ListShards` operation, the Kinesis stream is determined via the `NextToken`. Where, passing both a `StreamARN`/`StreamName` in addition to a `NextToken` returns an error. 


## Changes

- Fixes an API error triggered when paginating via `ListShards` and both a `StreamARN` and `NextToken` are supplied.