### PR TITLE
fix(aws_kinesis): recover from partial Connect failures and nil checkpoint on steal

### DIFF
--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -969,7 +969,6 @@ func (k *kinesisReader) Connect(ctx context.Context) error {
 
 	k.svc = svc
 	k.checkpointer = checkpointer
-	k.msgChan = make(chan asyncMessage)
 
 	if err = k.waitUntilStreamsExists(ctx); err != nil {
 		return err
@@ -994,6 +993,14 @@ func (k *kinesisReader) Connect(ctx context.Context) error {
 			k.log.Debugf("Enhanced Fan Out consumer registered for stream %s with ARN: %s", stream.id, consumerARN)
 		}
 	}
+
+	// Only assign msgChan once everything above has succeeded, since a non-nil
+	// msgChan is what marks this reader as connected. Assigning it earlier
+	// meant a failure in the steps above left the reader permanently "connected"
+	// but without a running shard consumer, so subsequent Connect calls
+	// returned nil and ReadBatch blocked forever on a channel nothing writes
+	// to.
+	k.msgChan = make(chan asyncMessage)
 
 	if len(k.streams[0].explicitShards) > 0 {
 		go k.runExplicitShards()
@@ -1028,6 +1035,17 @@ func (k *kinesisReader) ReadBatch(ctx context.Context) (service.MessageBatch, se
 // CloseAsync shuts down the Kinesis input and stops processing requests.
 func (k *kinesisReader) Close(ctx context.Context) error {
 	k.done()
+
+	k.cMut.Lock()
+	if k.msgChan == nil {
+		// Connect never completed successfully, so there is no shard runner
+		// goroutine responsible for closing closedChan on our behalf.
+		k.closeOnce.Do(func() {
+			close(k.closedChan)
+		})
+	}
+	k.cMut.Unlock()
+
 	select {
 	case <-k.closedChan:
 	case <-ctx.Done():

--- a/internal/impl/aws/input_kinesis_checkpointer.go
+++ b/internal/impl/aws/input_kinesis_checkpointer.go
@@ -352,7 +352,9 @@ func (k *awsKinesisCheckpointer) Claim(ctx context.Context, streamID, shardID, f
 		if err != nil {
 			return "", err
 		}
-		startingSequence = cp.SequenceNumber
+		if cp != nil {
+			startingSequence = cp.SequenceNumber
+		}
 	}
 
 	return startingSequence, nil


### PR DESCRIPTION
## Summary

Two independent reliability fixes for the `aws_kinesis` input, found while auditing the component after the panic fixed in #925.

### 1. A failed first `Connect` permanently stalled the input

`Connect` assigned `k.msgChan` — the field that marks the reader as connected — *before* `waitUntilStreamsExists` and EFO consumer registration. If either failed (transient `DescribeStream` throttle, IAM hiccup, stream still being created), `Connect` returned the error, but every retried `Connect` after that hit the `if k.msgChan != nil { return nil }` guard and reported success without ever starting the shard runner goroutine. The result: `ReadBatch` blocked forever on a channel nothing writes to, and `Close` hung waiting for `closedChan`, which only the (never-started) runner closes. One transient AWS error at startup silently bricked the input until process restart.

`msgChan` is now assigned only after all setup has succeeded, immediately before spawning the runner, so a failed `Connect` leaves the reader cleanly disconnected and retryable. `Close` also now handles the never-connected case instead of waiting for a runner that doesn't exist.

### 2. Nil pointer panic in `Claim` after stealing a shard

Same crash class as #925. After stealing a shard, `Claim` waits out a grace period and re-reads the checkpoint to pick up the victim's final yielded sequence — but it dereferenced the result unconditionally, and `getCheckpoint` is documented to return a nil checkpoint with a nil error when the item does not exist. If the checkpoint row is gone by the time the thief re-reads it (e.g. the victim finished the shard and deleted its checkpoint, or DynamoDB returns `ResourceNotFoundException`), the rebalance goroutine panicked and took down the whole process.

`Claim` now falls back to the sequence captured from the steal's `ALL_OLD` return values, which preserves at-least-once delivery.

Made with [Cursor](https://cursor.com)