### PR TITLE
fix(aws_kinesis): don't panic when ListShards fails during shard collection

### DIFF
--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -723,7 +723,10 @@ func collectShards(ctx context.Context, arn string, svc *kinesis.Client) ([]type
 			StreamARN: streamARN,
 			NextToken: token,
 		})
-		return shardsRes.Shards, shardsRes.NextToken, err
+		if err != nil {
+			return nil, nil, err
+		}
+		return shardsRes.Shards, shardsRes.NextToken, nil
 	}
 
 	shardIter := helper.TokenIterator(listShardFn)


### PR DESCRIPTION
## Summary

The pagination closure in `collectShards` dereferences the `ListShards` response before checking the error, and the AWS SDK returns a **nil** response struct on error. As a result, any `ListShards` failure crashes the whole process with a nil pointer panic instead of surfacing an error to the rebalance loop (which already handles it correctly).

The most common trigger is routine shutdown: stopping the pipeline cancels the reader's context, an in-flight `ListShards` in the `runBalancedShards` rebalance loop returns `context.Canceled` with a nil response, and the process panics instead of exiting cleanly. Transient AWS errors (throttling, network blips) hit the same path.

Observed in production on v1.18.1:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x49ad065]
goroutine 2275 [running]:
github.com/warpstreamlabs/bento/internal/impl/aws.collectShards.func1(...)
	.../bento@v1.18.1/internal/impl/aws/input_kinesis.go:727
github.com/warpstreamlabs/bento/internal/impl/aws.collectShards.TokenIterator[...].func2(...)
github.com/warpstreamlabs/bento/internal/impl/aws/helper.Collect[...](...)
github.com/warpstreamlabs/bento/internal/impl/aws.(*kinesisReader).runBalancedShards(...)
```

Introduced in #532 (v1.18.0), which rewrote `collectShards` to use the token-iterator helper and dropped the error check the previous loop had.

## Fix

Check the error before touching the response, matching the standard AWS SDK v2 pattern.

Made with [Cursor](https://cursor.com)