### PR TITLE
perf(bloblang): cache queryParser combinator tree per Context 

### DIFF
--- a/docs/20260717.md
+++ b/docs/20260717.md
@@ -1,0 +1,134 @@
+# Bloblang Parser 性能优化 / Bloblang Parser Performance Optimization
+
+日期 / Date: 2026-07-17
+
+## 背景 / Background
+
+**中文**：`internal/bloblang/parser` 使用手写的解析器组合子（parser combinator）实现 Bloblang 语法解析。分析发现 `queryParser(pCtx)` —— 整个语法树中最核心、递归调用最频繁的解析函数（27 处调用点，覆盖函数参数、括号表达式、`if`/`match`/lambda、切片索引等）—— 每次被调用都会重新构建整棵 `OneOf`/`Sequence`/`Delimited`/`arithmeticParser` 组合子闭包树，而不是构建一次复用多次。递归越深（嵌套 lambda、多层分支），重复构建的浪费越大。
+
+**English**: `internal/bloblang/parser` implements Bloblang syntax parsing using hand-written parser combinators. Profiling revealed that `queryParser(pCtx)` — the most central, most recursively-invoked parser function in the entire grammar (27 call sites, covering function arguments, bracket expressions, `if`/`match`/lambda expressions, slice indexing, etc.) — rebuilt its entire `OneOf`/`Sequence`/`Delimited`/`arithmeticParser` combinator closure tree from scratch on every single invocation, instead of being built once and reused. The deeper the recursion (nested lambdas, multi-branch logic), the more repeated-construction waste accumulated.
+
+实测基线（`BenchmarkMappingParser`，3 行简单赋值）/ Baseline measurement (3-line simple assignment mapping):
+
+```
+312936 ns/op   356586 B/op   10347 allocs/op
+```
+
+## 改动一：修复闭包变量遮蔽隐患（前置修复）/ Change 1: Fix Closure Variable Shadowing Hazard (Prerequisite Fix)
+
+**中文**：第一次尝试直接给 `queryParser` 加缓存后，`go test -race` 在真实回归测试中检测到数据竞争。根因：`lambdaExpressionParser(pCtx)` 返回的闭包在函数体内部执行 `pCtx = pCtx.WithNamedContext(name)`，对闭包捕获的外层变量做重新赋值。没有缓存时每次调用都是全新闭包各自持有独立副本，天然安全；一旦闭包被缓存复用，多个 goroutine 并发调用同一闭包实例，对同一个被捕获变量并发读写，导致 named context 链污染（"context label would shadow a parent context" 误判）。
+
+修复方式：改用局部变量 `localCtx` 承接 `WithNamedContext` 的结果，不再修改闭包捕获的 `pCtx`。逐字节输出结果不变，纯粹是内部状态管理方式的调整。
+
+系统性排查确认：全包（`combinators.go` 全部组合子 + 所有解析器构造函数）只有这一处违反"闭包构建后不可变"的契约。
+
+**English**: The first attempt to cache `queryParser` directly triggered a data race detected by `go test -race` in real regression tests. Root cause: the closure returned by `lambdaExpressionParser(pCtx)` executed `pCtx = pCtx.WithNamedContext(name)` inside its body, reassigning the outer variable captured by the closure. Without caching, every call produced a brand-new closure with its own independent copy — inherently safe. Once the closure was cached and reused, multiple goroutines calling the same closure instance concurrently would race on reads/writes to the same captured variable, corrupting the named-context chain (causing false "context label would shadow a parent context" errors).
+
+Fix: introduced a local variable `localCtx` to hold the result of `WithNamedContext`, no longer mutating the captured `pCtx`. Output is byte-for-byte identical; this is purely an internal state-management adjustment.
+
+A systematic sweep confirmed this was the *only* place in the entire package (all combinators in `combinators.go` plus every parser constructor function) that violated the "closure is immutable after construction" contract.
+
+- 文件 / File: `internal/bloblang/parser/query_expression_parser.go`
+- 验证 / Verification: 不依赖缓存机制的最小竞态复现测试（`-race -count=30` 全绿）/ Minimal race-reproduction test independent of any caching mechanism (`-race -count=30`, all green)
+
+## 改动二：Context 级 `queryParser` 解析器缓存 / Change 2: Context-Scoped `queryParser` Cache
+
+**中文**：在确认闭包状态安全后，给 `Context` 增加一个按身份（`Functions`/`Methods` 指针 + `namedContext` 链）区分的缓存。`queryParser` 查缓存，未命中才构建并存入，命中则直接复用已构建的闭包树。`Deactivated()`（切换 `Functions`/`Methods` 指针）会重建独立缓存，避免脏共享。
+
+**English**: With closure-state safety confirmed, a cache keyed by Context identity (the `Functions`/`Methods` pointers plus the `namedContext` chain) was added to `Context`. `queryParser` checks the cache first; on a miss it builds and stores the tree, on a hit it reuses the already-built closure tree directly. `Deactivated()` (which swaps the `Functions`/`Methods` pointers) rebuilds an independent cache to avoid stale cross-contamination.
+
+- 文件 / Files: `internal/bloblang/parser/context.go`, `query_parser.go`
+- 并发安全 / Concurrency safety: `sync.Mutex` 保护的 map，`-race` 验证通过 / `sync.Mutex`-guarded map, verified with `-race`
+
+## 改动三：cacheKey 结构体化 / Change 3: Struct-Based Cache Key
+
+**中文**：Profile 显示 `cacheKey()` 用 `fmt.Fprintf("%p|%p", ...)` 格式化指针地址为字符串，走反射格式化路径，即使缓存命中也要付出这个成本。改为 `cacheKeyT{functions, methods unsafe.Pointer, namedChain string}` 结构体直接做 map key（`unsafe.Pointer` 仅作不透明可比较值使用，不做指针运算/解引用），省掉了指针格式化的反射开销。`namedContext` 链本身仍需拼字符串（运行时可变长度无法用固定结构体字段表示）。
+
+**English**: Profiling showed `cacheKey()` formatted pointer addresses into a string via `fmt.Fprintf("%p|%p", ...)`, which goes through reflection-based formatting — a cost paid even on cache hits. Replaced with a `cacheKeyT{functions, methods unsafe.Pointer, namedChain string}` struct used directly as the map key (`unsafe.Pointer` used purely as an opaque comparable value, no pointer arithmetic or dereferencing), eliminating the reflection-based pointer-formatting overhead. The `namedContext` chain itself still needs to be flattened into a string since its length/content is only known at runtime.
+
+- 文件 / File: `internal/bloblang/parser/context.go`
+
+## 改动四：`ParseMapping` 前瞻短路 / Change 4: `ParseMapping` Lookahead Short-Circuit
+
+**中文**：`ParseMapping` 对每个输入无条件先尝试 `singleRootImport`（`from "..."` 单行导入语法），哪怕输入根本不是这种语法。新增 `mightBeSingleRootImport()` 前瞻判断，复用 `singleRootImport` 自身开头所用的真实组合子（`DiscardedWhitespaceNewlineComments` + `Term("from")`）做检测，只有可能匹配时才继续完整尝试，避免了非 import 场景下的无谓解析开销。
+
+**English**: `ParseMapping` unconditionally attempted `singleRootImport` (the `from "..."` single-line import syntax) for every input, even when the input clearly wasn't that syntax. Added a `mightBeSingleRootImport()` lookahead check that reuses the exact same combinators `singleRootImport` itself starts with (`DiscardedWhitespaceNewlineComments` + `Term("from")`), only proceeding with the full attempt when a match is plausible — eliminating wasted parsing work for the common non-import case.
+
+- 文件 / File: `internal/bloblang/parser/mapping_parser.go`
+
+## 验证 / Verification
+
+**中文**：
+- 每个改动均遵循 TDD：先写红灯测试，再实现，验证转绿
+- 竞态复现测试（`lambda_race_test.go`）、缓存行为测试（`query_parser_cache_test.go`）、前瞻短路差分测试（`mapping_parser_shortcircuit_test.go`）
+- 新增真实数据执行测试 `TestComplexMappingExecutesCorrectly`：用真实 JSON 输入执行含嵌套 lambda/match/if-else 的复杂 mapping，断言业务结果而非仅判断解析是否成功
+- 全量回归测试（`internal/bloblang/...` + `internal/impl/pure/...` + `public/bloblang/...`，含 `-race`）保持绿灯，语法规则零改动
+
+**English**:
+- Every change followed TDD: red test first, then implementation, then verified green
+- Race-reproduction test (`lambda_race_test.go`), cache-behaviour tests (`query_parser_cache_test.go`), lookahead differential test (`mapping_parser_shortcircuit_test.go`)
+- Added `TestComplexMappingExecutesCorrectly`: executes a complex mapping (nested lambdas/match/if-else) against real JSON input and asserts on actual business results, not just parse success
+- Full regression suite (`internal/bloblang/...` + `internal/impl/pure/...` + `public/bloblang/...`, with `-race`) remained green throughout; zero changes to grammar/syntax rules
+
+## 性能收益 / Performance Results
+
+基准环境 / Benchmark environment: Apple M4, `go test -bench -benchmem -count=3`
+
+### 简单场景（3 行赋值）/ Simple Scenario (3-line assignment)
+
+| 指标 / Metric | 基线 / Baseline | 优化后 / Optimized | 降幅 / Reduction |
+|---|---|---|---|
+| ns/op（新建 Context / new Context） | 314122~329369 | 149869~150688 | ~53.9% |
+| ns/op（复用 Context / reused Context） | 302239~304384 | 135511~135599 | ~55.3% |
+| allocs/op | 10347 | 3967~4226 | ~59-62% |
+| B/op | 356586 | 133753~141026 | ~60-62% |
+
+### 复杂场景（13 行，含嵌套 lambda/match/if-else/链式调用）/ Complex Scenario (13 lines, nested lambda/match/if-else/chained calls)
+
+| 指标 / Metric | 基线 / Baseline | 优化后 / Optimized | 降幅 / Reduction |
+|---|---|---|---|
+| ns/op（新建 Context / new Context） | 2659318~2753777 | 1138907~1140791 | ~57.8% |
+| ns/op（复用 Context / reused Context） | 2720088~3019012 | 1118293~1119874 | ~61.5% |
+| allocs/op | 84495 | 31457 | ~62.8% |
+
+### 端到端（解析 + 真实数据执行）/ End-to-End (Parse + Execute with Real Data)
+
+| 场景 / Scenario | 基线 ns/op | 优化后 ns/op | 降幅 / Reduction |
+|---|---|---|---|
+| 解析 + 执行 / Parse + Execute | 2939197~3075917 | 1178630~1191650 | ~59.9% |
+| 仅执行（解析在循环外完成）/ Execute only (parsed once outside loop) | 27040~28284 | 24150~24878 | ~11.6%（噪声范围 / within noise） |
+
+## 重要适用边界 / Important Scope Boundary
+
+**中文**：本次优化只作用于**解析阶段**（`ParseMapping`），对**执行阶段**（`Executor.Exec`/`MapPart`）零影响——这是设计上如此，缓存的是"如何构建 `query.Function` 树"，不影响"树如何被求值"。
+
+对于典型生产场景——mapping 只在启动时解析一次，之后长期复用同一个 `*mapping.Executor` 处理海量消息流——本次优化几乎没有可观察的收益，因为解析只发生一次，真正的热路径在 `Exec`。
+
+本次优化真正有价值的场景：mapping 被**频繁重新解析**，例如 Bloblang REPL/playground 交互式编辑、CI 阶段批量校验大量 mapping 语法、动态路由规则频繁变更并重新编译、测试套件中大量重复调用 `ParseMapping`。
+
+**English**: This optimization only affects the **parsing phase** (`ParseMapping`) and has zero impact on the **execution phase** (`Executor.Exec`/`MapPart`) — by design, since the cache addresses "how the `query.Function` tree is built," not "how that tree is evaluated."
+
+For the typical production scenario — a mapping is parsed once at startup and the same `*mapping.Executor` is reused to process an unbounded stream of messages — this optimization yields no observable benefit, since parsing happens only once and the actual hot path is `Exec`.
+
+This optimization is genuinely valuable in scenarios where mappings are **re-parsed frequently**: interactive Bloblang REPL/playground editing, CI-stage bulk validation of many mapping syntaxes, dynamic routing rules that are frequently changed and recompiled, or test suites that call `ParseMapping` repeatedly.
+
+## 未纳入本次范围的优化点 / Optimizations Not Included in This Round
+
+**中文**：
+1. **`NewError` 懒构造**（占 profile 中 ~13% 分配）：`OneOf` 尝试候选分支失败时构造的 `*Error` 对象即使最终成功也已分配。收益最大但改动面广，涉及大量断言具体错误消息文本的存量测试，风险较高，建议单独评估。
+2. **子解析器缓存范围扩展**（`functionArgsParser`/`methodParser`/`matchCaseParser` 等）：这些函数目前不在缓存范围内，每次被父解析器调用仍会重新构建。复杂度更高（部分函数依赖运行时参数如 `fn query.Function`，需要更复杂的 key 设计），收益相对边际，暂不推荐。
+
+**English**:
+1. **Lazy `NewError` construction** (~13% of allocations in profiling): `*Error` objects constructed by failed `OneOf` branch attempts are allocated even when a later branch succeeds. Highest potential payoff but broad blast radius — touches many existing tests that assert exact error message text. Recommended as a separate, carefully-scoped effort.
+2. **Extending the cache to sub-parsers** (`functionArgsParser`/`methodParser`/`matchCaseParser`, etc.): these are not currently cached and are still rebuilt on every call from their parent parser. Higher complexity (some depend on runtime parameters like `fn query.Function`, requiring a more complex cache key), with comparatively marginal payoff. Not recommended at this time.
+
+## 改动文件清单 / Changed Files
+
+- `internal/bloblang/parser/context.go` — Context 缓存字段、cacheKeyT 结构体 / Context cache field, cacheKeyT struct
+- `internal/bloblang/parser/query_parser.go` — queryParser 缓存查询/存储逻辑 / queryParser cache lookup/store logic
+- `internal/bloblang/parser/query_expression_parser.go` — lambdaExpressionParser 闭包变量遮蔽修复 / lambdaExpressionParser closure shadowing fix
+- `internal/bloblang/parser/mapping_parser.go` — ParseMapping 前瞻短路 / ParseMapping lookahead short-circuit
+- `internal/bloblang/parser/mapping_parser_test.go` — 新增复杂场景 benchmark 与真实数据执行测试 / new complex-scenario benchmarks and real-data execution test
+- `internal/bloblang/parser/lambda_race_test.go`（新增 / new）— 竞态复现测试 / race-reproduction test
+- `internal/bloblang/parser/query_parser_cache_test.go`（新增 / new）— 缓存行为测试 / cache-behaviour tests
+- `internal/bloblang/parser/mapping_parser_shortcircuit_test.go`（新增 / new）— 前瞻短路差分测试 / lookahead short-circuit differential test

--- a/internal/bloblang/parser/context.go
+++ b/internal/bloblang/parser/context.go
@@ -5,6 +5,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
+	"unsafe"
 
 	"github.com/warpstreamlabs/bento/internal/bloblang/query"
 )
@@ -16,6 +19,96 @@ type Context struct {
 	Methods      *query.MethodSet
 	namedContext *namedContext
 	importer     Importer
+
+	// cache holds parsers built for a given Context identity (Functions,
+	// Methods and namedContext chain) so that recursive/repeated calls to
+	// queryParser don't rebuild the same combinator tree on every
+	// invocation. It is shared across Context values derived from one
+	// another via WithNamedContext, since those calls don't change
+	// Functions/Methods. Contexts that swap Functions/Methods (e.g.
+	// Deactivated) get a fresh cache to avoid stale/incorrect reuse.
+	//
+	// Safety note: this cache is only sound because every parser closure
+	// built by this package treats its captured Context as immutable after
+	// construction (no closure reassigns a captured Context variable at
+	// call time). See lambdaExpressionParser for the one historical
+	// exception, fixed to use a local variable instead.
+	cache *parserCache
+}
+
+// cacheKeyT is a comparable identity for a Context, derived from the fields
+// that actually influence how a parser is constructed: the Functions/
+// Methods set identities (compared by pointer value, not formatted into a
+// string) and the namedContext chain flattened into a string. Using a
+// struct instead of a formatted string avoids the cost of fmt.Fprintf's
+// reflection-based pointer formatting on every cache lookup, which shows up
+// as measurable overhead even on cache hits.
+type cacheKeyT struct {
+	functions unsafe.Pointer
+	methods   unsafe.Pointer
+	namedChain string
+}
+
+// parserCache is a concurrency-safe store of built parsers keyed by a
+// Context's identity. It's intentionally untyped (map[cacheKeyT]any) so it
+// can hold parsers of different result types (e.g. Func[query.Function])
+// without requiring a cache per type.
+type parserCache struct {
+	mu    sync.Mutex
+	byKey map[cacheKeyT]any
+}
+
+func newParserCache() *parserCache {
+	return &parserCache{byKey: make(map[cacheKeyT]any)}
+}
+
+// cacheKey returns a comparable identity for the Context derived from the
+// fields that actually influence how a parser is constructed: the
+// Functions/Methods set identities (compared by pointer) and the
+// namedContext chain. The importer is deliberately excluded since it only
+// affects how `import` statements read files, not how query expressions are
+// parsed.
+func (pCtx Context) cacheKey() cacheKeyT {
+	key := cacheKeyT{
+		functions: unsafe.Pointer(pCtx.Functions),
+		methods:   unsafe.Pointer(pCtx.Methods),
+	}
+	if pCtx.namedContext != nil {
+		var sb strings.Builder
+		for nc := pCtx.namedContext; nc != nil; nc = nc.next {
+			sb.WriteByte('|')
+			sb.WriteString(nc.name)
+		}
+		key.namedChain = sb.String()
+	}
+	return key
+}
+
+// cachedParser looks up a previously built parser for the given cache key.
+func cachedParser[T any](pCtx Context, key cacheKeyT) (Func[T], bool) {
+	if pCtx.cache == nil {
+		return nil, false
+	}
+	pCtx.cache.mu.Lock()
+	defer pCtx.cache.mu.Unlock()
+	v, ok := pCtx.cache.byKey[key]
+	if !ok {
+		return nil, false
+	}
+	fn, ok := v.(Func[T])
+	return fn, ok
+}
+
+// storeParser stores a built parser under the given cache key for later
+// reuse. If the Context has no cache (e.g. a zero-value Context constructed
+// directly rather than via EmptyContext/GlobalContext) this is a no-op.
+func storeParser[T any](pCtx Context, key cacheKeyT, fn Func[T]) {
+	if pCtx.cache == nil {
+		return
+	}
+	pCtx.cache.mu.Lock()
+	defer pCtx.cache.mu.Unlock()
+	pCtx.cache.byKey[key] = fn
 }
 
 // EmptyContext returns a parser context with no functions, methods or import
@@ -25,6 +118,7 @@ func EmptyContext() Context {
 		Functions: query.NewFunctionSet(),
 		Methods:   query.NewMethodSet(),
 		importer:  newOSImporter(),
+		cache:     newParserCache(),
 	}
 }
 
@@ -35,6 +129,7 @@ func GlobalContext() Context {
 		Functions: query.AllFunctions,
 		Methods:   query.AllMethods,
 		importer:  newOSImporter(),
+		cache:     newParserCache(),
 	}
 }
 
@@ -98,6 +193,11 @@ func (pCtx Context) Deactivated() Context {
 	nextCtx := pCtx
 	nextCtx.Functions = pCtx.Functions.Deactivated()
 	nextCtx.Methods = pCtx.Methods.Deactivated()
+	// Functions/Methods identities changed, so any parser cached under the
+	// old identity is not valid for this context (and vice versa). Use a
+	// fresh cache to avoid cross-contamination between active/deactivated
+	// contexts.
+	nextCtx.cache = newParserCache()
 	return nextCtx
 }
 

--- a/internal/bloblang/parser/lambda_race_test.go
+++ b/internal/bloblang/parser/lambda_race_test.go
@@ -1,0 +1,58 @@
+package parser
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLambdaExpressionParserConcurrentSharedClosure reproduces a data race
+// in lambdaExpressionParser independent of any caching mechanism: it builds
+// the parser closure exactly once (as a future Context-level cache would)
+// and then invokes that single closure instance from multiple goroutines
+// concurrently, each parsing a different lambda expression with a distinct
+// context label.
+//
+// lambdaExpressionParser's returned closure currently does:
+//
+//	pCtx = pCtx.WithNamedContext(name)
+//
+// which reassigns the pCtx variable captured from the enclosing
+// lambdaExpressionParser(pCtx) call. When the same closure instance is
+// invoked concurrently, this is a write to a shared variable racing against
+// concurrent reads (HasNamedContext checks) and writes from other
+// goroutines, corrupting the named-context chain used for shadow detection.
+//
+// Run with -race to observe the failure.
+func TestLambdaExpressionParserConcurrentSharedClosure(t *testing.T) {
+	pCtx := GlobalContext()
+
+	// Build the closure ONCE, simulating what a Context-level cache for
+	// queryParser would do: construct lambdaExpressionParser(pCtx) a single
+	// time and have all callers share that one instance.
+	sharedParser := lambdaExpressionParser(pCtx)
+
+	names := []string{"v", "item", "ele", "num", "patron", "foo", "bar", "baz"}
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(names))
+	for i, n := range names {
+		i, n := i, n
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			expr := fmt.Sprintf(`%s -> %s.uppercase()`, n, n)
+			res := sharedParser([]rune(expr))
+			if res.Err != nil {
+				errs[i] = fmt.Errorf("name=%s: %s", n, res.Err.Error())
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		assert.NoError(t, err, "a lambda expression with its own distinct context label must never fail with a shadow error when parsed concurrently against a shared closure instance")
+	}
+}

--- a/internal/bloblang/parser/mapping_parser.go
+++ b/internal/bloblang/parser/mapping_parser.go
@@ -19,12 +19,23 @@ import (
 func ParseMapping(pCtx Context, expr string) (*mapping.Executor, *Error) {
 	in := []rune(expr)
 
-	resDirectImport := singleRootImport(pCtx)(in)
-	if resDirectImport.Err != nil && resDirectImport.Err.IsFatal() {
-		return nil, resDirectImport.Err
-	}
-	if resDirectImport.Err == nil && len(resDirectImport.Remaining) == 0 {
-		return resDirectImport.Payload, nil
+	// Fast-path pre-check: singleRootImport only ever succeeds when the
+	// input (after leading whitespace/comments) begins with the `from`
+	// keyword. Skipping the attempt entirely for inputs that can't possibly
+	// match avoids constructing/running its parser combinators (including a
+	// recursive parseExecutor call on failure) for the common case of
+	// regular mappings. This performs the exact same
+	// DiscardedWhitespaceNewlineComments + Term("from") check that
+	// singleRootImport itself starts with, so it can't diverge from its
+	// real parsing semantics.
+	if mightBeSingleRootImport(in) {
+		resDirectImport := singleRootImport(pCtx)(in)
+		if resDirectImport.Err != nil && resDirectImport.Err.IsFatal() {
+			return nil, resDirectImport.Err
+		}
+		if resDirectImport.Err == nil && len(resDirectImport.Remaining) == 0 {
+			return resDirectImport.Payload, nil
+		}
 	}
 
 	resExe := parseExecutor(pCtx)(in)
@@ -38,6 +49,16 @@ func ParseMapping(pCtx Context, expr string) (*mapping.Executor, *Error) {
 		return nil, res.Err
 	}
 	return res.Payload, nil
+}
+
+// mightBeSingleRootImport reports whether input could possibly be parsed by
+// singleRootImport, without running the full import parser (which reads
+// files and builds a nested executor on success). It mirrors exactly the
+// leading sequence singleRootImport itself requires: optional whitespace/
+// comments followed by the `from` keyword.
+func mightBeSingleRootImport(input []rune) bool {
+	res := DiscardedWhitespaceNewlineComments(input)
+	return Term("from")(res.Remaining).Err == nil
 }
 
 //------------------------------------------------------------------------------

--- a/internal/bloblang/parser/mapping_parser_shortcircuit_test.go
+++ b/internal/bloblang/parser/mapping_parser_shortcircuit_test.go
@@ -1,0 +1,134 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseMappingImportShortCircuit verifies that ParseMapping's fast-path
+// pre-check (skip attempting singleRootImport unless the input could
+// plausibly be a `from "..."` single-root-import) does not change parsing
+// behaviour for any of: a bare import, an import preceded by whitespace/
+// comments, and inputs that must NOT be treated as an import (regular
+// mappings, mappings that merely contain the substring "from" elsewhere,
+// empty input, whitespace-only input).
+func TestParseMappingImportShortCircuit(t *testing.T) {
+	dir := t.TempDir()
+	importedPath := filepath.Join(dir, "imported.blobl")
+	require.NoError(t, os.WriteFile(importedPath, []byte(`root.imported = true`), 0o644))
+
+	tests := map[string]struct {
+		mapping   string
+		expectErr bool
+	}{
+		"bare import": {
+			mapping: `from "` + importedPath + `"`,
+		},
+		"import with leading whitespace": {
+			mapping: "   \n  from \"" + importedPath + "\"",
+		},
+		"import with leading comment": {
+			mapping: "# a comment\nfrom \"" + importedPath + "\"",
+		},
+		"import with leading blank lines and comments mixed": {
+			mapping: "\n# one\n\n# two\n   from \"" + importedPath + "\"",
+		},
+		"regular mapping starting with root": {
+			mapping: `root.foo = this.bar`,
+		},
+		"regular mapping mentioning from in a string": {
+			mapping: `root.foo = "from the start"`,
+		},
+		"regular mapping mentioning from as an identifier-like substring": {
+			mapping: `let fromage = this.bar
+root.foo = $fromage`,
+		},
+		"single expression shorthand": {
+			mapping: `this.foo.uppercase()`,
+		},
+		"let statement": {
+			mapping: `let x = 5
+root.foo = $x`,
+		},
+		"malformed import missing quotes": {
+			mapping:   `from bad`,
+			expectErr: true,
+		},
+		"empty input": {
+			mapping:   ``,
+			expectErr: true,
+		},
+		"whitespace only input": {
+			mapping:   "   \n  \n",
+			expectErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			exec, err := ParseMapping(GlobalContext(), test.mapping)
+			if test.expectErr {
+				assert.NotNil(t, err, "expected an error for mapping: %q", test.mapping)
+				return
+			}
+			require.Nil(t, err, "unexpected error for mapping: %q", test.mapping)
+			require.NotNil(t, exec)
+		})
+	}
+}
+
+// TestParseMappingImportShortCircuitMatchesUnconditionalAttempt is a
+// differential test: it parses a table of mappings both via the public
+// ParseMapping (which applies the fast-path pre-check) and via a direct,
+// unconditional call chain equivalent to the pre-optimisation behaviour,
+// and asserts both produce the same success/failure outcome. This guards
+// against the pre-check silently diverging from ParseMapping's original
+// unconditional-attempt semantics for any input shape.
+func TestParseMappingImportShortCircuitMatchesUnconditionalAttempt(t *testing.T) {
+	inputs := []string{
+		`from "nonexistent.blobl"`,
+		"  \n from \"nonexistent.blobl\"",
+		"# comment\nfrom \"nonexistent.blobl\"",
+		`root.foo = this.bar`,
+		`this.foo.uppercase()`,
+		``,
+		"   ",
+		`meta foo = this.bar`,
+		`map foo { root = this }`,
+		`from`,
+		`fromfoo = this.bar`,
+	}
+
+	pCtx := GlobalContext()
+	for _, in := range inputs {
+		rn := []rune(in)
+
+		// Unconditional attempt, mirroring ParseMapping's pre-optimisation
+		// control flow exactly.
+		var wantErr bool
+		resDirectImport := singleRootImport(pCtx)(rn)
+		if resDirectImport.Err != nil && resDirectImport.Err.IsFatal() {
+			wantErr = true
+		} else if resDirectImport.Err == nil && len(resDirectImport.Remaining) == 0 {
+			wantErr = false
+		} else {
+			resExe := parseExecutor(pCtx)(rn)
+			if resExe.Err != nil && resExe.Err.IsFatal() {
+				wantErr = true
+			} else {
+				resSingle := singleRootMapping(pCtx)(rn)
+				res := bestMatch(resExe, resSingle)
+				wantErr = res.Err != nil
+			}
+		}
+
+		_, err := ParseMapping(pCtx, in)
+		gotErr := err != nil
+
+		assert.Equal(t, wantErr, gotErr, "mismatch for input %q", in)
+	}
+}

--- a/internal/bloblang/parser/mapping_parser_test.go
+++ b/internal/bloblang/parser/mapping_parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -594,6 +595,229 @@ root.baz = this.baz.slice(0, 10)
 `)
 		if err != nil {
 			b.Error(err.Error())
+		}
+	}
+}
+
+// BenchmarkMappingParserReusedContext measures parsing performance when the
+// same Context (and therefore the same parser cache) is reused across
+// parses, which reflects how a long-running service typically uses a single
+// bloblang Environment/Context to parse many mappings over its lifetime.
+func BenchmarkMappingParserReusedContext(b *testing.B) {
+	pCtx := GlobalContext()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseMapping(pCtx, `
+root.foo = this.foo.uppercase()
+root.bar = this.bar.lowercase()
+root.baz = this.baz.slice(0, 10)
+`)
+		if err != nil {
+			b.Error(err.Error())
+		}
+	}
+}
+
+// complexMapping exercises deeply recursive/branching syntax: nested lambda
+// expressions (map_each/filter/sort_by), multiple if/else if/else chains,
+// a match expression, and many chained method/function calls across many
+// assignment statements. This is representative of real-world mappings that
+// are far more demanding on the parser than a handful of flat assignments.
+const complexMapping = `
+let threshold = 10
+
+root.id = this.id
+root.name = this.name.trim().capitalize()
+root.tags = this.tags.map_each(t -> t.lowercase().trim())
+root.active_items = this.items.filter(item -> item.status == "active" && item.qty > 0)
+root.sorted_items = this.items.filter(item -> item.qty > 0).sort_by(item -> item.priority)
+root.total = this.items.map_each(item -> item.price * item.qty).sum()
+root.grouped = this.items.map_each(entry -> {
+  "id": entry.id,
+  "label": entry.name.uppercase(),
+  "flag": entry.qty > $threshold,
+})
+
+root.status = match this.status {
+  this == "pending" => "PENDING"
+  this == "active" => "ACTIVE"
+  this == "done" => "DONE"
+  _ => "UNKNOWN"
+}
+
+if this.type == "a" {
+  root.category = "Alpha"
+} else if this.type == "b" {
+  root.category = "Beta"
+} else if this.type == "c" {
+  root.category = "Gamma"
+} else {
+  root.category = "Other"
+}
+
+root.nested = this.groups.map_each(group -> group.members.filter(m -> m.active).map_each(m -> m.name.uppercase()))
+root.summary = "%s has %v active items worth %v".format(this.name, root.active_items.length(), root.total)
+meta processed = true
+`
+
+// BenchmarkMappingParserComplex measures parsing performance for a mapping
+// with realistic complexity: nested lambdas, match/if branching, chained
+// method calls and many statements. This is the scenario where the
+// queryParser cache is expected to matter most, since deep recursion is
+// exactly where the pre-cache implementation rebuilt combinator trees
+// repeatedly.
+func BenchmarkMappingParserComplex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := ParseMapping(GlobalContext(), complexMapping)
+		if err != nil {
+			b.Error(err.Error())
+		}
+	}
+}
+
+// BenchmarkMappingParserComplexReusedContext is the reused-Context
+// counterpart to BenchmarkMappingParserComplex, reflecting a long-running
+// service parsing many complex mappings against a single Environment.
+func BenchmarkMappingParserComplexReusedContext(b *testing.B) {
+	pCtx := GlobalContext()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseMapping(pCtx, complexMapping)
+		if err != nil {
+			b.Error(err.Error())
+		}
+	}
+}
+
+// complexMappingInput is realistic JSON input for complexMapping, used to
+// exercise the executor (not just the parser) against real data: multiple
+// items with varying status/qty/priority, nested groups with active/inactive
+// members, and a status value that exercises every match case.
+const complexMappingInput = `{
+  "id": "order-42",
+  "name": "  acme order  ",
+  "status": "active",
+  "type": "b",
+  "tags": [" URGENT ", " Fragile "],
+  "items": [
+    {"id": "i1", "name": "widget", "status": "active", "qty": 3, "price": 10.5, "priority": 2},
+    {"id": "i2", "name": "gadget", "status": "inactive", "qty": 0, "price": 5.0, "priority": 1},
+    {"id": "i3", "name": "gizmo", "status": "active", "qty": 1, "price": 20.0, "priority": 5}
+  ],
+  "groups": [
+    {"members": [{"name": "alice", "active": true}, {"name": "bob", "active": false}]},
+    {"members": [{"name": "carol", "active": true}]}
+  ]
+}`
+
+// TestComplexMappingExecutesCorrectly parses complexMapping and executes it
+// against real message data, asserting on the actual output content and
+// metadata rather than just checking for a nil parse error. This is the
+// gap left by the pure-parsing benchmarks/tests: this test exercises the
+// full parse -> build executor -> Exec pipeline with real business logic
+// (map_each/filter/sort_by/match/if-else/format), and is used to prove the
+// cache changes don't alter runtime behaviour, not just parse success.
+func TestComplexMappingExecutesCorrectly(t *testing.T) {
+	exec, perr := ParseMapping(GlobalContext(), complexMapping)
+	require.Nil(t, perr)
+
+	msg := message.QuickBatch([][]byte{[]byte(complexMappingInput)})
+
+	resPart, err := exec.MapPart(0, msg)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(resPart.AsBytes(), &got))
+
+	assert.Equal(t, "order-42", got["id"])
+	assert.Equal(t, "Acme Order", got["name"])
+	assert.Equal(t, []any{"urgent", "fragile"}, got["tags"])
+	assert.Equal(t, "ACTIVE", got["status"])
+	assert.Equal(t, "Beta", got["category"])
+
+	activeItems, ok := got["active_items"].([]any)
+	require.True(t, ok)
+	assert.Len(t, activeItems, 2, "only i1 and i3 are status=active with qty>0")
+
+	sortedItems, ok := got["sorted_items"].([]any)
+	require.True(t, ok)
+	require.Len(t, sortedItems, 2)
+	firstSorted := sortedItems[0].(map[string]any)
+	assert.Equal(t, "i1", firstSorted["id"], "i2 is filtered out by qty>0; remaining i1(priority=2) sorts before i3(priority=5)")
+
+	// total = sum(price*qty) across ALL items (10.5*3 + 5.0*0 + 20.0*1) = 51.5
+	assert.InDelta(t, 51.5, got["total"], 0.0001)
+
+	grouped, ok := got["grouped"].([]any)
+	require.True(t, ok)
+	require.Len(t, grouped, 3)
+	firstGroup := grouped[0].(map[string]any)
+	assert.Equal(t, "i1", firstGroup["id"])
+	assert.Equal(t, "WIDGET", firstGroup["label"])
+	assert.Equal(t, false, firstGroup["flag"], "qty=3 is not > threshold=10")
+
+	nested, ok := got["nested"].([]any)
+	require.True(t, ok)
+	require.Len(t, nested, 2)
+	assert.Equal(t, []any{"ALICE"}, nested[0], "only alice is active in group 1")
+	assert.Equal(t, []any{"CAROL"}, nested[1], "only carol is active in group 2")
+
+	assert.Contains(t, got["summary"], "acme order")
+	assert.Contains(t, got["summary"], "2 active items")
+
+	processedMeta, exists := resPart.MetaGetMut("processed")
+	require.True(t, exists)
+	assert.Equal(t, true, processedMeta)
+}
+
+// BenchmarkMappingExecComplex measures the full end-to-end cost of parsing
+// AND executing complexMapping against real input data, as opposed to the
+// parse-only benchmarks above. The queryParser cache only affects the parse
+// phase, so this benchmark shows how much of the total (parse + execute)
+// cost the cache improvement actually addresses in a realistic workload.
+func BenchmarkMappingExecComplex(b *testing.B) {
+	inputBytes := []byte(complexMappingInput)
+	for i := 0; i < b.N; i++ {
+		exec, perr := ParseMapping(GlobalContext(), complexMapping)
+		if perr != nil {
+			b.Fatal(perr.Error())
+		}
+		msg := message.QuickBatch([][]byte{inputBytes})
+		if _, err := exec.MapPart(0, msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkMappingExecComplexReusedContext is the reused-Context counterpart
+// to BenchmarkMappingExecComplex.
+func BenchmarkMappingExecComplexReusedContext(b *testing.B) {
+	pCtx := GlobalContext()
+	inputBytes := []byte(complexMappingInput)
+	for i := 0; i < b.N; i++ {
+		exec, perr := ParseMapping(pCtx, complexMapping)
+		if perr != nil {
+			b.Fatal(perr.Error())
+		}
+		msg := message.QuickBatch([][]byte{inputBytes})
+		if _, err := exec.MapPart(0, msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkMappingExecOnlyComplex measures ONLY the execution cost (parsing
+// once outside the loop), isolating how much of the total pipeline cost is
+// unaffected by the parser cache. Comparing this against
+// BenchmarkMappingExecComplex shows the parse:execute cost ratio.
+func BenchmarkMappingExecOnlyComplex(b *testing.B) {
+	exec, perr := ParseMapping(GlobalContext(), complexMapping)
+	if perr != nil {
+		b.Fatal(perr.Error())
+	}
+	inputBytes := []byte(complexMappingInput)
+	for i := 0; i < b.N; i++ {
+		msg := message.QuickBatch([][]byte{inputBytes})
+		if _, err := exec.MapPart(0, msg); err != nil {
+			b.Fatal(err)
 		}
 	}
 }

--- a/internal/bloblang/parser/query_expression_parser.go
+++ b/internal/bloblang/parser/query_expression_parser.go
@@ -234,6 +234,12 @@ func lambdaExpressionParser(pCtx Context) Func[query.Function] {
 		}
 
 		name := res.Payload
+		// Use a local copy instead of reassigning the pCtx variable captured
+		// from the enclosing lambdaExpressionParser(pCtx) call. Reassigning
+		// the captured variable would mutate state shared by every
+		// invocation of this closure, which is unsafe if the closure is
+		// ever reused across calls (e.g. built once and cached).
+		localCtx := pCtx
 		if name != "_" {
 			if pCtx.HasNamedContext(name) {
 				return Fail[query.Function](
@@ -247,10 +253,10 @@ func lambdaExpressionParser(pCtx Context) Func[query.Function] {
 			}[name]; exists {
 				return Fail[query.Function](NewFatalError(input, fmt.Errorf("context label `%v` is not allowed", name)), input)
 			}
-			pCtx = pCtx.WithNamedContext(name)
+			localCtx = pCtx.WithNamedContext(name)
 		}
 
-		queryRes := MustBe(queryParser(pCtx))(res.Remaining)
+		queryRes := MustBe(queryParser(localCtx))(res.Remaining)
 		if queryRes.Err != nil {
 			return queryRes
 		}

--- a/internal/bloblang/parser/query_parser.go
+++ b/internal/bloblang/parser/query_parser.go
@@ -4,7 +4,25 @@ import (
 	"github.com/warpstreamlabs/bento/internal/bloblang/query"
 )
 
+// queryParserBuiltHook, when non-nil, is invoked every time queryParser
+// actually builds a new parser tree (i.e. on a cache miss). It exists purely
+// to make cache behaviour observable from tests, since comparing Func[T]
+// values structurally isn't possible in Go (reflect.ValueOf(fn).Pointer()
+// can return the same code address for structurally identical closures even
+// when they capture different environments). It must never be set outside
+// of tests.
+var queryParserBuiltHook func()
+
 func queryParser(pCtx Context) Func[query.Function] {
+	key := pCtx.cacheKey()
+	if cached, ok := cachedParser[query.Function](pCtx, key); ok {
+		return cached
+	}
+
+	if queryParserBuiltHook != nil {
+		queryParserBuiltHook()
+	}
+
 	rootParser := parseWithTails(Expect(
 		OneOf(
 			matchExpressionParser(pCtx),
@@ -19,10 +37,14 @@ func queryParser(pCtx Context) Func[query.Function] {
 		),
 		"query",
 	), pCtx)
-	return func(input []rune) Result[query.Function] {
+
+	built := func(input []rune) Result[query.Function] {
 		res := SpacesAndTabs(input)
 		return arithmeticParser(rootParser)(res.Remaining)
 	}
+
+	storeParser(pCtx, key, built)
+	return built
 }
 
 func tryParseQuery(expr string) (query.Function, *Error) {

--- a/internal/bloblang/parser/query_parser_cache_test.go
+++ b/internal/bloblang/parser/query_parser_cache_test.go
@@ -1,0 +1,195 @@
+package parser
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/warpstreamlabs/bento/internal/bloblang/query"
+)
+
+// withBuildCounter temporarily installs a hook that increments a counter
+// every time queryParser actually builds a new parser tree (cache miss). It
+// returns a pointer to the counter and automatically restores the previous
+// hook when the test finishes. This is necessary because comparing Func[T]
+// values via reflect.ValueOf(fn).Pointer() is unreliable: Go may report the
+// same code pointer for structurally identical closures even when they
+// capture different environments, so pointer comparison cannot be used to
+// detect cache hits/misses.
+func withBuildCounter(t *testing.T) *int {
+	t.Helper()
+	count := 0
+	prev := queryParserBuiltHook
+	queryParserBuiltHook = func() { count++ }
+	t.Cleanup(func() { queryParserBuiltHook = prev })
+	return &count
+}
+
+// TestQueryParserCacheReusesSameKey verifies that calling queryParser
+// multiple times with an equivalent Context (same Functions/Methods/
+// namedContext identity) only builds the parser tree once; subsequent calls
+// must be served from cache.
+func TestQueryParserCacheReusesSameKey(t *testing.T) {
+	count := withBuildCounter(t)
+	pCtx := GlobalContext()
+
+	_ = queryParser(pCtx)
+	_ = queryParser(pCtx)
+	_ = queryParser(pCtx)
+
+	assert.Equal(t, 1, *count,
+		"expected queryParser to build only once for an equivalent context")
+}
+
+// TestQueryParserCacheIsolatesDifferentKeys verifies that contexts with
+// different identity (different Functions/Methods sets, or different
+// namedContext chains) each trigger their own build instead of sharing a
+// cache entry, and that previously built contexts are still served from
+// cache afterwards.
+func TestQueryParserCacheIsolatesDifferentKeys(t *testing.T) {
+	count := withBuildCounter(t)
+
+	globalCtx := GlobalContext()
+	emptyCtx := EmptyContext()
+
+	_ = queryParser(globalCtx)
+	assert.Equal(t, 1, *count, "expected first context to trigger a build")
+
+	_ = queryParser(emptyCtx)
+	assert.Equal(t, 2, *count, "expected a different Functions/Methods identity to trigger its own build")
+
+	namedCtx := globalCtx.WithNamedContext("foo")
+	_ = queryParser(namedCtx)
+	assert.Equal(t, 3, *count, "expected a namedContext change to trigger its own build")
+
+	// Re-requesting any of the three previously built contexts must not
+	// trigger additional builds.
+	_ = queryParser(globalCtx)
+	_ = queryParser(emptyCtx)
+	_ = queryParser(namedCtx)
+	assert.Equal(t, 3, *count, "expected previously built contexts to be served from cache")
+}
+
+// TestQueryParserCacheNamedContextStillParsesCorrectly ensures that caching
+// doesn't break the semantics of named contexts: a query referencing a named
+// context must resolve against the correct field function, both before and
+// after the fix to lambdaExpressionParser's variable shadowing.
+func TestQueryParserCacheNamedContextStillParsesCorrectly(t *testing.T) {
+	baseCtx := GlobalContext()
+
+	// Prime the cache with the base (non-named) context first.
+	primeRes := queryParser(baseCtx)([]rune("this"))
+	require.Nil(t, primeRes.Err)
+
+	namedCtx := baseCtx.WithNamedContext("foo")
+
+	res := queryParser(namedCtx)([]rune("foo"))
+	require.Nil(t, res.Err)
+
+	fn, ok := res.Payload.(query.Function)
+	require.True(t, ok)
+	assert.Contains(t, fn.Annotation(), "foo")
+}
+
+// TestQueryParserCacheDeactivatedContextIsolated ensures a Deactivated
+// context (which swaps Functions/Methods for deactivated variants) does not
+// share cached parsers with its originating context, and still parses
+// (though it cannot execute) correctly.
+func TestQueryParserCacheDeactivatedContextIsolated(t *testing.T) {
+	count := withBuildCounter(t)
+
+	activeCtx := GlobalContext()
+	deactivatedCtx := activeCtx.Deactivated()
+
+	_ = queryParser(activeCtx)
+	assert.Equal(t, 1, *count)
+
+	_ = queryParser(deactivatedCtx)
+	assert.Equal(t, 2, *count, "expected Deactivated() context to trigger its own build, not reuse the active context's cache")
+
+	res := queryParser(deactivatedCtx)([]rune(`this.foo.uppercase()`))
+	require.Nil(t, res.Err)
+	assert.Equal(t, 2, *count, "expected re-parsing with the deactivated context to be served from cache")
+}
+
+// TestContextCacheKeyIsComparableAndStable verifies the cacheKey type itself:
+// it must be a valid, comparable map key (usable as map[cacheKeyT]any),
+// equal for contexts with identical identity, and different when
+// Functions/Methods identity or the namedContext chain differs. This guards
+// the internal representation independently of queryParser's build-counter
+// behaviour, so a future change to cacheKey's type can't silently break
+// equality semantics without a test failing here first.
+func TestContextCacheKeyIsComparableAndStable(t *testing.T) {
+	globalCtx := GlobalContext()
+	globalCtx2 := GlobalContext()
+	emptyCtx := EmptyContext()
+
+	// Same identity (same Functions/Methods pointers) must produce equal
+	// keys even across independently constructed Context values that both
+	// point at the shared global function/method sets.
+	assert.Equal(t, globalCtx.cacheKey(), globalCtx2.cacheKey(),
+		"two GlobalContext() calls share the same underlying Functions/Methods pointers and must produce equal cache keys")
+
+	// Different Functions/Methods identity must produce different keys.
+	assert.NotEqual(t, globalCtx.cacheKey(), emptyCtx.cacheKey())
+
+	// A namedContext chain must affect the key, and nesting order matters.
+	fooCtx := globalCtx.WithNamedContext("foo")
+	barCtx := globalCtx.WithNamedContext("bar")
+	fooBarCtx := fooCtx.WithNamedContext("bar")
+	barFooCtx := barCtx.WithNamedContext("foo")
+
+	assert.NotEqual(t, globalCtx.cacheKey(), fooCtx.cacheKey())
+	assert.NotEqual(t, fooCtx.cacheKey(), barCtx.cacheKey())
+	assert.NotEqual(t, fooBarCtx.cacheKey(), barFooCtx.cacheKey(),
+		"nesting order of named contexts must produce distinct keys since it affects shadow-detection semantics")
+
+	// The key type must be safe to use as a map key (this would fail to
+	// compile if cacheKey() returned a non-comparable type).
+	m := map[any]bool{}
+	m[globalCtx.cacheKey()] = true
+	assert.True(t, m[globalCtx2.cacheKey()],
+		"cache key must be usable as a map key and be equal for equivalent contexts")
+}
+
+// TestQueryParserCacheConcurrentAccessIsSafe ensures the parser cache can be
+// read/written concurrently without triggering the race detector, and that
+// concurrently parsing distinct lambda expressions (which exercise the
+// previously racy code path) against a shared cached parser is now safe
+// (run with -race).
+func TestQueryParserCacheConcurrentAccessIsSafe(t *testing.T) {
+	pCtx := GlobalContext()
+
+	names := []string{"v", "item", "ele", "num", "patron", "foo", "bar", "baz"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		for _, n := range names {
+			n := n
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				p := queryParser(pCtx)
+				res := p([]rune(n + " -> " + n + `.uppercase()`))
+				assert.Nil(t, res.Err)
+			}()
+		}
+	}
+	wg.Wait()
+}
+
+// TestQueryParserCacheProducesWorkingParser is a behavioural sanity check
+// ensuring the cached parser still parses a representative query correctly,
+// guarding against the cache silently returning a stale/incorrect parser.
+func TestQueryParserCacheProducesWorkingParser(t *testing.T) {
+	pCtx := GlobalContext()
+
+	for i := 0; i < 3; i++ {
+		res := queryParser(pCtx)([]rune(`this.foo.uppercase()`))
+		require.Nil(t, res.Err)
+		_, ok := res.Payload.(query.Function)
+		require.True(t, ok)
+	}
+}


### PR DESCRIPTION
# Bloblang Parser 性能优化 / Bloblang Parser Performance Optimization

日期 / Date: 2026-07-17

## 背景 / Background

**中文**：`internal/bloblang/parser` 使用手写的解析器组合子（parser combinator）实现 Bloblang 语法解析。分析发现 `queryParser(pCtx)` —— 整个语法树中最核心、递归调用最频繁的解析函数（27 处调用点，覆盖函数参数、括号表达式、`if`/`match`/lambda、切片索引等）—— 每次被调用都会重新构建整棵 `OneOf`/`Sequence`/`Delimited`/`arithmeticParser` 组合子闭包树，而不是构建一次复用多次。递归越深（嵌套 lambda、多层分支），重复构建的浪费越大。

**English**: `internal/bloblang/parser` implements Bloblang syntax parsing using hand-written parser combinators. Profiling revealed that `queryParser(pCtx)` — the most central, most recursively-invoked parser function in the entire grammar (27 call sites, covering function arguments, bracket expressions, `if`/`match`/lambda expressions, slice indexing, etc.) — rebuilt its entire `OneOf`/`Sequence`/`Delimited`/`arithmeticParser` combinator closure tree from scratch on every single invocation, instead of being built once and reused. The deeper the recursion (nested lambdas, multi-branch logic), the more repeated-construction waste accumulated.

实测基线（`BenchmarkMappingParser`，3 行简单赋值）/ Baseline measurement (3-line simple assignment mapping):

```
312936 ns/op   356586 B/op   10347 allocs/op
```

## 改动一：修复闭包变量遮蔽隐患（前置修复）/ Change 1: Fix Closure Variable Shadowing Hazard (Prerequisite Fix)

**中文**：第一次尝试直接给 `queryParser` 加缓存后，`go test -race` 在真实回归测试中检测到数据竞争。根因：`lambdaExpressionParser(pCtx)` 返回的闭包在函数体内部执行 `pCtx = pCtx.WithNamedContext(name)`，对闭包捕获的外层变量做重新赋值。没有缓存时每次调用都是全新闭包各自持有独立副本，天然安全；一旦闭包被缓存复用，多个 goroutine 并发调用同一闭包实例，对同一个被捕获变量并发读写，导致 named context 链污染（"context label would shadow a parent context" 误判）。

修复方式：改用局部变量 `localCtx` 承接 `WithNamedContext` 的结果，不再修改闭包捕获的 `pCtx`。逐字节输出结果不变，纯粹是内部状态管理方式的调整。

系统性排查确认：全包（`combinators.go` 全部组合子 + 所有解析器构造函数）只有这一处违反"闭包构建后不可变"的契约。

**English**: The first attempt to cache `queryParser` directly triggered a data race detected by `go test -race` in real regression tests. Root cause: the closure returned by `lambdaExpressionParser(pCtx)` executed `pCtx = pCtx.WithNamedContext(name)` inside its body, reassigning the outer variable captured by the closure. Without caching, every call produced a brand-new closure with its own independent copy — inherently safe. Once the closure was cached and reused, multiple goroutines calling the same closure instance concurrently would race on reads/writes to the same captured variable, corrupting the named-context chain (causing false "context label would shadow a parent context" errors).

Fix: introduced a local variable `localCtx` to hold the result of `WithNamedContext`, no longer mutating the captured `pCtx`. Output is byte-for-byte identical; this is purely an internal state-management adjustment.

A systematic sweep confirmed this was the *only* place in the entire package (all combinators in `combinators.go` plus every parser constructor function) that violated the "closure is immutable after construction" contract.

- 文件 / File: `internal/bloblang/parser/query_expression_parser.go`
- 验证 / Verification: 不依赖缓存机制的最小竞态复现测试（`-race -count=30` 全绿）/ Minimal race-reproduction test independent of any caching mechanism (`-race -count=30`, all green)

## 改动二：Context 级 `queryParser` 解析器缓存 / Change 2: Context-Scoped `queryParser` Cache

**中文**：在确认闭包状态安全后，给 `Context` 增加一个按身份（`Functions`/`Methods` 指针 + `namedContext` 链）区分的缓存。`queryParser` 查缓存，未命中才构建并存入，命中则直接复用已构建的闭包树。`Deactivated()`（切换 `Functions`/`Methods` 指针）会重建独立缓存，避免脏共享。

**English**: With closure-state safety confirmed, a cache keyed by Context identity (the `Functions`/`Methods` pointers plus the `namedContext` chain) was added to `Context`. `queryParser` checks the cache first; on a miss it builds and stores the tree, on a hit it reuses the already-built closure tree directly. `Deactivated()` (which swaps the `Functions`/`Methods` pointers) rebuilds an independent cache to avoid stale cross-contamination.

- 文件 / Files: `internal/bloblang/parser/context.go`, `query_parser.go`
- 并发安全 / Concurrency safety: `sync.Mutex` 保护的 map，`-race` 验证通过 / `sync.Mutex`-guarded map, verified with `-race`

## 改动三：cacheKey 结构体化 / Change 3: Struct-Based Cache Key

**中文**：Profile 显示 `cacheKey()` 用 `fmt.Fprintf("%p|%p", ...)` 格式化指针地址为字符串，走反射格式化路径，即使缓存命中也要付出这个成本。改为 `cacheKeyT{functions, methods unsafe.Pointer, namedChain string}` 结构体直接做 map key（`unsafe.Pointer` 仅作不透明可比较值使用，不做指针运算/解引用），省掉了指针格式化的反射开销。`namedContext` 链本身仍需拼字符串（运行时可变长度无法用固定结构体字段表示）。

**English**: Profiling showed `cacheKey()` formatted pointer addresses into a string via `fmt.Fprintf("%p|%p", ...)`, which goes through reflection-based formatting — a cost paid even on cache hits. Replaced with a `cacheKeyT{functions, methods unsafe.Pointer, namedChain string}` struct used directly as the map key (`unsafe.Pointer` used purely as an opaque comparable value, no pointer arithmetic or dereferencing), eliminating the reflection-based pointer-formatting overhead. The `namedContext` chain itself still needs to be flattened into a string since its length/content is only known at runtime.

- 文件 / File: `internal/bloblang/parser/context.go`

## 改动四：`ParseMapping` 前瞻短路 / Change 4: `ParseMapping` Lookahead Short-Circuit

**中文**：`ParseMapping` 对每个输入无条件先尝试 `singleRootImport`（`from "..."` 单行导入语法），哪怕输入根本不是这种语法。新增 `mightBeSingleRootImport()` 前瞻判断，复用 `singleRootImport` 自身开头所用的真实组合子（`DiscardedWhitespaceNewlineComments` + `Term("from")`）做检测，只有可能匹配时才继续完整尝试，避免了非 import 场景下的无谓解析开销。

**English**: `ParseMapping` unconditionally attempted `singleRootImport` (the `from "..."` single-line import syntax) for every input, even when the input clearly wasn't that syntax. Added a `mightBeSingleRootImport()` lookahead check that reuses the exact same combinators `singleRootImport` itself starts with (`DiscardedWhitespaceNewlineComments` + `Term("from")`), only proceeding with the full attempt when a match is plausible — eliminating wasted parsing work for the common non-import case.

- 文件 / File: `internal/bloblang/parser/mapping_parser.go`

## 验证 / Verification

**中文**：
- 每个改动均遵循 TDD：先写红灯测试，再实现，验证转绿
- 竞态复现测试（`lambda_race_test.go`）、缓存行为测试（`query_parser_cache_test.go`）、前瞻短路差分测试（`mapping_parser_shortcircuit_test.go`）
- 新增真实数据执行测试 `TestComplexMappingExecutesCorrectly`：用真实 JSON 输入执行含嵌套 lambda/match/if-else 的复杂 mapping，断言业务结果而非仅判断解析是否成功
- 全量回归测试（`internal/bloblang/...` + `internal/impl/pure/...` + `public/bloblang/...`，含 `-race`）保持绿灯，语法规则零改动

**English**:
- Every change followed TDD: red test first, then implementation, then verified green
- Race-reproduction test (`lambda_race_test.go`), cache-behaviour tests (`query_parser_cache_test.go`), lookahead differential test (`mapping_parser_shortcircuit_test.go`)
- Added `TestComplexMappingExecutesCorrectly`: executes a complex mapping (nested lambdas/match/if-else) against real JSON input and asserts on actual business results, not just parse success
- Full regression suite (`internal/bloblang/...` + `internal/impl/pure/...` + `public/bloblang/...`, with `-race`) remained green throughout; zero changes to grammar/syntax rules

## 性能收益 / Performance Results

基准环境 / Benchmark environment: Apple M4, `go test -bench -benchmem -count=3`

### 简单场景（3 行赋值）/ Simple Scenario (3-line assignment)

| 指标 / Metric | 基线 / Baseline | 优化后 / Optimized | 降幅 / Reduction |
|---|---|---|---|
| ns/op（新建 Context / new Context） | 314122~329369 | 149869~150688 | ~53.9% |
| ns/op（复用 Context / reused Context） | 302239~304384 | 135511~135599 | ~55.3% |
| allocs/op | 10347 | 3967~4226 | ~59-62% |
| B/op | 356586 | 133753~141026 | ~60-62% |

### 复杂场景（13 行，含嵌套 lambda/match/if-else/链式调用）/ Complex Scenario (13 lines, nested lambda/match/if-else/chained calls)

| 指标 / Metric | 基线 / Baseline | 优化后 / Optimized | 降幅 / Reduction |
|---|---|---|---|
| ns/op（新建 Context / new Context） | 2659318~2753777 | 1138907~1140791 | ~57.8% |
| ns/op（复用 Context / reused Context） | 2720088~3019012 | 1118293~1119874 | ~61.5% |
| allocs/op | 84495 | 31457 | ~62.8% |

### 端到端（解析 + 真实数据执行）/ End-to-End (Parse + Execute with Real Data)

| 场景 / Scenario | 基线 ns/op | 优化后 ns/op | 降幅 / Reduction |
|---|---|---|---|
| 解析 + 执行 / Parse + Execute | 2939197~3075917 | 1178630~1191650 | ~59.9% |
| 仅执行（解析在循环外完成）/ Execute only (parsed once outside loop) | 27040~28284 | 24150~24878 | ~11.6%（噪声范围 / within noise） |

## 重要适用边界 / Important Scope Boundary

**中文**：本次优化只作用于**解析阶段**（`ParseMapping`），对**执行阶段**（`Executor.Exec`/`MapPart`）零影响——这是设计上如此，缓存的是"如何构建 `query.Function` 树"，不影响"树如何被求值"。

对于典型生产场景——mapping 只在启动时解析一次，之后长期复用同一个 `*mapping.Executor` 处理海量消息流——本次优化几乎没有可观察的收益，因为解析只发生一次，真正的热路径在 `Exec`。

本次优化真正有价值的场景：mapping 被**频繁重新解析**，例如 Bloblang REPL/playground 交互式编辑、CI 阶段批量校验大量 mapping 语法、动态路由规则频繁变更并重新编译、测试套件中大量重复调用 `ParseMapping`。

**English**: This optimization only affects the **parsing phase** (`ParseMapping`) and has zero impact on the **execution phase** (`Executor.Exec`/`MapPart`) — by design, since the cache addresses "how the `query.Function` tree is built," not "how that tree is evaluated."

For the typical production scenario — a mapping is parsed once at startup and the same `*mapping.Executor` is reused to process an unbounded stream of messages — this optimization yields no observable benefit, since parsing happens only once and the actual hot path is `Exec`.

This optimization is genuinely valuable in scenarios where mappings are **re-parsed frequently**: interactive Bloblang REPL/playground editing, CI-stage bulk validation of many mapping syntaxes, dynamic routing rules that are frequently changed and recompiled, or test suites that call `ParseMapping` repeatedly.

## 未纳入本次范围的优化点 / Optimizations Not Included in This Round

**中文**：
1. **`NewError` 懒构造**（占 profile 中 ~13% 分配）：`OneOf` 尝试候选分支失败时构造的 `*Error` 对象即使最终成功也已分配。收益最大但改动面广，涉及大量断言具体错误消息文本的存量测试，风险较高，建议单独评估。
2. **子解析器缓存范围扩展**（`functionArgsParser`/`methodParser`/`matchCaseParser` 等）：这些函数目前不在缓存范围内，每次被父解析器调用仍会重新构建。复杂度更高（部分函数依赖运行时参数如 `fn query.Function`，需要更复杂的 key 设计），收益相对边际，暂不推荐。

**English**:
1. **Lazy `NewError` construction** (~13% of allocations in profiling): `*Error` objects constructed by failed `OneOf` branch attempts are allocated even when a later branch succeeds. Highest potential payoff but broad blast radius — touches many existing tests that assert exact error message text. Recommended as a separate, carefully-scoped effort.
2. **Extending the cache to sub-parsers** (`functionArgsParser`/`methodParser`/`matchCaseParser`, etc.): these are not currently cached and are still rebuilt on every call from their parent parser. Higher complexity (some depend on runtime parameters like `fn query.Function`, requiring a more complex cache key), with comparatively marginal payoff. Not recommended at this time.

## 改动文件清单 / Changed Files

- `internal/bloblang/parser/context.go` — Context 缓存字段、cacheKeyT 结构体 / Context cache field, cacheKeyT struct
- `internal/bloblang/parser/query_parser.go` — queryParser 缓存查询/存储逻辑 / queryParser cache lookup/store logic
- `internal/bloblang/parser/query_expression_parser.go` — lambdaExpressionParser 闭包变量遮蔽修复 / lambdaExpressionParser closure shadowing fix
- `internal/bloblang/parser/mapping_parser.go` — ParseMapping 前瞻短路 / ParseMapping lookahead short-circuit
- `internal/bloblang/parser/mapping_parser_test.go` — 新增复杂场景 benchmark 与真实数据执行测试 / new complex-scenario benchmarks and real-data execution test
- `internal/bloblang/parser/lambda_race_test.go`（新增 / new）— 竞态复现测试 / race-reproduction test
- `internal/bloblang/parser/query_parser_cache_test.go`（新增 / new）— 缓存行为测试 / cache-behaviour tests
- `internal/bloblang/parser/mapping_parser_shortcircuit_test.go`（新增 / new）— 前瞻短路差分测试 / lookahead short-circuit differential test
