### PR TITLE
Fix kafka key metadata

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -471,7 +471,9 @@ type msgWithRecord struct {
 
 func (f *franzKafkaReader) recordToMessage(record *kgo.Record) *msgWithRecord {
 	msg := service.NewMessage(record.Value)
-	msg.MetaSetMut("kafka_key", string(record.Key))
+	if record.Key != nil {
+		msg.MetaSetMut("kafka_key", string(record.Key))
+	}
 	msg.MetaSetMut("kafka_topic", record.Topic)
 	msg.MetaSetMut("kafka_partition", int(record.Partition))
 	msg.MetaSetMut("kafka_offset", int(record.Offset))

--- a/internal/impl/kafka/input_kafka_franz_test.go
+++ b/internal/impl/kafka/input_kafka_franz_test.go
@@ -416,3 +416,50 @@ kafka_franz:
 		return messageCount == 2
 	}, time.Second*20, time.Millisecond*500)
 }
+
+func TestRecordToMessageKafkaKeyMeta(t *testing.T) {
+	conf, err := franzKafkaInputConfig().ParseYAML(`
+seed_brokers: [localhost:9092]
+topics: [foo]
+consumer_group: bar
+`, nil)
+	require.NoError(t, err)
+
+	input, err := newFranzKafkaReaderFromConfig(conf, service.MockResources())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		key        []byte
+		wantExists bool
+		wantKey    string
+	}{
+		{
+			name:       "nil key omits metadata",
+			key:        nil,
+			wantExists: false,
+		},
+		{
+			name:       "empty key sets empty metadata",
+			key:        []byte{},
+			wantExists: true,
+			wantKey:    "",
+		},
+		{
+			name:       "populated key sets metadata",
+			key:        []byte("foobar"),
+			wantExists: true,
+			wantKey:    "foobar",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			msg := input.recordToMessage(&kgo.Record{Key: test.key}).msg
+
+			key, exists := msg.MetaGet("kafka_key")
+			assert.Equal(t, test.wantExists, exists)
+			assert.Equal(t, test.wantKey, key)
+		})
+	}
+}

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -457,6 +457,11 @@ func (ie *interpolationExecutor) exec(i int) (topic string, key []byte, partitio
 			err = fmt.Errorf("key interpolation error: %w", err)
 			return
 		}
+		// TODO: replace with a null aware method on the executor
+		// rather than infer from the returned bytes
+		if slices.Equal(key, []byte("null")) {
+			key = nil
+		}
 	}
 	if ie.partitionExecutor != nil {
 		var partStr string

--- a/internal/impl/kafka/output_kafka_franz_test.go
+++ b/internal/impl/kafka/output_kafka_franz_test.go
@@ -107,3 +107,32 @@ topic: foo
 		})
 	}
 }
+
+func TestFranzWriterInterpolatedKey(t *testing.T) {
+	conf := `
+seed_brokers: [ foo:1234 ]
+topic: foo
+key: '${! json("key") }'
+`
+
+	pConf, err := franzKafkaOutputConfig().ParseYAML(conf, nil)
+	require.NoError(t, err)
+
+	out, err := newFranzKafkaWriterFromConfig(pConf, service.MockResources().Logger())
+	require.NoError(t, err)
+
+	msgBatch := service.MessageBatch{
+		service.NewMessage([]byte(`{"id":"foo","content":"foo stuff"}`)),
+		service.NewMessage([]byte(`{"id":"bar","content":"bar stuff", "key": 1234}`)),
+	}
+
+	ie := out.newInterpolationExecutor(msgBatch)
+
+	_, key, _, err := ie.exec(0)
+	require.NoError(t, err)
+	assert.Nil(t, key)
+
+	_, key, _, err = ie.exec(1)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("1234"), key)
+}


### PR DESCRIPTION
This fixes an issue that pertains to partition routing with the `kafka_franz` components.

The `kafka_franz` input would erroneously set the metadata field "kafka_key" to an empty string if there was no kafka_key on the record: 

```go
msg.MetaSetMut("kafka_key", string(record.Key))
```

A `nil` record.Key would be cast to an empty string.

Then at the output layer: 

```yaml
output:
  kafka_franz_warpstream:
    key: ${! metadata("kafka_key") }
    topic: audit-content-gc
    tls:
      enabled: true
      skip_cert_verify: true
```

The bloblang mapping for the field 'key' would resolve to an empty string, and that empty string value would be used to hash into a partition (and therefore the same partition), whereas setting the key to a nil value would utilise all partitions. 

--- 
