### PR TITLE
feature(gcp_pubsub): add extract_tracing_map / inject_tracing_map support

### DIFF
--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -117,6 +117,8 @@ You can access these metadata fields using [function interpolation](/docs/config
 			).
 				Description("Allows you to configure the input subscription and creates if it doesn't exist.").
 				Advanced(),
+			service.NewExtractTracingSpanMappingField(),
+			service.NewRootSpanWithLinkField().Version("1.19.0"),
 		)
 }
 
@@ -127,7 +129,11 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			return newGCPPubSubReader(pConf, mgr)
+			r, err := newGCPPubSubReader(pConf, mgr)
+			if err != nil {
+				return nil, err
+			}
+			return conf.WrapInputExtractTracingSpanMapping("gcp_pubsub", r)
 		})
 	if err != nil {
 		panic(err)

--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -118,7 +118,7 @@ You can access these metadata fields using [function interpolation](/docs/config
 				Description("Allows you to configure the input subscription and creates if it doesn't exist.").
 				Advanced(),
 			service.NewExtractTracingSpanMappingField(),
-			service.NewRootSpanWithLinkField().Version("1.19.0"),
+			service.NewRootSpanWithLinkField().Version("1.20.0"),
 		)
 }
 

--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -117,8 +117,8 @@ You can access these metadata fields using [function interpolation](/docs/config
 			).
 				Description("Allows you to configure the input subscription and creates if it doesn't exist.").
 				Advanced(),
-			service.NewExtractTracingSpanMappingField(),
-			service.NewRootSpanWithLinkField().Version("1.20.0"),
+			service.NewExtractTracingSpanMappingField().Version("1.21.0"),
+			service.NewRootSpanWithLinkField().Version("1.21.0"),
 		)
 }
 

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -74,6 +74,7 @@ pipeline:
 			service.NewMetadataExcludeFilterField("metadata").
 				Optional().
 				Description("Specify criteria for which metadata values are sent as attributes, all are sent by default."),
+			service.NewInjectTracingSpanMappingField(),
 			service.NewObjectField(
 				"flow_control",
 				service.NewIntField("max_outstanding_bytes").
@@ -360,7 +361,11 @@ func init() {
 			return
 		}
 
-		out, err = newPubSubOutput(conf)
+		if out, err = newPubSubOutput(conf); err != nil {
+			return
+		}
+
+		out, err = conf.WrapBatchOutputExtractTracingSpanMapping("gcp_pubsub", out)
 
 		return
 	}); err != nil {

--- a/website/docs/components/inputs/gcp_pubsub.md
+++ b/website/docs/components/inputs/gcp_pubsub.md
@@ -55,6 +55,8 @@ input:
     create_subscription:
       enabled: false
       topic: ""
+    extract_tracing_map: root = @ # No default (optional)
+    new_root_span_with_link: false # No default (optional)
 ```
 
 </TabItem>
@@ -155,5 +157,28 @@ Defines the topic that the subscription should be vinculated to.
 
 Type: `string`  
 Default: `""`  
+
+### `extract_tracing_map`
+
+EXPERIMENTAL: A [Bloblang mapping](/docs/guides/bloblang/about) that attempts to extract an object containing tracing propagation information, which will then be used as the root tracing span for the message. The specification of the extracted fields must match the format used by the service wide tracer.
+
+
+Type: `string`  
+
+```yml
+# Examples
+
+extract_tracing_map: root = @
+
+extract_tracing_map: root = this.meta.span
+```
+
+### `new_root_span_with_link`
+
+EXPERIMENTAL: Starts a new root span with link to parent.
+
+
+Type: `bool`  
+Requires version 1.19.0 or newer  
 
 

--- a/website/docs/components/inputs/gcp_pubsub.md
+++ b/website/docs/components/inputs/gcp_pubsub.md
@@ -179,6 +179,6 @@ EXPERIMENTAL: Starts a new root span with link to parent.
 
 
 Type: `bool`  
-Requires version 1.19.0 or newer  
+Requires version 1.20.0 or newer  
 
 

--- a/website/docs/components/inputs/gcp_pubsub.md
+++ b/website/docs/components/inputs/gcp_pubsub.md
@@ -164,6 +164,7 @@ EXPERIMENTAL: A [Bloblang mapping](/docs/guides/bloblang/about) that attempts to
 
 
 Type: `string`  
+Requires version 1.21.0 or newer  
 
 ```yml
 # Examples
@@ -179,6 +180,6 @@ EXPERIMENTAL: Starts a new root span with link to parent.
 
 
 Type: `bool`  
-Requires version 1.20.0 or newer  
+Requires version 1.21.0 or newer  
 
 

--- a/website/docs/components/outputs/gcp_pubsub.md
+++ b/website/docs/components/outputs/gcp_pubsub.md
@@ -66,6 +66,7 @@ output:
     publish_timeout: 1m0s
     metadata:
       exclude_prefixes: []
+    inject_tracing_map: meta = @.assign(this) # No default (optional)
     flow_control:
       max_outstanding_bytes: -1
       max_outstanding_messages: 1000
@@ -210,6 +211,21 @@ Provide a list of explicit metadata key prefixes to be excluded when adding meta
 
 Type: `array`  
 Default: `[]`  
+
+### `inject_tracing_map`
+
+EXPERIMENTAL: A [Bloblang mapping](/docs/guides/bloblang/about) used to inject an object containing tracing propagation information into outbound messages. The specification of the injected fields will match the format used by the service wide tracer.
+
+
+Type: `string`  
+
+```yml
+# Examples
+
+inject_tracing_map: meta = @.assign(this)
+
+inject_tracing_map: root.meta.span = this
+```
 
 ### `flow_control`
 


### PR DESCRIPTION

## What this adds

- `extract_tracing_map` and `new_root_span_with_link` fields on the `gcp_pubsub` input.
- `inject_tracing_map` field on the `gcp_pubsub` output.

All three use the existing generic tracing mechanism in `public/service/config_extract_tracing.go` and `public/service/config_inject_tracing.go`, so behavior and configuration match every other component that already exposes these fields.

## Motivation

GCP Pub/Sub users currently have no config-driven way to propagate a W3C trace context across a Pub/Sub hop. The generic extract/inject tracing mapping already exists in Bento and is wired into `kafka_franz` (added in v1.17.0), `kafka`, and the `nats` components, but `gcp_pubsub` was never wired up.

Pub/Sub messages carry attributes (a string key/value map), which is the natural carrier for trace context, analogous to Kafka record headers. The input already copies message attributes into Bento metadata, and the output already emits filtered metadata as attributes, so the standard mapping wrappers slot in without any component-specific tracing code.

This is a small parity change rather than a new capability, so no issue was opened first ‚I'm happy to open a tracking issue if that's preferred.

## How it mirrors the existing mechanism

- Input: registers `service.NewExtractTracingSpanMappingField()` plus its companion `service.NewRootSpanWithLinkField()` (every existing registrant pairs them: `nats`, `kafka`, `kafka_franz`), and wraps the reader with `conf.WrapInputExtractTracingSpanMapping("gcp_pubsub", r)` in the constructor. This mirrors `kafka_franz` (`internal/impl/kafka/input_kafka_franz.go`), adjusted for the single-message `RegisterInput` API (`WrapInput...` rather than `WrapBatchInput...`). The `new_root_span_with_link` version tag assumes the next release is 1.19.0 ‚Äî happy to adjust.
- Output: registers `service.NewInjectTracingSpanMappingField()` and wraps the writer with `conf.WrapBatchOutputExtractTracingSpanMapping("gcp_pubsub", out)`, matching the `kafka` output (`internal/impl/kafka/output_sarama_kafka.go`).

Ordering matches the Kafka precedent: on read, attributes are copied into metadata first and the extraction mapping runs against that populated state; on write, the injection mapping runs before the writer builds Pub/Sub attributes from metadata, so injected span fields flow through to the wire attributes.

The field descriptions and examples come from the shared field constructors, so wording stays consistent with the other components.

## Tests

- `go build ./...` passes.
- `go test ./internal/impl/gcp/...` passes.
- `gofmt -s`, `goimports -local github.com/warpstreamlabs/bento`, and `go vet` are clean on the changed files; the full `golangci-lint` run (`make lint`) was not available in this environment and is left to CI.
- `make docs` regenerated `website/docs/components/inputs/gcp_pubsub.md` and `website/docs/components/outputs/gcp_pubsub.md`; both are included in this PR.
- `make test-integration` was not run ‚ it requires the Pub/Sub emulator, which wasn't available in this environment (mentioning per CONTRIBUTING.md).

No new component-level tests were added, matching the existing convention: the tracing mapping mechanism is tested generically in `public/service/config_extract_tracing_test.go` and `public/service/config_inject_tracing_test.go`, and no component (`kafka_franz`, `kafka`, `nats`) ships its own tracing-map test.

Note: the `make docs` lint step reports pre-existing failures in unrelated DuckDB/SQL components that require a CGO build tag (`x_bento_extra`) not available in this environment. Those are unaffected by this change; only the two `gcp_pubsub` docs were regenerated.

## Checklist

- [x] Unit tested (`go test ./internal/impl/gcp/...`)
- [x] `go build ./...` passes
- [x] Formatted (`gofmt -s` + `goimports -local`; full `make fmt`/`make lint` left to CI as noted above)
- [x] Docs regenerated with `make docs`

No CHANGELOG entry is included: recent history shows changelog entries are batched by maintainers at release time rather than added in feature PRs.
