### PR TITLE
fix(aws_kinesis): prevent busy-spin in shard consumer select loop

### DIFF
--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -519,9 +519,20 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 	var nextFlushChan chan<- asyncMessage
 	commitCtx, commitCtxClose := context.WithTimeout(k.ctx, k.commitPeriod)
 
+	// Reusable timers backing nextTimedBatchChan and nextPullChan. Reusing
+	// timers rather than calling time.After on every empty poll avoids
+	// allocating a new runtime timer per iteration, which is significant when
+	// running thousands of shard consumers.
+	timedBatchTimer := time.NewTimer(time.Hour)
+	timedBatchTimer.Stop()
+	pullTimer := time.NewTimer(time.Hour)
+	pullTimer.Stop()
+
 	go func() {
 		defer func() {
 			commitCtxClose()
+			timedBatchTimer.Stop()
+			pullTimer.Stop()
 			recordBatcher.Close(context.Background(), state == awsKinesisConsumerFinished)
 			boff.Reset()
 			k.boffPool.Put(boff)
@@ -565,7 +576,8 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 			if state == awsKinesisConsumerConsuming && len(pending) == 0 && nextPullChan == unblockedChan {
 				if pending, iter, err = k.getRecords(info, shardID, iter); err != nil {
 					if !awsErrIsTimeout(err) {
-						nextPullChan = time.After(boff.NextBackOff())
+						pullTimer.Reset(boff.NextBackOff())
+						nextPullChan = pullTimer.C
 
 						var aerr *types.ExpiredIteratorException
 						if errors.As(err, &aerr) {
@@ -581,7 +593,8 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 						}
 					}
 				} else if len(pending) == 0 {
-					nextPullChan = time.After(boff.NextBackOff())
+					pullTimer.Reset(boff.NextBackOff())
+					nextPullChan = pullTimer.C
 				} else {
 					boff.Reset()
 					nextPullChan = blockedChan
@@ -636,9 +649,22 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 			if nextTimedBatchChan == nil {
 				if tNext, exists := recordBatcher.UntilNext(); exists {
 					if len(pending) > 0 || recordBatcher.HasPendingMessage() {
-						nextTimedBatchChan = time.After(tNext)
+						timedBatchTimer.Reset(tNext)
+						nextTimedBatchChan = timedBatchTimer.C
 					}
 				}
+			}
+
+			// If we have a message ready for dispatch but the pipeline isn't
+			// keeping up then nextPullChan may be set to the permanently
+			// unblocked (closed) channel, in which case the select below would
+			// never block and this loop would spin hot without making any
+			// progress. Falling through the select is only productive when it
+			// leads to pulling more records, so suppress the pull case until
+			// the pending message has been flushed.
+			pullChan := nextPullChan
+			if pendingMsg.msg != nil && pullChan == unblockedChan {
+				pullChan = blockedChan
 			}
 
 			select {
@@ -664,7 +690,7 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 				nextTimedBatchChan = nil
 			case nextFlushChan <- pendingMsg:
 				pendingMsg = asyncMessage{}
-			case <-nextPullChan:
+			case <-pullChan:
 				nextPullChan = unblockedChan
 			case <-k.ctx.Done():
 				state = awsKinesisConsumerClosing


### PR DESCRIPTION
## Summary

With high shard counts (e.g. 1000 shards), the `aws_kinesis` input burned enormous amounts of CPU in `runtime.selectgo`, channel lock contention, and runtime timer management. Two causes, both in the per-shard consumer loop in `runConsumer`:

1. **Busy-spin on a closed channel.** The loop uses a permanently-closed channel (`unblockedChan`) as a "don't block" sentinel for the select. Whenever a consumer held a message that the shared unbuffered `msgChan` wasn't immediately ready to accept (which is the common case with many shards funneling into one channel), `nextPullChan` could be flipped to the closed channel, making the select **always ready** — the goroutine spun at full speed without making any progress until the flush succeeded. The fix suppresses the pull case while a message is pending dispatch, since falling through the select is only productive when it leads to pulling more records.

2. **Runtime timer churn.** `time.After` was called on every empty poll (backoff) and every timed-batch re-arm, allocating a new runtime timer each time across thousands of shard consumer goroutines. These are replaced with two reusable `time.Timer`s per consumer (safe to `Reset` without draining on Go 1.23+).

Profile from a consumer of a 1000-shard stream showing the select loop and timer towers dominating CPU before the fix (`runConsumer.func2` → `runtime.selectgo`/`lock2`/`futex` and `time.After`/`newTimer`/`maybeRunChan`).

No behavioral changes: all `nextPullChan` state transitions are preserved; the select can simply block now when no progress is possible.

## Testing

- `go build` / `go vet` clean, existing Kinesis unit tests pass.
- Verified by code-tracing all loop states: the masked pull case only applies when a pending message is awaiting dispatch, during which the consumer parks on the flush/commit/shutdown cases; commit (lease renewal) continues to fire while blocked.

Made with [Cursor](https://cursor.com)