### PR TITLE
feat(cache): add ListableCache interface for enumerating cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Optional `ListKeys` method for caches enabling consumers of cache resources to enumerate keys, caches that do not support key listing yield `ErrKeyListingNotSupported` @ecordell
+- `memory`, `file`, `aws_s3` and `gcp_cloud_storage` caches support `ListKeys` @ecordell
+
 ### Fixed
 
 - `parse_big_decimal` rejects scales above 16383 to avoid unbounded big-integer work @aratz-lasa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Optional `ListKeys` method for caches enabling consumers of cache resources to enumerate keys, caches that do not support key listing yield `ErrKeyListingNotSupported` @ecordell
-- `memory`, `file`, `aws_s3` and `gcp_cloud_storage` caches support `ListKeys` @ecordell
+- Optional `Keys` method for caches enabling consumers of cache resources to enumerate keys, caches that do not support key listing yield `ErrKeyListingNotSupported` @ecordell
+- `memory`, `file`, `aws_s3` and `gcp_cloud_storage` caches support `Keys` @ecordell
 
 ### Fixed
 

--- a/internal/component/cache/cache_metrics.go
+++ b/internal/component/cache/cache_metrics.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"errors"
-	"iter"
 	"time"
 
 	"github.com/Jeffail/shutdown"
@@ -38,9 +37,9 @@ type metricsCache struct {
 	mDelSuccess metrics.StatCounter
 	mDelLatency metrics.StatTimer
 
-	mListKeysError   metrics.StatCounter
-	mListKeysSuccess metrics.StatCounter
-	mListKeysLatency metrics.StatTimer
+	mKeysError   metrics.StatCounter
+	mKeysSuccess metrics.StatCounter
+	mKeysLatency metrics.StatTimer
 }
 
 // MetricsForCache wraps a cache with a struct that adds standard metrics over
@@ -75,9 +74,9 @@ func MetricsForCache(c V1, stats metrics.Type) V1 {
 		mDelSuccess: cacheSuccess.With("delete"),
 		mDelLatency: cacheLatency.With("delete"),
 
-		mListKeysError:   cacheError.With("list_keys"),
-		mListKeysSuccess: cacheSuccess.With("list_keys"),
-		mListKeysLatency: cacheLatency.With("list_keys"),
+		mKeysError:   cacheError.With("list_keys"),
+		mKeysSuccess: cacheSuccess.With("list_keys"),
+		mKeysLatency: cacheLatency.With("list_keys"),
 	}
 }
 
@@ -161,11 +160,11 @@ func (a *metricsCache) Delete(ctx context.Context, key string) error {
 	return err
 }
 
-func (a *metricsCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+func (a *metricsCache) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
 		started := time.Now()
 		errored := false
-		for key, err := range a.c.ListKeys(ctx) {
+		for key, err := range a.c.Keys(ctx) {
 			if err != nil {
 				errored = true
 			}
@@ -173,11 +172,11 @@ func (a *metricsCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
 				break
 			}
 		}
-		a.mListKeysLatency.Timing(int64(time.Since(started)))
+		a.mKeysLatency.Timing(int64(time.Since(started)))
 		if errored {
-			a.mListKeysError.Incr(1)
+			a.mKeysError.Incr(1)
 		} else {
-			a.mListKeysSuccess.Incr(1)
+			a.mKeysSuccess.Incr(1)
 		}
 	}
 }

--- a/internal/component/cache/cache_metrics.go
+++ b/internal/component/cache/cache_metrics.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"errors"
+	"iter"
 	"time"
 
 	"github.com/Jeffail/shutdown"
@@ -36,6 +37,10 @@ type metricsCache struct {
 	mDelError   metrics.StatCounter
 	mDelSuccess metrics.StatCounter
 	mDelLatency metrics.StatTimer
+
+	mListKeysError   metrics.StatCounter
+	mListKeysSuccess metrics.StatCounter
+	mListKeysLatency metrics.StatTimer
 }
 
 // MetricsForCache wraps a cache with a struct that adds standard metrics over
@@ -69,6 +74,10 @@ func MetricsForCache(c V1, stats metrics.Type) V1 {
 		mDelError:   cacheError.With("delete"),
 		mDelSuccess: cacheSuccess.With("delete"),
 		mDelLatency: cacheLatency.With("delete"),
+
+		mListKeysError:   cacheError.With("list_keys"),
+		mListKeysSuccess: cacheSuccess.With("list_keys"),
+		mListKeysLatency: cacheLatency.With("list_keys"),
 	}
 }
 
@@ -150,6 +159,27 @@ func (a *metricsCache) Delete(ctx context.Context, key string) error {
 		a.mDelSuccess.Incr(1)
 	}
 	return err
+}
+
+func (a *metricsCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		started := time.Now()
+		errored := false
+		for key, err := range a.c.ListKeys(ctx) {
+			if err != nil {
+				errored = true
+			}
+			if !yield(key, err) {
+				break
+			}
+		}
+		a.mListKeysLatency.Timing(int64(time.Since(started)))
+		if errored {
+			a.mListKeysError.Incr(1)
+		} else {
+			a.mListKeysSuccess.Incr(1)
+		}
+	}
 }
 
 func (a *metricsCache) Close(ctx context.Context) error {

--- a/internal/component/cache/cache_metrics.go
+++ b/internal/component/cache/cache_metrics.go
@@ -11,8 +11,8 @@ import (
 	"github.com/warpstreamlabs/bento/internal/component/metrics"
 )
 
-type metricsCache struct {
-	c   V1
+type metricsCache[V V1] struct {
+	c   V
 	sig *shutdown.Signaller
 
 	mGetNotFound metrics.StatCounter
@@ -36,21 +36,16 @@ type metricsCache struct {
 	mDelError   metrics.StatCounter
 	mDelSuccess metrics.StatCounter
 	mDelLatency metrics.StatTimer
-
-	mKeysError   metrics.StatCounter
-	mKeysSuccess metrics.StatCounter
-	mKeysLatency metrics.StatTimer
 }
 
-// MetricsForCache wraps a cache with a struct that adds standard metrics over
-// each method.
-func MetricsForCache(c V1, stats metrics.Type) V1 {
+func newMetricsCache[V V1](c V, stats metrics.Type) *metricsCache[V] {
 	cacheSuccess := stats.GetCounterVec("cache_success", "operation")
 	cacheError := stats.GetCounterVec("cache_error", "operation")
 	cacheLatency := stats.GetTimerVec("cache_latency_ns", "operation")
 
-	return &metricsCache{
-		c: c, sig: shutdown.NewSignaller(),
+	return &metricsCache[V]{
+		c:   c,
+		sig: shutdown.NewSignaller(),
 
 		mGetNotFound: stats.GetCounterVec("cache_not_found", "operation").With("get"),
 		mGetError:    cacheError.With("get"),
@@ -73,14 +68,16 @@ func MetricsForCache(c V1, stats metrics.Type) V1 {
 		mDelError:   cacheError.With("delete"),
 		mDelSuccess: cacheSuccess.With("delete"),
 		mDelLatency: cacheLatency.With("delete"),
-
-		mKeysError:   cacheError.With("list_keys"),
-		mKeysSuccess: cacheSuccess.With("list_keys"),
-		mKeysLatency: cacheLatency.With("list_keys"),
 	}
 }
 
-func (a *metricsCache) Get(ctx context.Context, key string) ([]byte, error) {
+// MetricsForCache wraps a cache with a struct that adds standard metrics over
+// each method.
+func MetricsForCache(c V1, stats metrics.Type) V1 {
+	return newMetricsCache(c, stats)
+}
+
+func (a *metricsCache[V]) Get(ctx context.Context, key string) ([]byte, error) {
 	started := time.Now()
 	b, err := a.c.Get(ctx, key)
 	a.mGetLatency.Timing(int64(time.Since(started)))
@@ -96,7 +93,7 @@ func (a *metricsCache) Get(ctx context.Context, key string) ([]byte, error) {
 	return b, err
 }
 
-func (a *metricsCache) Exists(ctx context.Context, key string) (bool, error) {
+func (a *metricsCache[V]) Exists(ctx context.Context, key string) (bool, error) {
 	started := time.Now()
 	b, err := a.c.Exists(ctx, key)
 	a.mExistsLatency.Timing(int64(time.Since(started)))
@@ -108,7 +105,7 @@ func (a *metricsCache) Exists(ctx context.Context, key string) (bool, error) {
 	return b, err
 }
 
-func (a *metricsCache) Set(ctx context.Context, key string, value []byte, ttl *time.Duration) error {
+func (a *metricsCache[V]) Set(ctx context.Context, key string, value []byte, ttl *time.Duration) error {
 	started := time.Now()
 	err := a.c.Set(ctx, key, value, ttl)
 	a.mSetLatency.Timing(int64(time.Since(started)))
@@ -120,7 +117,7 @@ func (a *metricsCache) Set(ctx context.Context, key string, value []byte, ttl *t
 	return err
 }
 
-func (a *metricsCache) SetMulti(ctx context.Context, items map[string]TTLItem) error {
+func (a *metricsCache[V]) SetMulti(ctx context.Context, items map[string]TTLItem) error {
 	started := time.Now()
 	err := a.c.SetMulti(ctx, items)
 	a.mSetLatency.Timing(int64(time.Since(started)))
@@ -132,7 +129,7 @@ func (a *metricsCache) SetMulti(ctx context.Context, items map[string]TTLItem) e
 	return err
 }
 
-func (a *metricsCache) Add(ctx context.Context, key string, value []byte, ttl *time.Duration) error {
+func (a *metricsCache[V]) Add(ctx context.Context, key string, value []byte, ttl *time.Duration) error {
 	started := time.Now()
 	err := a.c.Add(ctx, key, value, ttl)
 	a.mAddLatency.Timing(int64(time.Since(started)))
@@ -148,7 +145,7 @@ func (a *metricsCache) Add(ctx context.Context, key string, value []byte, ttl *t
 	return err
 }
 
-func (a *metricsCache) Delete(ctx context.Context, key string) error {
+func (a *metricsCache[V]) Delete(ctx context.Context, key string) error {
 	started := time.Now()
 	err := a.c.Delete(ctx, key)
 	a.mDelLatency.Timing(int64(time.Since(started)))
@@ -160,7 +157,35 @@ func (a *metricsCache) Delete(ctx context.Context, key string) error {
 	return err
 }
 
-func (a *metricsCache) Keys(ctx context.Context) KeyIterator {
+func (a *metricsCache[V]) Close(ctx context.Context) error {
+	return a.c.Close(ctx)
+}
+
+//------------------------------------------------------------------------------
+
+type metricsListableCache struct {
+	*metricsCache[Listable]
+
+	mKeysError   metrics.StatCounter
+	mKeysSuccess metrics.StatCounter
+	mKeysLatency metrics.StatTimer
+}
+
+func MetricsForListableCache(c Listable, stats metrics.Type) Listable {
+	cacheSuccess := stats.GetCounterVec("cache_success", "operation")
+	cacheError := stats.GetCounterVec("cache_error", "operation")
+	cacheLatency := stats.GetTimerVec("cache_latency_ns", "operation")
+
+	return &metricsListableCache{
+		metricsCache: newMetricsCache(c, stats),
+
+		mKeysError:   cacheError.With("list_keys"),
+		mKeysSuccess: cacheSuccess.With("list_keys"),
+		mKeysLatency: cacheLatency.With("list_keys"),
+	}
+}
+
+func (a *metricsListableCache) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
 		started := time.Now()
 		errored := false
@@ -179,8 +204,4 @@ func (a *metricsCache) Keys(ctx context.Context) KeyIterator {
 			a.mKeysSuccess.Incr(1)
 		}
 	}
-}
-
-func (a *metricsCache) Close(ctx context.Context) error {
-	return a.c.Close(ctx)
 }

--- a/internal/component/cache/cache_metrics_test.go
+++ b/internal/component/cache/cache_metrics_test.go
@@ -301,7 +301,7 @@ func TestCacheAirGapKeys(t *testing.T) {
 			},
 		},
 	}
-	agrl := MetricsForCache(rl, metrics.Noop())
+	agrl := MetricsForListableCache(rl, metrics.Noop())
 
 	var keys []string
 	for k, err := range agrl.Keys(ctx) {
@@ -317,7 +317,7 @@ func TestCacheAirGapKeysNotSupported(t *testing.T) {
 	}
 	agrl := MetricsForCache(rl, metrics.Noop())
 
-	for _, err := range agrl.Keys(t.Context()) {
-		require.ErrorIs(t, err, component.ErrKeyListingNotSupported)
-	}
+	// A cache that cannot enumerate its keys is not wrapped as Listable.
+	_, ok := agrl.(Listable)
+	assert.False(t, ok)
 }

--- a/internal/component/cache/cache_metrics_test.go
+++ b/internal/component/cache/cache_metrics_test.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"iter"
 	"testing"
 	"time"
 
@@ -86,7 +85,7 @@ func (c *closableCache) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-func (c *closableCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+func (c *closableCache) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
 		yield("", component.ErrKeyListingNotSupported)
 	}
@@ -274,7 +273,7 @@ type listableClosableCache struct {
 	*closableCache
 }
 
-func (c *listableClosableCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+func (c *listableClosableCache) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
 		if c.err != nil {
 			yield("", c.err)
@@ -288,7 +287,7 @@ func (c *listableClosableCache) ListKeys(ctx context.Context) iter.Seq2[string, 
 	}
 }
 
-func TestCacheAirGapListKeys(t *testing.T) {
+func TestCacheAirGapKeys(t *testing.T) {
 	ctx := t.Context()
 	rl := &listableClosableCache{
 		closableCache: &closableCache{
@@ -305,20 +304,20 @@ func TestCacheAirGapListKeys(t *testing.T) {
 	agrl := MetricsForCache(rl, metrics.Noop())
 
 	var keys []string
-	for k, err := range agrl.ListKeys(ctx) {
+	for k, err := range agrl.Keys(ctx) {
 		require.NoError(t, err)
 		keys = append(keys, k)
 	}
 	assert.ElementsMatch(t, []string{"foo", "baz"}, keys)
 }
 
-func TestCacheAirGapListKeysNotSupported(t *testing.T) {
+func TestCacheAirGapKeysNotSupported(t *testing.T) {
 	rl := &closableCache{
 		m: map[string]testCacheItem{},
 	}
 	agrl := MetricsForCache(rl, metrics.Noop())
 
-	for _, err := range agrl.ListKeys(t.Context()) {
+	for _, err := range agrl.Keys(t.Context()) {
 		require.ErrorIs(t, err, component.ErrKeyListingNotSupported)
 	}
 }

--- a/internal/component/cache/cache_metrics_test.go
+++ b/internal/component/cache/cache_metrics_test.go
@@ -2,10 +2,12 @@ package cache
 
 import (
 	"context"
+	"iter"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/warpstreamlabs/bento/internal/component"
 	"github.com/warpstreamlabs/bento/internal/component/metrics"
@@ -82,6 +84,12 @@ func (c *closableCache) Delete(ctx context.Context, key string) error {
 	}
 	delete(c.m, key)
 	return nil
+}
+
+func (c *closableCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		yield("", component.ErrKeyListingNotSupported)
+	}
 }
 
 func (c *closableCache) Close(ctx context.Context) error {
@@ -260,4 +268,57 @@ func TestCacheAirGapDelete(t *testing.T) {
 	err := agrl.Delete(ctx, "foo")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]testCacheItem{}, rl.m)
+}
+
+type listableClosableCache struct {
+	*closableCache
+}
+
+func (c *listableClosableCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		if c.err != nil {
+			yield("", c.err)
+			return
+		}
+		for k := range c.m {
+			if !yield(k, nil) {
+				return
+			}
+		}
+	}
+}
+
+func TestCacheAirGapListKeys(t *testing.T) {
+	ctx := t.Context()
+	rl := &listableClosableCache{
+		closableCache: &closableCache{
+			m: map[string]testCacheItem{
+				"foo": {
+					b: []byte("bar"),
+				},
+				"baz": {
+					b: []byte("qux"),
+				},
+			},
+		},
+	}
+	agrl := MetricsForCache(rl, metrics.Noop())
+
+	var keys []string
+	for k, err := range agrl.ListKeys(ctx) {
+		require.NoError(t, err)
+		keys = append(keys, k)
+	}
+	assert.ElementsMatch(t, []string{"foo", "baz"}, keys)
+}
+
+func TestCacheAirGapListKeysNotSupported(t *testing.T) {
+	rl := &closableCache{
+		m: map[string]testCacheItem{},
+	}
+	agrl := MetricsForCache(rl, metrics.Noop())
+
+	for _, err := range agrl.ListKeys(t.Context()) {
+		require.ErrorIs(t, err, component.ErrKeyListingNotSupported)
+	}
 }

--- a/internal/component/cache/interface.go
+++ b/internal/component/cache/interface.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"iter"
 	"time"
 )
 
@@ -36,6 +37,11 @@ type V1 interface {
 
 	// Delete attempts to remove a key. Returns an error if a failure occurs.
 	Delete(ctx context.Context, key string) error
+
+	// ListKeys returns an iterator over all keys currently held by the cache.
+	// Iteration stops after the first non-nil error, caches that are unable
+	// to enumerate their keys yield component.ErrKeyListingNotSupported.
+	ListKeys(ctx context.Context) iter.Seq2[string, error]
 
 	// Close the component, blocks until either the underlying resources are
 	// cleaned up or the context is cancelled. Returns an error if the context

--- a/internal/component/cache/interface.go
+++ b/internal/component/cache/interface.go
@@ -42,13 +42,17 @@ type V1 interface {
 	// Delete attempts to remove a key. Returns an error if a failure occurs.
 	Delete(ctx context.Context, key string) error
 
-	// Keys returns an iterator over all keys currently held by the cache.
-	// Iteration stops after the first non-nil error, caches that are unable
-	// to enumerate their keys yield component.ErrKeyListingNotSupported.
-	Keys(ctx context.Context) KeyIterator
-
 	// Close the component, blocks until either the underlying resources are
 	// cleaned up or the context is cancelled. Returns an error if the context
 	// is cancelled.
 	Close(ctx context.Context) error
+}
+
+type Listable interface {
+	V1
+
+	// Keys returns an iterator over all keys currently held by the cache.
+	// Iteration stops after the first non-nil error, caches that are unable
+	// to enumerate their keys yield component.ErrKeyListingNotSupported.
+	Keys(ctx context.Context) KeyIterator
 }

--- a/internal/component/cache/interface.go
+++ b/internal/component/cache/interface.go
@@ -12,6 +12,10 @@ type TTLItem struct {
 	TTL   *time.Duration
 }
 
+// KeyIterator is an iterator over the keys held by a cache. Iteration stops
+// after the first non-nil error.
+type KeyIterator = iter.Seq2[string, error]
+
 // V1 Defines a common interface of cache implementations.
 type V1 interface {
 	// Get attempts to locate and return a cached value by its key, returns an
@@ -38,10 +42,10 @@ type V1 interface {
 	// Delete attempts to remove a key. Returns an error if a failure occurs.
 	Delete(ctx context.Context, key string) error
 
-	// ListKeys returns an iterator over all keys currently held by the cache.
+	// Keys returns an iterator over all keys currently held by the cache.
 	// Iteration stops after the first non-nil error, caches that are unable
 	// to enumerate their keys yield component.ErrKeyListingNotSupported.
-	ListKeys(ctx context.Context) iter.Seq2[string, error]
+	Keys(ctx context.Context) KeyIterator
 
 	// Close the component, blocks until either the underlying resources are
 	// cleaned up or the context is cancelled. Returns an error if the context

--- a/internal/component/cache/prefetch.go
+++ b/internal/component/cache/prefetch.go
@@ -1,0 +1,66 @@
+package cache
+
+import "context"
+
+// PrefetchKeys builds a Keys iterator that runs the provided produce function in
+// a background goroutine, allowing it to fetch subsequent pages of keys while
+// the caller consumes the keys already found. Up to readAhead keys are
+// buffered; sizing this at or above a backend's page size lets the next page be
+// fetched while the current one is being yielded.
+//
+// The produce function should call emit once for each key. emit returns false
+// once the caller has stopped consuming (an early break, or a downstream
+// error), after which produce should stop and return - typically nil.
+// Returning a non-nil error from produce terminates iteration after yielding
+// that error to the caller. If ctx is cancelled iteration stops without
+// yielding a further error; produce should return promptly when ctx is done.
+//
+// This is a helper for implementing the optional key-listing behaviour of a
+// paginated cache; it manages the goroutine lifecycle and cancellation on early
+// termination so implementations only need to express their paging loop. It is
+// intended for use by bento's own cache components.
+func PrefetchKeys(ctx context.Context, readAhead int, produce func(ctx context.Context, emit func(key string) bool) error) KeyIterator {
+	return func(yield func(string, error) bool) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		type result struct {
+			key string
+			err error
+		}
+		results := make(chan result, readAhead)
+
+		go func() {
+			defer close(results)
+			err := produce(ctx, func(key string) bool {
+				select {
+				case results <- result{key: key}:
+					return true
+				case <-ctx.Done():
+					return false
+				}
+			})
+			// Only surface an error while the caller is still listening and
+			// neither side has cancelled - a cancellation is the caller's
+			// signal to stop, not an error to report.
+			if err != nil && ctx.Err() == nil {
+				select {
+				case results <- result{err: err}:
+				case <-ctx.Done():
+				}
+			}
+		}()
+
+		for r := range results {
+			if r.err != nil {
+				yield("", r.err)
+				return
+			}
+			if !yield(r.key, nil) {
+				// Cancelling (via the deferred cancel) unblocks the producer's
+				// pending emit so it observes the stop and exits.
+				return
+			}
+		}
+	}
+}

--- a/internal/component/cache/prefetch_test.go
+++ b/internal/component/cache/prefetch_test.go
@@ -1,0 +1,110 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefetchKeys(t *testing.T) {
+	src := []string{"a", "b", "c", "d", "e"}
+	seq := PrefetchKeys(t.Context(), 2, func(ctx context.Context, emit func(string) bool) error {
+		for _, k := range src {
+			if !emit(k) {
+				return nil
+			}
+		}
+		return nil
+	})
+
+	var keys []string
+	for k, err := range seq {
+		require.NoError(t, err)
+		keys = append(keys, k)
+	}
+	assert.Equal(t, src, keys)
+}
+
+func TestPrefetchKeysError(t *testing.T) {
+	errBoom := errors.New("boom")
+	seq := PrefetchKeys(t.Context(), 2, func(ctx context.Context, emit func(string) bool) error {
+		if !emit("a") {
+			return nil
+		}
+		return errBoom
+	})
+
+	var keys []string
+	var gotErr error
+	for k, err := range seq {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		keys = append(keys, k)
+	}
+	assert.Equal(t, []string{"a"}, keys)
+	assert.ErrorIs(t, gotErr, errBoom)
+}
+
+func TestPrefetchKeysEarlyBreak(t *testing.T) {
+	stopped := make(chan struct{})
+	seq := PrefetchKeys(t.Context(), 1, func(ctx context.Context, emit func(string) bool) error {
+		defer close(stopped)
+		for i := 0; ; i++ {
+			if !emit(strconv.Itoa(i)) {
+				return nil
+			}
+		}
+	})
+
+	var keys []string
+	for k := range seq {
+		keys = append(keys, k)
+		if len(keys) == 3 {
+			break
+		}
+	}
+	assert.Equal(t, []string{"0", "1", "2"}, keys)
+
+	// The producer must observe the early break and exit rather than leak.
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("producer did not stop after early break")
+	}
+}
+
+func TestPrefetchKeysContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	stopped := make(chan struct{})
+	seq := PrefetchKeys(ctx, 1, func(ctx context.Context, emit func(string) bool) error {
+		defer close(stopped)
+		for i := 0; ; i++ {
+			if !emit(strconv.Itoa(i)) {
+				return ctx.Err()
+			}
+		}
+	})
+
+	var keys []string
+	for k, err := range seq {
+		require.NoError(t, err) // cancellation stops iteration without an error
+		keys = append(keys, k)
+		if len(keys) == 2 {
+			cancel()
+		}
+	}
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("producer did not stop after context cancellation")
+	}
+}

--- a/internal/component/errors.go
+++ b/internal/component/errors.go
@@ -87,15 +87,21 @@ func (e *ErrBackOff) Error() string {
 
 // Manager errors.
 var (
-	ErrInputNotFound          = errors.New("input not found")
-	ErrCacheNotFound          = errors.New("cache not found")
-	ErrProcessorNotFound      = errors.New("processor not found")
-	ErrRateLimitNotFound      = errors.New("rate limit not found")
-	ErrOutputNotFound         = errors.New("output not found")
+	ErrInputNotFound     = errors.New("input not found")
+	ErrCacheNotFound     = errors.New("cache not found")
+	ErrProcessorNotFound = errors.New("processor not found")
+	ErrRateLimitNotFound = errors.New("rate limit not found")
+	ErrOutputNotFound    = errors.New("output not found")
+	ErrPipeNotFound      = errors.New("pipe was not found")
+)
+
+//------------------------------------------------------------------------------
+
+// Cache errors.
+var (
 	ErrKeyAlreadyExists       = errors.New("key already exists")
 	ErrKeyNotFound            = errors.New("key does not exist")
 	ErrKeyListingNotSupported = errors.New("cache does not support listing keys")
-	ErrPipeNotFound           = errors.New("pipe was not found")
 )
 
 //------------------------------------------------------------------------------

--- a/internal/component/errors.go
+++ b/internal/component/errors.go
@@ -87,14 +87,15 @@ func (e *ErrBackOff) Error() string {
 
 // Manager errors.
 var (
-	ErrInputNotFound     = errors.New("input not found")
-	ErrCacheNotFound     = errors.New("cache not found")
-	ErrProcessorNotFound = errors.New("processor not found")
-	ErrRateLimitNotFound = errors.New("rate limit not found")
-	ErrOutputNotFound    = errors.New("output not found")
-	ErrKeyAlreadyExists  = errors.New("key already exists")
-	ErrKeyNotFound       = errors.New("key does not exist")
-	ErrPipeNotFound      = errors.New("pipe was not found")
+	ErrInputNotFound          = errors.New("input not found")
+	ErrCacheNotFound          = errors.New("cache not found")
+	ErrProcessorNotFound      = errors.New("processor not found")
+	ErrRateLimitNotFound      = errors.New("rate limit not found")
+	ErrOutputNotFound         = errors.New("output not found")
+	ErrKeyAlreadyExists       = errors.New("key already exists")
+	ErrKeyNotFound            = errors.New("key does not exist")
+	ErrKeyListingNotSupported = errors.New("cache does not support listing keys")
+	ErrPipeNotFound           = errors.New("pipe was not found")
 )
 
 //------------------------------------------------------------------------------

--- a/internal/impl/aws/cache_s3.go
+++ b/internal/impl/aws/cache_s3.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"iter"
 	"sync"
 	"time"
 
@@ -252,6 +253,42 @@ func (s *s3Cache) Delete(ctx context.Context, key string) (err error) {
 		case <-time.After(wait):
 		case <-ctx.Done():
 			return
+		}
+	}
+}
+
+func (s *s3Cache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		boff := s.boffPool.Get().(backoff.BackOff)
+		defer func() {
+			boff.Reset()
+			s.boffPool.Put(boff)
+		}()
+
+		pager := s3.NewListObjectsV2Paginator(s.s3, &s3.ListObjectsV2Input{
+			Bucket: &s.bucket,
+		})
+		for pager.HasMorePages() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				wait := boff.NextBackOff()
+				if wait == backoff.Stop {
+					yield("", err)
+					return
+				}
+				select {
+				case <-time.After(wait):
+				case <-ctx.Done():
+					yield("", err)
+					return
+				}
+				continue
+			}
+			for _, obj := range page.Contents {
+				if obj.Key != nil && !yield(*obj.Key, nil) {
+					return
+				}
+			}
 		}
 	}
 }

--- a/internal/impl/aws/cache_s3.go
+++ b/internal/impl/aws/cache_s3.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"iter"
 	"sync"
 	"time"
 
@@ -257,8 +256,11 @@ func (s *s3Cache) Delete(ctx context.Context, key string) (err error) {
 	}
 }
 
-func (s *s3Cache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
-	return func(yield func(string, error) bool) {
+func (s *s3Cache) Keys(ctx context.Context) service.KeyIterator {
+	// readAhead is set to the maximum number of keys in a single S3 page so
+	// that the next page can be fetched while the current one is yielded.
+	const readAhead = 1000
+	return service.PrefetchKeys(ctx, readAhead, func(ctx context.Context, emit func(string) bool) error {
 		boff := s.boffPool.Get().(backoff.BackOff)
 		defer func() {
 			boff.Reset()
@@ -273,24 +275,23 @@ func (s *s3Cache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
 			if err != nil {
 				wait := boff.NextBackOff()
 				if wait == backoff.Stop {
-					yield("", err)
-					return
+					return err
 				}
 				select {
 				case <-time.After(wait):
 				case <-ctx.Done():
-					yield("", err)
-					return
+					return err
 				}
 				continue
 			}
 			for _, obj := range page.Contents {
-				if obj.Key != nil && !yield(*obj.Key, nil) {
-					return
+				if obj.Key != nil && !emit(*obj.Key) {
+					return nil
 				}
 			}
 		}
-	}
+		return nil
+	})
 }
 
 func (s *s3Cache) Close(context.Context) error {

--- a/internal/impl/aws/cache_s3.go
+++ b/internal/impl/aws/cache_s3.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/cenkalti/backoff/v4"
 
+	"github.com/warpstreamlabs/bento/internal/component/cache"
 	"github.com/warpstreamlabs/bento/internal/impl/aws/config"
 	"github.com/warpstreamlabs/bento/public/service"
 )
@@ -260,7 +261,7 @@ func (s *s3Cache) Keys(ctx context.Context) service.KeyIterator {
 	// readAhead is set to the maximum number of keys in a single S3 page so
 	// that the next page can be fetched while the current one is yielded.
 	const readAhead = 1000
-	return service.PrefetchKeys(ctx, readAhead, func(ctx context.Context, emit func(string) bool) error {
+	return cache.PrefetchKeys(ctx, readAhead, func(ctx context.Context, emit func(string) bool) error {
 		boff := s.boffPool.Get().(backoff.BackOff)
 		defer func() {
 			boff.Reset()

--- a/internal/impl/aws/integration_s3_test.go
+++ b/internal/impl/aws/integration_s3_test.go
@@ -381,6 +381,7 @@ cache_resources:
 			integration.CacheTestGetAndSet(1),
 			integration.CacheTestMissingKey(),
 			integration.CacheTestExistsAndSet(1),
+			integration.CacheTestListKeys(5),
 		)
 		suite.Run(
 			t, template,

--- a/internal/impl/aws/integration_s3_test.go
+++ b/internal/impl/aws/integration_s3_test.go
@@ -381,7 +381,7 @@ cache_resources:
 			integration.CacheTestGetAndSet(1),
 			integration.CacheTestMissingKey(),
 			integration.CacheTestExistsAndSet(1),
-			integration.CacheTestListKeys(5),
+			integration.CacheTestKeys(5),
 		)
 		suite.Run(
 			t, template,

--- a/internal/impl/gcp/cache_cloud_storage.go
+++ b/internal/impl/gcp/cache_cloud_storage.go
@@ -9,6 +9,7 @@ import (
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
 
+	"github.com/warpstreamlabs/bento/internal/component/cache"
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
@@ -145,7 +146,7 @@ func (c *gcpCloudStorageCache) Keys(ctx context.Context) service.KeyIterator {
 	// readAhead matches the storage client's default page size so that the next
 	// page can be fetched while the current one is yielded.
 	const readAhead = 1000
-	return service.PrefetchKeys(ctx, readAhead, func(ctx context.Context, emit func(string) bool) error {
+	return cache.PrefetchKeys(ctx, readAhead, func(ctx context.Context, emit func(string) bool) error {
 		it := c.bucketHandle.Objects(ctx, nil)
 		for {
 			attrs, err := it.Next()

--- a/internal/impl/gcp/cache_cloud_storage.go
+++ b/internal/impl/gcp/cache_cloud_storage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"iter"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -142,23 +141,25 @@ func (c *gcpCloudStorageCache) Delete(ctx context.Context, key string) error {
 	return c.bucketHandle.Object(key).Delete(ctx)
 }
 
-func (c *gcpCloudStorageCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
-	return func(yield func(string, error) bool) {
+func (c *gcpCloudStorageCache) Keys(ctx context.Context) service.KeyIterator {
+	// readAhead matches the storage client's default page size so that the next
+	// page can be fetched while the current one is yielded.
+	const readAhead = 1000
+	return service.PrefetchKeys(ctx, readAhead, func(ctx context.Context, emit func(string) bool) error {
 		it := c.bucketHandle.Objects(ctx, nil)
 		for {
 			attrs, err := it.Next()
 			if errors.Is(err, iterator.Done) {
-				return
+				return nil
 			}
 			if err != nil {
-				yield("", err)
-				return
+				return err
 			}
-			if !yield(attrs.Name, nil) {
-				return
+			if !emit(attrs.Name) {
+				return nil
 			}
 		}
-	}
+	})
 }
 
 func (c *gcpCloudStorageCache) Close(ctx context.Context) error {

--- a/internal/impl/gcp/cache_cloud_storage.go
+++ b/internal/impl/gcp/cache_cloud_storage.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"io"
+	"iter"
 	"time"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
 
 	"github.com/warpstreamlabs/bento/public/service"
 )
@@ -138,6 +140,25 @@ func (c *gcpCloudStorageCache) Add(ctx context.Context, key string, value []byte
 
 func (c *gcpCloudStorageCache) Delete(ctx context.Context, key string) error {
 	return c.bucketHandle.Object(key).Delete(ctx)
+}
+
+func (c *gcpCloudStorageCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		it := c.bucketHandle.Objects(ctx, nil)
+		for {
+			attrs, err := it.Next()
+			if errors.Is(err, iterator.Done) {
+				return
+			}
+			if err != nil {
+				yield("", err)
+				return
+			}
+			if !yield(attrs.Name, nil) {
+				return
+			}
+		}
+	}
 }
 
 func (c *gcpCloudStorageCache) Close(ctx context.Context) error {

--- a/internal/impl/io/cache_file.go
+++ b/internal/impl/io/cache_file.go
@@ -3,7 +3,9 @@ package io
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
+	"iter"
 	"os"
 	"path/filepath"
 	"time"
@@ -90,6 +92,46 @@ func (f *fileCache) Add(_ context.Context, key string, value []byte, _ *time.Dur
 
 func (f *fileCache) Delete(_ context.Context, key string) error {
 	return f.mgr.FS().Remove(filepath.Join(f.dir, key))
+}
+
+func (f *fileCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		var walk func(rel string) bool
+		walk = func(rel string) bool {
+			if err := ctx.Err(); err != nil {
+				yield("", err)
+				return false
+			}
+			dir, err := f.mgr.FS().Open(filepath.Join(f.dir, rel))
+			if err != nil {
+				yield("", err)
+				return false
+			}
+			defer dir.Close()
+
+			rd, ok := dir.(fs.ReadDirFile)
+			if !ok {
+				yield("", fmt.Errorf("unable to list directory: %v", filepath.Join(f.dir, rel)))
+				return false
+			}
+			entries, err := rd.ReadDir(-1)
+			if err != nil {
+				yield("", err)
+				return false
+			}
+			for _, e := range entries {
+				if e.IsDir() {
+					if !walk(filepath.Join(rel, e.Name())) {
+						return false
+					}
+				} else if !yield(filepath.Join(rel, e.Name()), nil) {
+					return false
+				}
+			}
+			return true
+		}
+		walk("")
+	}
 }
 
 func (f *fileCache) Close(context.Context) error {

--- a/internal/impl/io/cache_file.go
+++ b/internal/impl/io/cache_file.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"iter"
 	"os"
 	"path/filepath"
 	"time"
@@ -94,7 +93,7 @@ func (f *fileCache) Delete(_ context.Context, key string) error {
 	return f.mgr.FS().Remove(filepath.Join(f.dir, key))
 }
 
-func (f *fileCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+func (f *fileCache) Keys(ctx context.Context) service.KeyIterator {
 	return func(yield func(string, error) bool) {
 		var walk func(rel string) bool
 		walk = func(rel string) bool {

--- a/internal/impl/io/cache_file_test.go
+++ b/internal/impl/io/cache_file_test.go
@@ -70,7 +70,7 @@ func TestFileCache(t *testing.T) {
 	assert.False(t, exists)
 }
 
-func TestFileCacheListKeys(t *testing.T) {
+func TestFileCacheKeys(t *testing.T) {
 	dir := t.TempDir()
 
 	tCtx := t.Context()
@@ -84,7 +84,7 @@ func TestFileCacheListKeys(t *testing.T) {
 	require.NoError(t, c.Set(tCtx, nestedKey, []byte("3"), nil))
 
 	var keys []string
-	for k, err := range c.ListKeys(tCtx) {
+	for k, err := range c.Keys(tCtx) {
 		require.NoError(t, err)
 		keys = append(keys, k)
 	}
@@ -93,14 +93,14 @@ func TestFileCacheListKeys(t *testing.T) {
 	require.NoError(t, c.Delete(tCtx, "foo"))
 
 	keys = nil
-	for k, err := range c.ListKeys(tCtx) {
+	for k, err := range c.Keys(tCtx) {
 		require.NoError(t, err)
 		keys = append(keys, k)
 	}
 	assert.ElementsMatch(t, []string{"bar", nestedKey}, keys)
 }
 
-func TestFileCacheListKeysCancelled(t *testing.T) {
+func TestFileCacheKeysCancelled(t *testing.T) {
 	dir := t.TempDir()
 
 	c := newFileCache(dir, service.MockResources())
@@ -109,7 +109,7 @@ func TestFileCacheListKeysCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	for _, err := range c.ListKeys(ctx) {
+	for _, err := range c.Keys(ctx) {
 		require.ErrorIs(t, err, context.Canceled)
 	}
 }

--- a/internal/impl/io/cache_file_test.go
+++ b/internal/impl/io/cache_file_test.go
@@ -3,6 +3,7 @@ package io
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,4 +68,48 @@ func TestFileCache(t *testing.T) {
 	exists, err = c.Exists(tCtx, "foo")
 	assert.NoError(t, err)
 	assert.False(t, exists)
+}
+
+func TestFileCacheListKeys(t *testing.T) {
+	dir := t.TempDir()
+
+	tCtx := t.Context()
+	c := newFileCache(dir, service.MockResources())
+
+	require.NoError(t, c.Set(tCtx, "foo", []byte("1"), nil))
+	require.NoError(t, c.Set(tCtx, "bar", []byte("2"), nil))
+
+	nestedKey := filepath.Join("nested", "baz")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "nested"), 0o755))
+	require.NoError(t, c.Set(tCtx, nestedKey, []byte("3"), nil))
+
+	var keys []string
+	for k, err := range c.ListKeys(tCtx) {
+		require.NoError(t, err)
+		keys = append(keys, k)
+	}
+	assert.ElementsMatch(t, []string{"foo", "bar", nestedKey}, keys)
+
+	require.NoError(t, c.Delete(tCtx, "foo"))
+
+	keys = nil
+	for k, err := range c.ListKeys(tCtx) {
+		require.NoError(t, err)
+		keys = append(keys, k)
+	}
+	assert.ElementsMatch(t, []string{"bar", nestedKey}, keys)
+}
+
+func TestFileCacheListKeysCancelled(t *testing.T) {
+	dir := t.TempDir()
+
+	c := newFileCache(dir, service.MockResources())
+	require.NoError(t, c.Set(t.Context(), "foo", []byte("1"), nil))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	for _, err := range c.ListKeys(ctx) {
+		require.ErrorIs(t, err, context.Canceled)
+	}
 }

--- a/internal/impl/pure/cache_memory.go
+++ b/internal/impl/pure/cache_memory.go
@@ -2,7 +2,6 @@ package pure
 
 import (
 	"context"
-	"iter"
 	"sync"
 	"time"
 
@@ -248,7 +247,7 @@ func (m *memoryCache) Delete(_ context.Context, key string) error {
 	return nil
 }
 
-func (m *memoryCache) ListKeys(_ context.Context) iter.Seq2[string, error] {
+func (m *memoryCache) Keys(_ context.Context) service.KeyIterator {
 	return func(yield func(string, error) bool) {
 		for _, shard := range m.shards {
 			// Snapshot each shard before yielding so that no locks are held

--- a/internal/impl/pure/cache_memory.go
+++ b/internal/impl/pure/cache_memory.go
@@ -2,6 +2,7 @@ package pure
 
 import (
 	"context"
+	"iter"
 	"sync"
 	"time"
 
@@ -245,6 +246,29 @@ func (m *memoryCache) Delete(_ context.Context, key string) error {
 	delete(shard.items, key)
 	shard.Unlock()
 	return nil
+}
+
+func (m *memoryCache) ListKeys(_ context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		for _, shard := range m.shards {
+			// Snapshot each shard before yielding so that no locks are held
+			// while control is passed to the caller.
+			shard.RLock()
+			keys := make([]string, 0, len(shard.items))
+			for k, v := range shard.items {
+				// Simulate compaction by omitting keys with an expired ttl.
+				if !shard.isExpired(v) {
+					keys = append(keys, k)
+				}
+			}
+			shard.RUnlock()
+			for _, k := range keys {
+				if !yield(k, nil) {
+					return
+				}
+			}
+		}
+	}
 }
 
 func (m *memoryCache) Close(context.Context) error {

--- a/internal/impl/pure/cache_memory_test.go
+++ b/internal/impl/pure/cache_memory_test.go
@@ -93,7 +93,7 @@ func TestMemoryCache(t *testing.T) {
 	require.False(t, exists)
 }
 
-func TestMemoryCacheListKeys(t *testing.T) {
+func TestMemoryCacheKeys(t *testing.T) {
 	ctx := t.Context()
 
 	for _, nShards := range []int{1, 16} {
@@ -104,7 +104,7 @@ func TestMemoryCacheListKeys(t *testing.T) {
 			require.NoError(t, c.Add(ctx, "baz", []byte("3"), nil))
 
 			var keys []string
-			for k, err := range c.ListKeys(ctx) {
+			for k, err := range c.Keys(ctx) {
 				require.NoError(t, err)
 				keys = append(keys, k)
 			}
@@ -113,7 +113,7 @@ func TestMemoryCacheListKeys(t *testing.T) {
 			require.NoError(t, c.Delete(ctx, "bar"))
 
 			keys = nil
-			for k, err := range c.ListKeys(ctx) {
+			for k, err := range c.Keys(ctx) {
 				require.NoError(t, err)
 				keys = append(keys, k)
 			}
@@ -122,7 +122,7 @@ func TestMemoryCacheListKeys(t *testing.T) {
 	}
 }
 
-func TestMemoryCacheListKeysExpired(t *testing.T) {
+func TestMemoryCacheKeysExpired(t *testing.T) {
 	ctx := t.Context()
 
 	// A long compaction interval so that expired items are retained but
@@ -136,7 +136,7 @@ func TestMemoryCacheListKeysExpired(t *testing.T) {
 	<-time.After(time.Millisecond * 50)
 
 	var keys []string
-	for k, err := range c.ListKeys(ctx) {
+	for k, err := range c.Keys(ctx) {
 		require.NoError(t, err)
 		keys = append(keys, k)
 	}

--- a/internal/impl/pure/cache_memory_test.go
+++ b/internal/impl/pure/cache_memory_test.go
@@ -93,6 +93,56 @@ func TestMemoryCache(t *testing.T) {
 	require.False(t, exists)
 }
 
+func TestMemoryCacheListKeys(t *testing.T) {
+	ctx := t.Context()
+
+	for _, nShards := range []int{1, 16} {
+		t.Run(fmt.Sprintf("%v shards", nShards), func(t *testing.T) {
+			c := newMemCache(0, 0, nShards, map[string]string{"foo": "1"})
+
+			require.NoError(t, c.Set(ctx, "bar", []byte("2"), nil))
+			require.NoError(t, c.Add(ctx, "baz", []byte("3"), nil))
+
+			var keys []string
+			for k, err := range c.ListKeys(ctx) {
+				require.NoError(t, err)
+				keys = append(keys, k)
+			}
+			assert.ElementsMatch(t, []string{"foo", "bar", "baz"}, keys)
+
+			require.NoError(t, c.Delete(ctx, "bar"))
+
+			keys = nil
+			for k, err := range c.ListKeys(ctx) {
+				require.NoError(t, err)
+				keys = append(keys, k)
+			}
+			assert.ElementsMatch(t, []string{"foo", "baz"}, keys)
+		})
+	}
+}
+
+func TestMemoryCacheListKeysExpired(t *testing.T) {
+	ctx := t.Context()
+
+	// A long compaction interval so that expired items are retained but
+	// considered expired by reads.
+	c := newMemCache(time.Hour, time.Hour, 1, nil)
+
+	ttl := time.Millisecond
+	require.NoError(t, c.Set(ctx, "expires", []byte("1"), &ttl))
+	require.NoError(t, c.Set(ctx, "remains", []byte("2"), nil))
+
+	<-time.After(time.Millisecond * 50)
+
+	var keys []string
+	for k, err := range c.ListKeys(ctx) {
+		require.NoError(t, err)
+		keys = append(keys, k)
+	}
+	assert.ElementsMatch(t, []string{"remains"}, keys)
+}
+
 func TestMemoryCacheCompaction(t *testing.T) {
 	defConf, err := memCacheConfig().ParseYAML(`
 default_ttl: 0s

--- a/internal/manager/mock/cache.go
+++ b/internal/manager/mock/cache.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"iter"
 	"time"
 
 	"github.com/warpstreamlabs/bento/internal/component"
@@ -70,6 +71,17 @@ func (c *Cache) Add(ctx context.Context, key string, value []byte, ttl *time.Dur
 func (c *Cache) Delete(ctx context.Context, key string) error {
 	delete(c.Values, key)
 	return nil
+}
+
+// ListKeys returns an iterator over all keys of the mock cache.
+func (c *Cache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		for k := range c.Values {
+			if !yield(k, nil) {
+				return
+			}
+		}
+	}
 }
 
 // Close does nothing.

--- a/internal/manager/mock/cache.go
+++ b/internal/manager/mock/cache.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"iter"
 	"time"
 
 	"github.com/warpstreamlabs/bento/internal/component"
@@ -73,8 +72,8 @@ func (c *Cache) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-// ListKeys returns an iterator over all keys of the mock cache.
-func (c *Cache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+// Keys returns an iterator over all keys of the mock cache.
+func (c *Cache) Keys(ctx context.Context) cache.KeyIterator {
 	return func(yield func(string, error) bool) {
 		for k := range c.Values {
 			if !yield(k, nil) {

--- a/public/service/cache.go
+++ b/public/service/cache.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"iter"
 	"time"
 
 	"github.com/warpstreamlabs/bento/internal/component"
@@ -48,6 +47,10 @@ type CacheItem struct {
 	TTL   *time.Duration
 }
 
+// KeyIterator is an iterator over the keys held by a cache, as returned by the
+// optional Keys method. Iteration stops after the first non-nil error.
+type KeyIterator = cache.KeyIterator
+
 // batchedCache represents a cache where the underlying implementation is able
 // to benefit from batched set requests. This interface is optional for caches
 // and when implemented will automatically be utilised where possible.
@@ -68,11 +71,73 @@ type existsCache interface {
 // listableCache represents a cache where the underlying implementation is able
 // to enumerate the keys it holds. This interface is optional for caches and
 // when implemented will automatically be utilised where possible, otherwise
-// calls to ListKeys yield ErrKeyListingNotSupported.
+// calls to Keys yield ErrKeyListingNotSupported.
 type listableCache interface {
-	// ListKeys returns an iterator over all keys currently held by the cache.
+	// Keys returns an iterator over all keys currently held by the cache.
 	// Iteration stops after the first non-nil error.
-	ListKeys(ctx context.Context) iter.Seq2[string, error]
+	Keys(ctx context.Context) KeyIterator
+}
+
+// PrefetchKeys builds a Keys iterator that runs the provided produce
+// function in a background goroutine, allowing it to fetch subsequent pages of
+// keys while the caller consumes the keys already found. Up to readAhead keys
+// are buffered; sizing this at or above a backend's page size lets the next
+// page be fetched while the current one is being yielded.
+//
+// The produce function should call emit once for each key. emit returns false
+// once the caller has stopped consuming (an early break, or a downstream
+// error), after which produce should stop and return - typically nil.
+// Returning a non-nil error from produce terminates iteration after yielding
+// that error to the caller. If ctx is cancelled iteration stops without
+// yielding a further error; produce should return promptly when ctx is done.
+//
+// This is a convenience for implementing the optional key-listing behaviour of
+// a paginated cache; it manages the goroutine lifecycle and cancellation on
+// early termination so implementations only need to express their paging loop.
+func PrefetchKeys(ctx context.Context, readAhead int, produce func(ctx context.Context, emit func(key string) bool) error) KeyIterator {
+	return func(yield func(string, error) bool) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		type result struct {
+			key string
+			err error
+		}
+		results := make(chan result, readAhead)
+
+		go func() {
+			defer close(results)
+			err := produce(ctx, func(key string) bool {
+				select {
+				case results <- result{key: key}:
+					return true
+				case <-ctx.Done():
+					return false
+				}
+			})
+			// Only surface an error while the caller is still listening and
+			// neither side has cancelled - a cancellation is the caller's
+			// signal to stop, not an error to report.
+			if err != nil && ctx.Err() == nil {
+				select {
+				case results <- result{err: err}:
+				case <-ctx.Done():
+				}
+			}
+		}()
+
+		for r := range results {
+			if r.err != nil {
+				yield("", r.err)
+				return
+			}
+			if !yield(r.key, nil) {
+				// Cancelling (via the deferred cancel) unblocks the producer's
+				// pending emit so it observes the stop and exits.
+				return
+			}
+		}
+	}
 }
 
 //------------------------------------------------------------------------------
@@ -151,13 +216,13 @@ func (a *airGapCache) Delete(ctx context.Context, key string) error {
 	return a.c.Delete(ctx, key)
 }
 
-func (a *airGapCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+func (a *airGapCache) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
 		if a.cl == nil {
 			yield("", component.ErrKeyListingNotSupported)
 			return
 		}
-		for key, err := range a.cl.ListKeys(ctx) {
+		for key, err := range a.cl.Keys(ctx) {
 			if errors.Is(err, ErrKeyListingNotSupported) {
 				err = component.ErrKeyListingNotSupported
 			}
@@ -210,9 +275,9 @@ func (r *reverseAirGapCache) Delete(ctx context.Context, key string) error {
 	return r.c.Delete(ctx, key)
 }
 
-func (r *reverseAirGapCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+func (r *reverseAirGapCache) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
-		for key, err := range r.c.ListKeys(ctx) {
+		for key, err := range r.c.Keys(ctx) {
 			if errors.Is(err, component.ErrKeyListingNotSupported) {
 				err = ErrKeyListingNotSupported
 			}

--- a/public/service/cache.go
+++ b/public/service/cache.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"iter"
 	"time"
 
 	"github.com/warpstreamlabs/bento/internal/component"
@@ -12,8 +13,9 @@ import (
 
 // Errors returned by cache types.
 var (
-	ErrKeyAlreadyExists = errors.New("key already exists")
-	ErrKeyNotFound      = errors.New("key does not exist")
+	ErrKeyAlreadyExists       = errors.New("key already exists")
+	ErrKeyNotFound            = errors.New("key does not exist")
+	ErrKeyListingNotSupported = errors.New("cache does not support listing keys")
 )
 
 // Cache is an interface implemented by Bento caches.
@@ -63,6 +65,16 @@ type existsCache interface {
 	Exists(ctx context.Context, key string) (bool, error)
 }
 
+// listableCache represents a cache where the underlying implementation is able
+// to enumerate the keys it holds. This interface is optional for caches and
+// when implemented will automatically be utilised where possible, otherwise
+// calls to ListKeys yield ErrKeyListingNotSupported.
+type listableCache interface {
+	// ListKeys returns an iterator over all keys currently held by the cache.
+	// Iteration stops after the first non-nil error.
+	ListKeys(ctx context.Context) iter.Seq2[string, error]
+}
+
 //------------------------------------------------------------------------------
 
 // Implements types.Cache.
@@ -70,12 +82,14 @@ type airGapCache struct {
 	c  Cache
 	cm batchedCache
 	ce existsCache
+	cl listableCache
 }
 
 func newAirGapCache(c Cache, stats metrics.Type) cache.V1 {
-	ag := &airGapCache{c: c, cm: nil}
+	ag := &airGapCache{c: c, cm: nil, cl: nil}
 	ag.cm, _ = c.(batchedCache)
 	ag.ce, _ = c.(existsCache)
+	ag.cl, _ = c.(listableCache)
 	return cache.MetricsForCache(ag, stats)
 }
 
@@ -137,6 +151,23 @@ func (a *airGapCache) Delete(ctx context.Context, key string) error {
 	return a.c.Delete(ctx, key)
 }
 
+func (a *airGapCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		if a.cl == nil {
+			yield("", component.ErrKeyListingNotSupported)
+			return
+		}
+		for key, err := range a.cl.ListKeys(ctx) {
+			if errors.Is(err, ErrKeyListingNotSupported) {
+				err = component.ErrKeyListingNotSupported
+			}
+			if !yield(key, err) {
+				return
+			}
+		}
+	}
+}
+
 func (a *airGapCache) Close(ctx context.Context) error {
 	return a.c.Close(ctx)
 }
@@ -177,6 +208,19 @@ func (r *reverseAirGapCache) Add(ctx context.Context, key string, value []byte, 
 
 func (r *reverseAirGapCache) Delete(ctx context.Context, key string) error {
 	return r.c.Delete(ctx, key)
+}
+
+func (r *reverseAirGapCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		for key, err := range r.c.ListKeys(ctx) {
+			if errors.Is(err, component.ErrKeyListingNotSupported) {
+				err = ErrKeyListingNotSupported
+			}
+			if !yield(key, err) {
+				return
+			}
+		}
+	}
 }
 
 func (r *reverseAirGapCache) Close(ctx context.Context) error {

--- a/public/service/cache.go
+++ b/public/service/cache.go
@@ -142,19 +142,26 @@ func PrefetchKeys(ctx context.Context, readAhead int, produce func(ctx context.C
 
 //------------------------------------------------------------------------------
 
-// Implements types.Cache.
+// Implements cache.V1.
 type airGapCache struct {
 	c  Cache
 	cm batchedCache
 	ce existsCache
-	cl listableCache
 }
 
 func newAirGapCache(c Cache, stats metrics.Type) cache.V1 {
-	ag := &airGapCache{c: c, cm: nil, cl: nil}
+	ag := &airGapCache{c: c}
 	ag.cm, _ = c.(batchedCache)
 	ag.ce, _ = c.(existsCache)
-	ag.cl, _ = c.(listableCache)
+
+	if cl, ok := c.(listableCache); ok {
+		lag := &listableAirGapCache{
+			airGapCache: ag,
+			cl:          cl,
+		}
+		return cache.MetricsForListableCache(lag, stats)
+	}
+
 	return cache.MetricsForCache(ag, stats)
 }
 
@@ -216,12 +223,20 @@ func (a *airGapCache) Delete(ctx context.Context, key string) error {
 	return a.c.Delete(ctx, key)
 }
 
-func (a *airGapCache) Keys(ctx context.Context) KeyIterator {
+func (a *airGapCache) Close(ctx context.Context) error {
+	return a.c.Close(ctx)
+}
+
+//------------------------------------------------------------------------------
+
+// Implements cache.Listable.
+type listableAirGapCache struct {
+	*airGapCache
+	cl listableCache
+}
+
+func (a *listableAirGapCache) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
-		if a.cl == nil {
-			yield("", component.ErrKeyListingNotSupported)
-			return
-		}
 		for key, err := range a.cl.Keys(ctx) {
 			if errors.Is(err, ErrKeyListingNotSupported) {
 				err = component.ErrKeyListingNotSupported
@@ -233,10 +248,6 @@ func (a *airGapCache) Keys(ctx context.Context) KeyIterator {
 	}
 }
 
-func (a *airGapCache) Close(ctx context.Context) error {
-	return a.c.Close(ctx)
-}
-
 //------------------------------------------------------------------------------
 
 // Implements Cache around a types.Cache.
@@ -244,8 +255,17 @@ type reverseAirGapCache struct {
 	c cache.V1
 }
 
-func newReverseAirGapCache(c cache.V1) *reverseAirGapCache {
-	return &reverseAirGapCache{c}
+func newReverseAirGapCache(c cache.V1) Cache {
+	rag := reverseAirGapCache{c: c}
+
+	if cl, ok := c.(cache.Listable); ok {
+		return &listableReverseAirGapCache{
+			reverseAirGapCache: &rag,
+			cl:                 cl,
+		}
+	}
+
+	return &rag
 }
 
 func (r *reverseAirGapCache) Get(ctx context.Context, key string) ([]byte, error) {
@@ -275,9 +295,21 @@ func (r *reverseAirGapCache) Delete(ctx context.Context, key string) error {
 	return r.c.Delete(ctx, key)
 }
 
-func (r *reverseAirGapCache) Keys(ctx context.Context) KeyIterator {
+func (r *reverseAirGapCache) Close(ctx context.Context) error {
+	return r.c.Close(ctx)
+}
+
+//------------------------------------------------------------------------------
+
+// Implements listableCache around a cache.Listable.
+type listableReverseAirGapCache struct {
+	*reverseAirGapCache
+	cl cache.Listable
+}
+
+func (r *listableReverseAirGapCache) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
-		for key, err := range r.c.Keys(ctx) {
+		for key, err := range r.cl.Keys(ctx) {
 			if errors.Is(err, component.ErrKeyListingNotSupported) {
 				err = ErrKeyListingNotSupported
 			}
@@ -286,8 +318,4 @@ func (r *reverseAirGapCache) Keys(ctx context.Context) KeyIterator {
 			}
 		}
 	}
-}
-
-func (r *reverseAirGapCache) Close(ctx context.Context) error {
-	return r.c.Close(ctx)
 }

--- a/public/service/cache.go
+++ b/public/service/cache.go
@@ -78,68 +78,6 @@ type listableCache interface {
 	Keys(ctx context.Context) KeyIterator
 }
 
-// PrefetchKeys builds a Keys iterator that runs the provided produce
-// function in a background goroutine, allowing it to fetch subsequent pages of
-// keys while the caller consumes the keys already found. Up to readAhead keys
-// are buffered; sizing this at or above a backend's page size lets the next
-// page be fetched while the current one is being yielded.
-//
-// The produce function should call emit once for each key. emit returns false
-// once the caller has stopped consuming (an early break, or a downstream
-// error), after which produce should stop and return - typically nil.
-// Returning a non-nil error from produce terminates iteration after yielding
-// that error to the caller. If ctx is cancelled iteration stops without
-// yielding a further error; produce should return promptly when ctx is done.
-//
-// This is a convenience for implementing the optional key-listing behaviour of
-// a paginated cache; it manages the goroutine lifecycle and cancellation on
-// early termination so implementations only need to express their paging loop.
-func PrefetchKeys(ctx context.Context, readAhead int, produce func(ctx context.Context, emit func(key string) bool) error) KeyIterator {
-	return func(yield func(string, error) bool) {
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		type result struct {
-			key string
-			err error
-		}
-		results := make(chan result, readAhead)
-
-		go func() {
-			defer close(results)
-			err := produce(ctx, func(key string) bool {
-				select {
-				case results <- result{key: key}:
-					return true
-				case <-ctx.Done():
-					return false
-				}
-			})
-			// Only surface an error while the caller is still listening and
-			// neither side has cancelled - a cancellation is the caller's
-			// signal to stop, not an error to report.
-			if err != nil && ctx.Err() == nil {
-				select {
-				case results <- result{err: err}:
-				case <-ctx.Done():
-				}
-			}
-		}()
-
-		for r := range results {
-			if r.err != nil {
-				yield("", r.err)
-				return
-			}
-			if !yield(r.key, nil) {
-				// Cancelling (via the deferred cancel) unblocks the producer's
-				// pending emit so it observes the stop and exits.
-				return
-			}
-		}
-	}
-}
-
 //------------------------------------------------------------------------------
 
 // Implements cache.V1.

--- a/public/service/cache_test.go
+++ b/public/service/cache_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"strconv"
 	"testing"
 	"time"
 
@@ -598,104 +597,6 @@ func TestCacheReverseAirGapKeys(t *testing.T) {
 	assert.ElementsMatch(t, []string{"foo", "baz"}, keys)
 }
 
-func TestPrefetchKeys(t *testing.T) {
-	src := []string{"a", "b", "c", "d", "e"}
-	seq := PrefetchKeys(t.Context(), 2, func(ctx context.Context, emit func(string) bool) error {
-		for _, k := range src {
-			if !emit(k) {
-				return nil
-			}
-		}
-		return nil
-	})
-
-	var keys []string
-	for k, err := range seq {
-		require.NoError(t, err)
-		keys = append(keys, k)
-	}
-	assert.Equal(t, src, keys)
-}
-
-func TestPrefetchKeysError(t *testing.T) {
-	errBoom := errors.New("boom")
-	seq := PrefetchKeys(t.Context(), 2, func(ctx context.Context, emit func(string) bool) error {
-		if !emit("a") {
-			return nil
-		}
-		return errBoom
-	})
-
-	var keys []string
-	var gotErr error
-	for k, err := range seq {
-		if err != nil {
-			gotErr = err
-			break
-		}
-		keys = append(keys, k)
-	}
-	assert.Equal(t, []string{"a"}, keys)
-	assert.ErrorIs(t, gotErr, errBoom)
-}
-
-func TestPrefetchKeysEarlyBreak(t *testing.T) {
-	stopped := make(chan struct{})
-	seq := PrefetchKeys(t.Context(), 1, func(ctx context.Context, emit func(string) bool) error {
-		defer close(stopped)
-		for i := 0; ; i++ {
-			if !emit(strconv.Itoa(i)) {
-				return nil
-			}
-		}
-	})
-
-	var keys []string
-	for k := range seq {
-		keys = append(keys, k)
-		if len(keys) == 3 {
-			break
-		}
-	}
-	assert.Equal(t, []string{"0", "1", "2"}, keys)
-
-	// The producer must observe the early break and exit rather than leak.
-	select {
-	case <-stopped:
-	case <-time.After(time.Second):
-		t.Fatal("producer did not stop after early break")
-	}
-}
-
-func TestPrefetchKeysContextCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	stopped := make(chan struct{})
-	seq := PrefetchKeys(ctx, 1, func(ctx context.Context, emit func(string) bool) error {
-		defer close(stopped)
-		for i := 0; ; i++ {
-			if !emit(strconv.Itoa(i)) {
-				return ctx.Err()
-			}
-		}
-	})
-
-	var keys []string
-	for k, err := range seq {
-		require.NoError(t, err) // cancellation stops iteration without an error
-		keys = append(keys, k)
-		if len(keys) == 2 {
-			cancel()
-		}
-	}
-
-	select {
-	case <-stopped:
-	case <-time.After(time.Second):
-		t.Fatal("producer did not stop after context cancellation")
-	}
-}
-
 // TestCacheKeysRoundTrip covers the full journey of a cache implementing
 // the optional Keys method registered as a plugin and then accessed as a
 // resource, which passes through the air gap, metrics and reverse air gap
@@ -711,7 +612,7 @@ func TestCacheKeysRoundTrip(t *testing.T) {
 		},
 	}
 
-	var agrl Cache = newReverseAirGapCache(newAirGapCache(rl, metrics.Noop()))
+	agrl := newReverseAirGapCache(newAirGapCache(rl, metrics.Noop()))
 
 	lc, ok := agrl.(interface {
 		Keys(ctx context.Context) KeyIterator
@@ -729,7 +630,7 @@ func TestCacheKeysRoundTrip(t *testing.T) {
 		m: map[string]testCacheItem{},
 	}
 
-	var agrlNotListable Cache = newReverseAirGapCache(newAirGapCache(rlNotListable, metrics.Noop()))
+	agrlNotListable := newReverseAirGapCache(newAirGapCache(rlNotListable, metrics.Noop()))
 
 	_, ok = agrlNotListable.(interface {
 		Keys(ctx context.Context) KeyIterator

--- a/public/service/cache_test.go
+++ b/public/service/cache_test.go
@@ -3,10 +3,12 @@ package service
 import (
 	"context"
 	"errors"
+	"iter"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/warpstreamlabs/bento/internal/component"
 	"github.com/warpstreamlabs/bento/internal/component/cache"
@@ -291,6 +293,59 @@ func TestCacheAirGapAddWithTTL(t *testing.T) {
 	assert.EqualError(t, err, "key already exists")
 }
 
+type listableClosableCache struct {
+	*closableCache
+}
+
+func (c *listableClosableCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		if c.err != nil {
+			yield("", c.err)
+			return
+		}
+		for k := range c.m {
+			if !yield(k, nil) {
+				return
+			}
+		}
+	}
+}
+
+func TestCacheAirGapListKeys(t *testing.T) {
+	ctx := t.Context()
+	rl := &listableClosableCache{
+		closableCache: &closableCache{
+			m: map[string]testCacheItem{
+				"foo": {
+					b: []byte("bar"),
+				},
+				"baz": {
+					b: []byte("qux"),
+				},
+			},
+		},
+	}
+	agrl := newAirGapCache(rl, metrics.Noop())
+
+	var keys []string
+	for k, err := range agrl.ListKeys(ctx) {
+		require.NoError(t, err)
+		keys = append(keys, k)
+	}
+	assert.ElementsMatch(t, []string{"foo", "baz"}, keys)
+}
+
+func TestCacheAirGapListKeysNotSupported(t *testing.T) {
+	rl := &closableCache{
+		m: map[string]testCacheItem{},
+	}
+	agrl := newAirGapCache(rl, metrics.Noop())
+
+	for _, err := range agrl.ListKeys(t.Context()) {
+		require.ErrorIs(t, err, component.ErrKeyListingNotSupported)
+	}
+}
+
 func TestCacheAirGapDelete(t *testing.T) {
 	ctx := context.Background()
 	rl := &closableCache{
@@ -365,6 +420,12 @@ func (c *closableCacheType) Delete(ctx context.Context, key string) error {
 	}
 	delete(c.m, key)
 	return nil
+}
+
+func (c *closableCacheType) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		yield("", component.ErrKeyListingNotSupported)
+	}
 }
 
 func (c *closableCacheType) Close(ctx context.Context) error {
@@ -505,4 +566,101 @@ func TestCacheReverseAirGapDelete(t *testing.T) {
 	err := agrl.Delete(context.Background(), "foo")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]testCacheItem{}, rl.m)
+}
+
+type listableClosableCacheType struct {
+	*closableCacheType
+}
+
+func (c *listableClosableCacheType) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		if c.err != nil {
+			yield("", c.err)
+			return
+		}
+		for k := range c.m {
+			if !yield(k, nil) {
+				return
+			}
+		}
+	}
+}
+
+func TestCacheReverseAirGapListKeys(t *testing.T) {
+	rl := &listableClosableCacheType{
+		closableCacheType: &closableCacheType{
+			m: map[string]testCacheItem{
+				"foo": {
+					b: []byte("bar"),
+				},
+				"baz": {
+					b: []byte("qux"),
+				},
+			},
+		},
+	}
+	agrl := newReverseAirGapCache(rl)
+
+	var keys []string
+	for k, err := range agrl.ListKeys(t.Context()) {
+		require.NoError(t, err)
+		keys = append(keys, k)
+	}
+	assert.ElementsMatch(t, []string{"foo", "baz"}, keys)
+}
+
+func TestCacheReverseAirGapListKeysNotSupported(t *testing.T) {
+	rl := &closableCacheType{
+		m: map[string]testCacheItem{},
+	}
+	agrl := newReverseAirGapCache(rl)
+
+	for _, err := range agrl.ListKeys(t.Context()) {
+		require.ErrorIs(t, err, ErrKeyListingNotSupported)
+	}
+}
+
+// TestCacheListKeysRoundTrip covers the full journey of a cache implementing
+// the optional ListKeys method registered as a plugin and then accessed as a
+// resource, which passes through the air gap, metrics and reverse air gap
+// wrappers.
+func TestCacheListKeysRoundTrip(t *testing.T) {
+	rl := &listableClosableCache{
+		closableCache: &closableCache{
+			m: map[string]testCacheItem{
+				"foo": {
+					b: []byte("bar"),
+				},
+			},
+		},
+	}
+
+	var agrl Cache = newReverseAirGapCache(newAirGapCache(rl, metrics.Noop()))
+
+	lc, ok := agrl.(interface {
+		ListKeys(ctx context.Context) iter.Seq2[string, error]
+	})
+	require.True(t, ok)
+
+	var keys []string
+	for k, err := range lc.ListKeys(t.Context()) {
+		require.NoError(t, err)
+		keys = append(keys, k)
+	}
+	assert.ElementsMatch(t, []string{"foo"}, keys)
+
+	rlNotListable := &closableCache{
+		m: map[string]testCacheItem{},
+	}
+
+	var agrlNotListable Cache = newReverseAirGapCache(newAirGapCache(rlNotListable, metrics.Noop()))
+
+	lcNotListable, ok := agrlNotListable.(interface {
+		ListKeys(ctx context.Context) iter.Seq2[string, error]
+	})
+	require.True(t, ok)
+
+	for _, err := range lcNotListable.ListKeys(t.Context()) {
+		require.ErrorIs(t, err, ErrKeyListingNotSupported)
+	}
 }

--- a/public/service/cache_test.go
+++ b/public/service/cache_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"errors"
-	"iter"
+	"strconv"
 	"testing"
 	"time"
 
@@ -297,7 +297,7 @@ type listableClosableCache struct {
 	*closableCache
 }
 
-func (c *listableClosableCache) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+func (c *listableClosableCache) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
 		if c.err != nil {
 			yield("", c.err)
@@ -311,7 +311,7 @@ func (c *listableClosableCache) ListKeys(ctx context.Context) iter.Seq2[string, 
 	}
 }
 
-func TestCacheAirGapListKeys(t *testing.T) {
+func TestCacheAirGapKeys(t *testing.T) {
 	ctx := t.Context()
 	rl := &listableClosableCache{
 		closableCache: &closableCache{
@@ -328,20 +328,20 @@ func TestCacheAirGapListKeys(t *testing.T) {
 	agrl := newAirGapCache(rl, metrics.Noop())
 
 	var keys []string
-	for k, err := range agrl.ListKeys(ctx) {
+	for k, err := range agrl.Keys(ctx) {
 		require.NoError(t, err)
 		keys = append(keys, k)
 	}
 	assert.ElementsMatch(t, []string{"foo", "baz"}, keys)
 }
 
-func TestCacheAirGapListKeysNotSupported(t *testing.T) {
+func TestCacheAirGapKeysNotSupported(t *testing.T) {
 	rl := &closableCache{
 		m: map[string]testCacheItem{},
 	}
 	agrl := newAirGapCache(rl, metrics.Noop())
 
-	for _, err := range agrl.ListKeys(t.Context()) {
+	for _, err := range agrl.Keys(t.Context()) {
 		require.ErrorIs(t, err, component.ErrKeyListingNotSupported)
 	}
 }
@@ -422,7 +422,7 @@ func (c *closableCacheType) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-func (c *closableCacheType) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+func (c *closableCacheType) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
 		yield("", component.ErrKeyListingNotSupported)
 	}
@@ -572,7 +572,7 @@ type listableClosableCacheType struct {
 	*closableCacheType
 }
 
-func (c *listableClosableCacheType) ListKeys(ctx context.Context) iter.Seq2[string, error] {
+func (c *listableClosableCacheType) Keys(ctx context.Context) KeyIterator {
 	return func(yield func(string, error) bool) {
 		if c.err != nil {
 			yield("", c.err)
@@ -586,7 +586,7 @@ func (c *listableClosableCacheType) ListKeys(ctx context.Context) iter.Seq2[stri
 	}
 }
 
-func TestCacheReverseAirGapListKeys(t *testing.T) {
+func TestCacheReverseAirGapKeys(t *testing.T) {
 	rl := &listableClosableCacheType{
 		closableCacheType: &closableCacheType{
 			m: map[string]testCacheItem{
@@ -602,29 +602,127 @@ func TestCacheReverseAirGapListKeys(t *testing.T) {
 	agrl := newReverseAirGapCache(rl)
 
 	var keys []string
-	for k, err := range agrl.ListKeys(t.Context()) {
+	for k, err := range agrl.Keys(t.Context()) {
 		require.NoError(t, err)
 		keys = append(keys, k)
 	}
 	assert.ElementsMatch(t, []string{"foo", "baz"}, keys)
 }
 
-func TestCacheReverseAirGapListKeysNotSupported(t *testing.T) {
+func TestCacheReverseAirGapKeysNotSupported(t *testing.T) {
 	rl := &closableCacheType{
 		m: map[string]testCacheItem{},
 	}
 	agrl := newReverseAirGapCache(rl)
 
-	for _, err := range agrl.ListKeys(t.Context()) {
+	for _, err := range agrl.Keys(t.Context()) {
 		require.ErrorIs(t, err, ErrKeyListingNotSupported)
 	}
 }
 
-// TestCacheListKeysRoundTrip covers the full journey of a cache implementing
-// the optional ListKeys method registered as a plugin and then accessed as a
+func TestPrefetchKeys(t *testing.T) {
+	src := []string{"a", "b", "c", "d", "e"}
+	seq := PrefetchKeys(t.Context(), 2, func(ctx context.Context, emit func(string) bool) error {
+		for _, k := range src {
+			if !emit(k) {
+				return nil
+			}
+		}
+		return nil
+	})
+
+	var keys []string
+	for k, err := range seq {
+		require.NoError(t, err)
+		keys = append(keys, k)
+	}
+	assert.Equal(t, src, keys)
+}
+
+func TestPrefetchKeysError(t *testing.T) {
+	errBoom := errors.New("boom")
+	seq := PrefetchKeys(t.Context(), 2, func(ctx context.Context, emit func(string) bool) error {
+		if !emit("a") {
+			return nil
+		}
+		return errBoom
+	})
+
+	var keys []string
+	var gotErr error
+	for k, err := range seq {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		keys = append(keys, k)
+	}
+	assert.Equal(t, []string{"a"}, keys)
+	assert.ErrorIs(t, gotErr, errBoom)
+}
+
+func TestPrefetchKeysEarlyBreak(t *testing.T) {
+	stopped := make(chan struct{})
+	seq := PrefetchKeys(t.Context(), 1, func(ctx context.Context, emit func(string) bool) error {
+		defer close(stopped)
+		for i := 0; ; i++ {
+			if !emit(strconv.Itoa(i)) {
+				return nil
+			}
+		}
+	})
+
+	var keys []string
+	for k := range seq {
+		keys = append(keys, k)
+		if len(keys) == 3 {
+			break
+		}
+	}
+	assert.Equal(t, []string{"0", "1", "2"}, keys)
+
+	// The producer must observe the early break and exit rather than leak.
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("producer did not stop after early break")
+	}
+}
+
+func TestPrefetchKeysContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	stopped := make(chan struct{})
+	seq := PrefetchKeys(ctx, 1, func(ctx context.Context, emit func(string) bool) error {
+		defer close(stopped)
+		for i := 0; ; i++ {
+			if !emit(strconv.Itoa(i)) {
+				return ctx.Err()
+			}
+		}
+	})
+
+	var keys []string
+	for k, err := range seq {
+		require.NoError(t, err) // cancellation stops iteration without an error
+		keys = append(keys, k)
+		if len(keys) == 2 {
+			cancel()
+		}
+	}
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("producer did not stop after context cancellation")
+	}
+}
+
+// TestCacheKeysRoundTrip covers the full journey of a cache implementing
+// the optional Keys method registered as a plugin and then accessed as a
 // resource, which passes through the air gap, metrics and reverse air gap
 // wrappers.
-func TestCacheListKeysRoundTrip(t *testing.T) {
+func TestCacheKeysRoundTrip(t *testing.T) {
 	rl := &listableClosableCache{
 		closableCache: &closableCache{
 			m: map[string]testCacheItem{
@@ -638,12 +736,12 @@ func TestCacheListKeysRoundTrip(t *testing.T) {
 	var agrl Cache = newReverseAirGapCache(newAirGapCache(rl, metrics.Noop()))
 
 	lc, ok := agrl.(interface {
-		ListKeys(ctx context.Context) iter.Seq2[string, error]
+		Keys(ctx context.Context) KeyIterator
 	})
 	require.True(t, ok)
 
 	var keys []string
-	for k, err := range lc.ListKeys(t.Context()) {
+	for k, err := range lc.Keys(t.Context()) {
 		require.NoError(t, err)
 		keys = append(keys, k)
 	}
@@ -656,11 +754,11 @@ func TestCacheListKeysRoundTrip(t *testing.T) {
 	var agrlNotListable Cache = newReverseAirGapCache(newAirGapCache(rlNotListable, metrics.Noop()))
 
 	lcNotListable, ok := agrlNotListable.(interface {
-		ListKeys(ctx context.Context) iter.Seq2[string, error]
+		Keys(ctx context.Context) KeyIterator
 	})
 	require.True(t, ok)
 
-	for _, err := range lcNotListable.ListKeys(t.Context()) {
+	for _, err := range lcNotListable.Keys(t.Context()) {
 		require.ErrorIs(t, err, ErrKeyListingNotSupported)
 	}
 }

--- a/public/service/cache_test.go
+++ b/public/service/cache_test.go
@@ -328,22 +328,11 @@ func TestCacheAirGapKeys(t *testing.T) {
 	agrl := newAirGapCache(rl, metrics.Noop())
 
 	var keys []string
-	for k, err := range agrl.Keys(ctx) {
+	for k, err := range agrl.(cache.Listable).Keys(ctx) {
 		require.NoError(t, err)
 		keys = append(keys, k)
 	}
 	assert.ElementsMatch(t, []string{"foo", "baz"}, keys)
-}
-
-func TestCacheAirGapKeysNotSupported(t *testing.T) {
-	rl := &closableCache{
-		m: map[string]testCacheItem{},
-	}
-	agrl := newAirGapCache(rl, metrics.Noop())
-
-	for _, err := range agrl.Keys(t.Context()) {
-		require.ErrorIs(t, err, component.ErrKeyListingNotSupported)
-	}
 }
 
 func TestCacheAirGapDelete(t *testing.T) {
@@ -602,22 +591,11 @@ func TestCacheReverseAirGapKeys(t *testing.T) {
 	agrl := newReverseAirGapCache(rl)
 
 	var keys []string
-	for k, err := range agrl.Keys(t.Context()) {
+	for k, err := range agrl.(listableCache).Keys(t.Context()) {
 		require.NoError(t, err)
 		keys = append(keys, k)
 	}
 	assert.ElementsMatch(t, []string{"foo", "baz"}, keys)
-}
-
-func TestCacheReverseAirGapKeysNotSupported(t *testing.T) {
-	rl := &closableCacheType{
-		m: map[string]testCacheItem{},
-	}
-	agrl := newReverseAirGapCache(rl)
-
-	for _, err := range agrl.Keys(t.Context()) {
-		require.ErrorIs(t, err, ErrKeyListingNotSupported)
-	}
 }
 
 func TestPrefetchKeys(t *testing.T) {
@@ -753,12 +731,8 @@ func TestCacheKeysRoundTrip(t *testing.T) {
 
 	var agrlNotListable Cache = newReverseAirGapCache(newAirGapCache(rlNotListable, metrics.Noop()))
 
-	lcNotListable, ok := agrlNotListable.(interface {
+	_, ok = agrlNotListable.(interface {
 		Keys(ctx context.Context) KeyIterator
 	})
-	require.True(t, ok)
-
-	for _, err := range lcNotListable.Keys(t.Context()) {
-		require.ErrorIs(t, err, ErrKeyListingNotSupported)
-	}
+	require.False(t, ok)
 }

--- a/public/service/integration/cache_test_definitions.go
+++ b/public/service/integration/cache_test_definitions.go
@@ -112,6 +112,34 @@ func CacheTestDelete() CacheTestDefinition {
 	)
 }
 
+// CacheTestListKeys checks that a cache supporting key listing enumerates the
+// keys it holds after n items are set.
+func CacheTestListKeys(n int) CacheTestDefinition {
+	return namedCacheTest(
+		"can list keys",
+		func(t *testing.T, env *cacheTestEnvironment) {
+			cache := initCache(t, env)
+			t.Cleanup(func() {
+				closeCache(t, cache)
+			})
+
+			expKeys := make([]string, 0, n)
+			for i := range n {
+				key := fmt.Sprintf("listkey%v", i)
+				require.NoError(t, cache.Set(env.ctx, key, fmt.Appendf(nil, "value%v", i), nil))
+				expKeys = append(expKeys, key)
+			}
+
+			var keys []string
+			for key, err := range cache.ListKeys(env.ctx) {
+				require.NoError(t, err)
+				keys = append(keys, key)
+			}
+			assert.ElementsMatch(t, expKeys, keys)
+		},
+	)
+}
+
 // CacheTestGetAndSet checks that we can set and then get n items.
 func CacheTestGetAndSet(n int) CacheTestDefinition {
 	return namedCacheTest(

--- a/public/service/integration/cache_test_definitions.go
+++ b/public/service/integration/cache_test_definitions.go
@@ -112,9 +112,9 @@ func CacheTestDelete() CacheTestDefinition {
 	)
 }
 
-// CacheTestListKeys checks that a cache supporting key listing enumerates the
+// CacheTestKeys checks that a cache supporting key listing enumerates the
 // keys it holds after n items are set.
-func CacheTestListKeys(n int) CacheTestDefinition {
+func CacheTestKeys(n int) CacheTestDefinition {
 	return namedCacheTest(
 		"can list keys",
 		func(t *testing.T, env *cacheTestEnvironment) {
@@ -131,7 +131,7 @@ func CacheTestListKeys(n int) CacheTestDefinition {
 			}
 
 			var keys []string
-			for key, err := range cache.ListKeys(env.ctx) {
+			for key, err := range cache.Keys(env.ctx) {
 				require.NoError(t, err)
 				keys = append(keys, key)
 			}

--- a/public/service/integration/cache_test_definitions.go
+++ b/public/service/integration/cache_test_definitions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/warpstreamlabs/bento/internal/component"
+	icache "github.com/warpstreamlabs/bento/internal/component/cache"
 )
 
 // CacheTestOpenClose checks that the cache can be started, an item added, and
@@ -130,8 +131,11 @@ func CacheTestKeys(n int) CacheTestDefinition {
 				expKeys = append(expKeys, key)
 			}
 
+			lister, ok := cache.(icache.Listable)
+			require.True(t, ok, "cache does not support key listing")
+
 			var keys []string
-			for key, err := range cache.Keys(env.ctx) {
+			for key, err := range lister.Keys(env.ctx) {
 				require.NoError(t, err)
 				keys = append(keys, key)
 			}


### PR DESCRIPTION
## Description

Adds an optional `ListableCache` interface to the `service` package for caches that are able to enumerate the keys they hold:

```go
type ListableCache interface {
	Cache

	// ListKeys returns a slice of all keys currently held by the cache.
	ListKeys(ctx context.Context) ([]string, error)
}
```

Not all caches can support key listing, so support is detected via type assertion on the cache obtained from `*Resources.AccessCache`. The air gap, metrics and reverse air gap wrappers propagate the capability only when the underlying cache implements it, so the assertion stays truthful through the whole chain. The metrics wrapper emits the standard cache metrics with `operation="list_keys"`.

Implementations included: `memory` (walks shards, omits TTL-expired items to match `Get` semantics), `file` (recursive directory walk), `aws_s3` (paginated `ListObjectsV2` with the cache's existing backoff pattern) and `gcp_cloud_storage` (bucket object iterator). The mock cache behind `MockResourcesOptAddCache` also implements it so plugin authors can test listable-cache consumers.

Motivation: components consuming a cache resource currently have no way to enumerate its contents, so patterns like "replay everything stored in this cache" require maintaining a separate index entry alongside the cached items. A follow-up PR adds a `cache` input built on this interface.

## Testing

- Unit tests for the type-assertion passthrough at each wrapper layer, including a round trip through all of them
- `ListKeys` unit tests for `memory` (including shards and TTL expiry) and `file` (including nested directories)
- New `CacheTestListKeys` integration test definition, wired into the `aws_s3` localstack suite and verified locally