### PR TITLE
feat(sql): support batch-scoped ClickHouse settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `parse_big_decimal` bloblang method for Kafka Connect / Debezium decimal decoding @aratz-lasa
+- `clickhouse_settings` on the `sql_insert` output for batch-scoped ClickHouse query settings @catkins
 
 ## 1.19.0 - 2026-07-10
 

--- a/internal/component/output/async_writer.go
+++ b/internal/component/output/async_writer.go
@@ -39,6 +39,13 @@ type AsyncSink interface {
 	Close(ctx context.Context) error
 }
 
+// BatchContextPreparer is an optional extension for sinks that derive context
+// values once per dispatched output transaction. The prepared context is
+// reused by connection retry attempts for that transaction.
+type BatchContextPreparer interface {
+	PrepareBatchContext(context.Context, message.Batch) (context.Context, error)
+}
+
 // AsyncWriter is an output type that writes messages to a writer.Type.
 type AsyncWriter struct {
 	connection atomic.Pointer[component.ConnectionStatus]
@@ -155,7 +162,7 @@ func (w *AsyncWriter) loop() {
 	wg.Add(w.maxInflight)
 
 	connectMut := sync.Mutex{}
-	connectLoop := func(msg message.Batch) (latency int64, err error) {
+	connectLoop := func(ctx context.Context, msg message.Batch) (latency int64, err error) {
 		w.connection.Store(component.ConnectionFailing(w.mgr, component.ErrNotConnected))
 
 		connectMut.Lock()
@@ -164,7 +171,7 @@ func (w *AsyncWriter) loop() {
 		// If another goroutine got here first and we're able to send over the
 		// connection, then we gracefully accept defeat.
 		if w.connection.Load().Connected {
-			if latency, err = w.latencyMeasuringWrite(closeLeisureCtx, msg); err != component.ErrNotConnected {
+			if latency, err = w.latencyMeasuringWrite(ctx, msg); err != component.ErrNotConnected {
 				return
 			} else if err != nil {
 				mError.Incr(1)
@@ -178,7 +185,7 @@ func (w *AsyncWriter) loop() {
 				err = component.ErrTypeClosed
 				return
 			}
-			if latency, err = w.latencyMeasuringWrite(closeLeisureCtx, msg); err != component.ErrNotConnected {
+			if latency, err = w.latencyMeasuringWrite(ctx, msg); err != component.ErrNotConnected {
 				w.connection.Store(component.ConnectionActive(w.mgr))
 				mConn.Incr(1)
 				return
@@ -206,11 +213,22 @@ func (w *AsyncWriter) loop() {
 			w.log.Trace("Attempting to write %v messages to '%v'.\n", ts.Payload.Len(), w.typeStr)
 			_, spans := tracing.WithChildSpans(w.tracer, traceName, ts.Payload)
 
-			latency, err := w.latencyMeasuringWrite(closeLeisureCtx, ts.Payload)
+			writeCtx := closeLeisureCtx
+			var err error
+			var attemptedWrite bool
+			if p, ok := w.writer.(BatchContextPreparer); ok {
+				writeCtx, err = p.PrepareBatchContext(writeCtx, ts.Payload)
+			}
+
+			var latency int64
+			if err == nil {
+				attemptedWrite = true
+				latency, err = w.latencyMeasuringWrite(writeCtx, ts.Payload)
+			}
 
 			// If our writer says it is not connected.
-			if errors.Is(err, component.ErrNotConnected) {
-				latency, err = connectLoop(ts.Payload)
+			if attemptedWrite && errors.Is(err, component.ErrNotConnected) {
+				latency, err = connectLoop(writeCtx, ts.Payload)
 			} else if err != nil {
 				mError.Incr(1)
 			}

--- a/internal/component/output/async_writer_test.go
+++ b/internal/component/output/async_writer_test.go
@@ -64,6 +64,36 @@ func (w *writerCantSend) WriteBatch(ctx context.Context, msg message.Batch) erro
 }
 func (w *writerCantSend) Close(context.Context) error { return nil }
 
+type preparedContextKey struct{}
+
+type contextPreparingMockWriter struct {
+	*mockAsyncWriter
+	prepareCount uint64
+	seenValues   []uint64
+	seenMut      sync.Mutex
+}
+
+type failingContextPreparingMockWriter struct {
+	*mockAsyncWriter
+}
+
+func (w *failingContextPreparingMockWriter) PrepareBatchContext(context.Context, message.Batch) (context.Context, error) {
+	return nil, component.ErrNotConnected
+}
+
+func (w *contextPreparingMockWriter) PrepareBatchContext(ctx context.Context, _ message.Batch) (context.Context, error) {
+	value := atomic.AddUint64(&w.prepareCount, 1)
+	return context.WithValue(ctx, preparedContextKey{}, value), nil
+}
+
+func (w *contextPreparingMockWriter) WriteBatch(ctx context.Context, msg message.Batch) error {
+	value, _ := ctx.Value(preparedContextKey{}).(uint64)
+	w.seenMut.Lock()
+	w.seenValues = append(w.seenValues, value)
+	w.seenMut.Unlock()
+	return w.mockAsyncWriter.WriteBatch(ctx, msg)
+}
+
 //------------------------------------------------------------------------------
 
 func TestAsyncWriterCantConnect(t *testing.T) {
@@ -338,6 +368,87 @@ func TestAsyncWriterCanReconnect(t *testing.T) {
 	ctx, done := context.WithTimeout(context.Background(), time.Second*30)
 	defer done()
 
+	w.TriggerCloseNow()
+	require.NoError(t, w.WaitForClose(ctx))
+}
+
+func TestAsyncWriterReusesPreparedBatchContextOnReconnect(t *testing.T) {
+	t.Parallel()
+
+	writerImpl := &contextPreparingMockWriter{mockAsyncWriter: newAsyncMockWriter()}
+	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	require.NoError(t, err)
+
+	msgChan := make(chan message.Transaction)
+	resChan := make(chan error)
+	require.NoError(t, w.Consume(msgChan))
+
+	select {
+	case writerImpl.connChan <- nil:
+	case <-time.After(time.Second):
+		t.Fatal("Timed out")
+	}
+
+	go func() {
+		writerImpl.writeChan <- component.ErrNotConnected
+		writerImpl.connChan <- nil
+		writerImpl.writeChan <- nil
+	}()
+
+	select {
+	case msgChan <- message.NewTransaction(message.QuickBatch(nil), resChan):
+	case <-time.After(time.Second):
+		t.Fatal("Timed out")
+	}
+	select {
+	case err := <-resChan:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Timed out")
+	}
+
+	require.Equal(t, uint64(1), atomic.LoadUint64(&writerImpl.prepareCount))
+	writerImpl.seenMut.Lock()
+	require.Equal(t, []uint64{1, 1}, writerImpl.seenValues)
+	writerImpl.seenMut.Unlock()
+
+	ctx, done := context.WithTimeout(context.Background(), time.Second*30)
+	defer done()
+	w.TriggerCloseNow()
+	require.NoError(t, w.WaitForClose(ctx))
+}
+
+func TestAsyncWriterDoesNotWriteWhenBatchContextPreparationFails(t *testing.T) {
+	t.Parallel()
+
+	writerImpl := &failingContextPreparingMockWriter{mockAsyncWriter: newAsyncMockWriter()}
+	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	require.NoError(t, err)
+
+	msgChan := make(chan message.Transaction)
+	resChan := make(chan error)
+	require.NoError(t, w.Consume(msgChan))
+
+	select {
+	case writerImpl.connChan <- nil:
+	case <-time.After(time.Second):
+		t.Fatal("Timed out")
+	}
+	select {
+	case msgChan <- message.NewTransaction(message.QuickBatch(nil), resChan):
+	case <-time.After(time.Second):
+		t.Fatal("Timed out")
+	}
+	select {
+	case err := <-resChan:
+		require.ErrorIs(t, err, component.ErrNotConnected)
+	case <-time.After(time.Second):
+		t.Fatal("Timed out")
+	}
+	require.Zero(t, atomic.LoadUint64(&writerImpl.msgsTotal))
+
+	ctx, done := context.WithTimeout(context.Background(), time.Second*30)
+	defer done()
 	w.TriggerCloseNow()
 	require.NoError(t, w.WaitForClose(ctx))
 }

--- a/internal/impl/sql/integration_test.go
+++ b/internal/impl/sql/integration_test.go
@@ -629,6 +629,7 @@ func TestIntegrationClickhouse(t *testing.T) {
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository:   "clickhouse/clickhouse-server",
 		ExposedPorts: []string{"9000/tcp"},
+		Env:          []string{"CLICKHOUSE_SKIP_USER_SETUP=1"},
 	})
 	require.NoError(t, err)
 
@@ -669,6 +670,56 @@ func TestIntegrationClickhouse(t *testing.T) {
 	}))
 
 	testSuite(t, "clickhouse", dsn, createTable)
+	testClickhouseOutputBatchSettings(t, dsn, db)
+}
+
+func testClickhouseOutputBatchSettings(t *testing.T, dsn string, db *sql.DB) {
+	t.Run("output_batch_settings", func(t *testing.T) {
+		tableName, err := gonanoid.Generate("abcdefghijklmnopqrstuvwxyz", 40)
+		require.NoError(t, err)
+		_, err = db.Exec(fmt.Sprintf(`CREATE TABLE %s (
+  id String
+) ENGINE = MergeTree
+ORDER BY id
+SETTINGS non_replicated_deduplication_window = 100`, tableName))
+		require.NoError(t, err)
+
+		builder := service.NewStreamBuilder()
+		require.NoError(t, builder.SetLoggerYAML(`level: OFF`))
+		require.NoError(t, builder.AddOutputYAML(fmt.Sprintf(`
+sql_insert:
+  driver: clickhouse
+  dsn: %s
+  table: %s
+  columns: [ id ]
+  args_mapping: 'root = [ this.id ]'
+  clickhouse_settings:
+    insert_deduplication_token: fixed-integration-token
+    deduplicate_blocks_in_dependent_materialized_views: '1'
+  max_in_flight: 1
+`, dsn, tableName)))
+
+		inFn, err := builder.AddBatchProducerFunc()
+		require.NoError(t, err)
+		stream, err := builder.Build()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = stream.StopWithin(15 * time.Second) })
+		go func() {
+			assert.NoError(t, stream.Run(context.Background()))
+		}()
+
+		batch := service.MessageBatch{
+			service.NewMessage([]byte(`{"id":"one"}`)),
+			service.NewMessage([]byte(`{"id":"two"}`)),
+		}
+		require.NoError(t, inFn(context.Background(), batch))
+		require.NoError(t, inFn(context.Background(), batch.DeepCopy()))
+		require.NoError(t, stream.StopWithin(15*time.Second))
+
+		var count int
+		require.NoError(t, db.QueryRow(fmt.Sprintf("SELECT count() FROM %s", tableName)).Scan(&count))
+		require.Equal(t, 2, count)
+	})
 }
 
 func TestIntegrationOldClickhouse(t *testing.T) {

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/Masterminds/squirrel"
 
 	"github.com/Jeffail/shutdown"
@@ -46,6 +47,15 @@ func sqlInsertOutputConfig() *service.ConfigSpec {
 			Optional().
 			Advanced().
 			Example("ON CONFLICT (name) DO NOTHING")).
+		Field(service.NewInterpolatedStringMapField("clickhouse_settings").
+			Description("A map of ClickHouse query settings to apply to each insert batch. Values support interpolation and are evaluated once against the first message in each dispatched output batch. The resolved settings are reused unchanged if Bento reconnects and retries that output transaction. An upstream nack and reprocessing creates a new output transaction and reevaluates the settings.").
+			Default(map[string]any{}).
+			Advanced().
+			Version("1.20.0").
+			Example(map[string]any{
+				"insert_deduplication_token":                         `${! uuid_v4() }`,
+				"deduplicate_blocks_in_dependent_materialized_views": "1",
+			})).
 		Field(service.NewIntField("max_in_flight").
 						Description("The maximum number of inserts to run in parallel.").
 						Default(64)).
@@ -92,6 +102,24 @@ output:
         gold_coins BIGINT
       )
 `,
+		).
+		Example("ClickHouse Batch Deduplication",
+			"Assign a unique deduplication token to each dispatched Bento output batch. All rows in the batch and any connection retry of that output transaction use the same token.",
+			`
+output:
+  sql_insert:
+    driver: clickhouse
+    dsn: clickhouse://default:@localhost:9000/default
+    table: events
+    columns: [event_id, payload]
+    args_mapping: 'root = [this.event_id, this]'
+    clickhouse_settings:
+      insert_deduplication_token: '${! uuid_v4() }'
+      deduplicate_blocks_in_dependent_materialized_views: '1'
+    batching:
+      count: 1000
+      period: 1s
+`,
 		)
 	return spec
 }
@@ -106,7 +134,14 @@ func init() {
 			if maxInFlight, err = conf.FieldInt("max_in_flight"); err != nil {
 				return
 			}
-			out, err = newSQLInsertOutputFromConfig(conf, mgr)
+			var sqlOut *sqlInsertOutput
+			if sqlOut, err = newSQLInsertOutputFromConfig(conf, mgr); err == nil {
+				if len(sqlOut.clickhouseSettings) > 0 {
+					out = &sqlInsertOutputWithBatchContext{sqlInsertOutput: sqlOut}
+				} else {
+					out = sqlOut
+				}
+			}
 			return
 		})
 	if err != nil {
@@ -126,6 +161,9 @@ type sqlInsertOutput struct {
 	useTxStmt   bool
 	argsMapping *bloblang.Executor
 
+	clickhouseSettings      map[string]*service.InterpolatedString
+	applyClickhouseSettings func(context.Context, clickhouse.Settings) context.Context
+
 	connSettings *connSettings
 	awsConf      aws.Config
 
@@ -133,10 +171,21 @@ type sqlInsertOutput struct {
 	shutSig *shutdown.Signaller
 }
 
+type sqlInsertOutputWithBatchContext struct {
+	*sqlInsertOutput
+}
+
+func (s *sqlInsertOutputWithBatchContext) PrepareBatchContext(ctx context.Context, batch service.MessageBatch) (context.Context, error) {
+	return s.prepareBatchContext(ctx, batch)
+}
+
 func newSQLInsertOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (*sqlInsertOutput, error) {
 	s := &sqlInsertOutput{
 		logger:  mgr.Logger(),
 		shutSig: shutdown.NewSignaller(),
+		applyClickhouseSettings: func(ctx context.Context, settings clickhouse.Settings) context.Context {
+			return clickhouse.Context(ctx, clickhouse.WithSettings(settings))
+		},
 	}
 
 	var err error
@@ -153,6 +202,13 @@ func newSQLInsertOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resou
 
 	if s.dsn, err = conf.FieldString("dsn"); err != nil {
 		return nil, err
+	}
+
+	if s.clickhouseSettings, err = conf.FieldInterpolatedStringMap("clickhouse_settings"); err != nil {
+		return nil, err
+	}
+	if s.driver != "clickhouse" && len(s.clickhouseSettings) > 0 {
+		return nil, errors.New("clickhouse_settings can only be used with the clickhouse driver")
 	}
 
 	tableStr, err := conf.FieldString("table")
@@ -297,7 +353,12 @@ func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageB
 		if err != nil {
 			return err
 		}
-		if stmt, err = tx.Prepare(sqlStr); err != nil {
+		if len(s.clickhouseSettings) > 0 {
+			stmt, err = tx.PrepareContext(ctx, sqlStr)
+		} else {
+			stmt, err = tx.Prepare(sqlStr)
+		}
+		if err != nil {
 			_ = tx.Rollback()
 			return err
 		}
@@ -337,6 +398,26 @@ func (s *sqlInsertOutput) writeBatch(ctx context.Context, batch service.MessageB
 		err = tx.Commit()
 	}
 	return err
+}
+
+func (s *sqlInsertOutput) prepareBatchContext(ctx context.Context, batch service.MessageBatch) (context.Context, error) {
+	if len(s.clickhouseSettings) == 0 {
+		return ctx, nil
+	}
+	if len(batch) == 0 {
+		return nil, errors.New("cannot resolve clickhouse_settings for an empty batch")
+	}
+
+	settings := make(clickhouse.Settings, len(s.clickhouseSettings))
+	for key, expr := range s.clickhouseSettings {
+		value, err := batch.TryInterpolatedString(0, expr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve ClickHouse setting %q: %w", key, err)
+		}
+		settings[key] = value
+	}
+
+	return s.applyClickhouseSettings(ctx, settings), nil
 }
 
 func (s *sqlInsertOutput) Close(ctx context.Context) error {

--- a/internal/impl/sql/output_sql_insert_test.go
+++ b/internal/impl/sql/output_sql_insert_test.go
@@ -2,14 +2,97 @@ package sql
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/require"
 
 	_ "modernc.org/sqlite"
 
 	"github.com/warpstreamlabs/bento/public/service"
 )
+
+type clickhouseSettingsContextKey struct{}
+
+var capturingInsertDriverID atomic.Uint64
+
+type capturingInsertDriver struct {
+	state *capturingInsertState
+}
+
+func (d *capturingInsertDriver) Open(string) (driver.Conn, error) {
+	return &capturingInsertConn{state: d.state}, nil
+}
+
+type capturingInsertState struct {
+	mut         sync.Mutex
+	settings    []clickhouse.Settings
+	rowAppends  int
+	commits     int
+	commitError error
+}
+
+type capturingInsertConn struct {
+	state *capturingInsertState
+}
+
+func (c *capturingInsertConn) Prepare(query string) (driver.Stmt, error) {
+	return c.PrepareContext(context.Background(), query)
+}
+
+func (c *capturingInsertConn) PrepareContext(ctx context.Context, _ string) (driver.Stmt, error) {
+	settings, _ := ctx.Value(clickhouseSettingsContextKey{}).(clickhouse.Settings)
+	settingsCopy := make(clickhouse.Settings, len(settings))
+	maps.Copy(settingsCopy, settings)
+	c.state.mut.Lock()
+	c.state.settings = append(c.state.settings, settingsCopy)
+	c.state.mut.Unlock()
+	return &capturingInsertStmt{state: c.state}, nil
+}
+
+func (c *capturingInsertConn) Close() error { return nil }
+func (c *capturingInsertConn) Begin() (driver.Tx, error) {
+	return &capturingInsertTx{state: c.state}, nil
+}
+
+type capturingInsertTx struct {
+	state *capturingInsertState
+}
+
+func (t *capturingInsertTx) Commit() error {
+	t.state.mut.Lock()
+	defer t.state.mut.Unlock()
+	t.state.commits++
+	err := t.state.commitError
+	t.state.commitError = nil
+	return err
+}
+
+func (t *capturingInsertTx) Rollback() error { return nil }
+
+type capturingInsertStmt struct {
+	state *capturingInsertState
+}
+
+func (s *capturingInsertStmt) Close() error  { return nil }
+func (s *capturingInsertStmt) NumInput() int { return -1 }
+func (s *capturingInsertStmt) Exec([]driver.Value) (driver.Result, error) {
+	s.state.mut.Lock()
+	s.state.rowAppends++
+	s.state.mut.Unlock()
+	return driver.RowsAffected(1), nil
+}
+func (s *capturingInsertStmt) Query([]driver.Value) (driver.Rows, error) {
+	return nil, io.EOF
+}
 
 func TestSQLInsertOutputEmptyShutdown(t *testing.T) {
 	conf := `
@@ -53,4 +136,77 @@ args_mapping: 'root = [ this.id ]'
 		}
 		o.dbMut.Unlock()
 	})
+}
+
+func TestSQLInsertOutputClickhouseSettingsBatchAndRetrySemantics(t *testing.T) {
+	conf := `
+driver: clickhouse
+dsn: clickhouse://localhost:9000/default
+table: events
+columns: [ id ]
+args_mapping: 'root = [ this.id ]'
+clickhouse_settings:
+  insert_deduplication_token: '${! uuid_v4() }'
+  deduplicate_blocks_in_dependent_materialized_views: '1'
+`
+	parsed, err := sqlInsertOutputConfig().ParseYAML(conf, service.NewEnvironment())
+	require.NoError(t, err)
+
+	o, err := newSQLInsertOutputFromConfig(parsed, service.MockResources())
+	require.NoError(t, err)
+	o.applyClickhouseSettings = func(ctx context.Context, settings clickhouse.Settings) context.Context {
+		return context.WithValue(ctx, clickhouseSettingsContextKey{}, settings)
+	}
+
+	state := &capturingInsertState{commitError: errors.New("ambiguous commit failure")}
+	driverName := fmt.Sprintf("bento_capturing_clickhouse_insert_%d", capturingInsertDriverID.Add(1))
+	sql.Register(driverName, &capturingInsertDriver{state: state})
+	db, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	o.db = db
+	t.Cleanup(func() { require.NoError(t, o.Close(context.Background())) })
+
+	batchOne := service.MessageBatch{
+		service.NewMessage([]byte(`{"id":"one"}`)),
+		service.NewMessage([]byte(`{"id":"two"}`)),
+	}
+	batchOneCtx, err := o.prepareBatchContext(context.Background(), batchOne)
+	require.NoError(t, err)
+
+	// A failed native batch and its retry both prepare with the one resolved
+	// settings context, while every record is appended to each native batch.
+	require.EqualError(t, o.writeBatch(batchOneCtx, batchOne), "ambiguous commit failure")
+	require.NoError(t, o.writeBatch(batchOneCtx, batchOne))
+
+	batchTwo := service.MessageBatch{service.NewMessage([]byte(`{"id":"three"}`))}
+	batchTwoCtx, err := o.prepareBatchContext(context.Background(), batchTwo)
+	require.NoError(t, err)
+	require.NoError(t, o.writeBatch(batchTwoCtx, batchTwo))
+
+	state.mut.Lock()
+	defer state.mut.Unlock()
+	require.Len(t, state.settings, 3)
+	tokenOne := state.settings[0]["insert_deduplication_token"]
+	require.NotEmpty(t, tokenOne)
+	require.Equal(t, tokenOne, state.settings[1]["insert_deduplication_token"])
+	require.NotEqual(t, tokenOne, state.settings[2]["insert_deduplication_token"])
+	require.Equal(t, "1", state.settings[0]["deduplicate_blocks_in_dependent_materialized_views"])
+	require.Equal(t, 5, state.rowAppends)
+	require.Equal(t, 3, state.commits)
+}
+
+func TestSQLInsertOutputRejectsClickhouseSettingsForOtherDrivers(t *testing.T) {
+	conf := `
+driver: sqlite
+dsn: ":memory:"
+table: events
+columns: [ id ]
+args_mapping: 'root = [ this.id ]'
+clickhouse_settings:
+  insert_deduplication_token: fixed
+`
+	parsed, err := sqlInsertOutputConfig().ParseYAML(conf, service.NewEnvironment())
+	require.NoError(t, err)
+	_, err = newSQLInsertOutputFromConfig(parsed, service.MockResources())
+	require.EqualError(t, err, "clickhouse_settings can only be used with the clickhouse driver")
 }

--- a/public/service/output.go
+++ b/public/service/output.go
@@ -70,6 +70,16 @@ type BatchOutput interface {
 	Closer
 }
 
+// BatchOutputContextPreparer is an optional extension of BatchOutput for
+// outputs that need to derive context values once for each dispatched output
+// batch. The returned context is reused when the same output transaction is
+// retried after a connection failure.
+type BatchOutputContextPreparer interface {
+	BatchOutput
+
+	PrepareBatchContext(context.Context, MessageBatch) (context.Context, error)
+}
+
 //------------------------------------------------------------------------------
 
 // Implements output.AsyncSink.
@@ -101,7 +111,14 @@ type airGapBatchWriter struct {
 }
 
 func newAirGapBatchWriter(w BatchOutput) output.AsyncSink {
-	return &airGapBatchWriter{w: w}
+	a := &airGapBatchWriter{w: w}
+	if wc, ok := w.(BatchOutputContextPreparer); ok {
+		return &airGapBatchWriterWithContext{
+			airGapBatchWriter: a,
+			w:                 wc,
+		}
+	}
+	return a
 }
 
 func (a *airGapBatchWriter) Connect(ctx context.Context) error {
@@ -115,6 +132,20 @@ func (a *airGapBatchWriter) WriteBatch(ctx context.Context, msg message.Batch) e
 		return nil
 	})
 	return publicToInternalErr(a.w.WriteBatch(ctx, parts))
+}
+
+type airGapBatchWriterWithContext struct {
+	*airGapBatchWriter
+	w BatchOutputContextPreparer
+}
+
+func (a *airGapBatchWriterWithContext) PrepareBatchContext(ctx context.Context, msg message.Batch) (context.Context, error) {
+	parts := make([]*Message, msg.Len())
+	_ = msg.Iter(func(i int, part *message.Part) error {
+		parts[i] = NewInternalMessage(part)
+		return nil
+	})
+	return a.w.PrepareBatchContext(ctx, parts)
 }
 
 func (a *airGapBatchWriter) Close(ctx context.Context) error {

--- a/public/service/output_test.go
+++ b/public/service/output_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/warpstreamlabs/bento/internal/component"
+	componentoutput "github.com/warpstreamlabs/bento/internal/component/output"
 	"github.com/warpstreamlabs/bento/internal/message"
 )
 
@@ -112,6 +113,31 @@ func (f *fnBatchOutput) WriteBatch(ctx context.Context, msgs MessageBatch) error
 func (f *fnBatchOutput) Close(ctx context.Context) error {
 	f.closed = true
 	return nil
+}
+
+type contextFnBatchOutput struct {
+	*fnBatchOutput
+	prepared int
+}
+
+func (f *contextFnBatchOutput) PrepareBatchContext(ctx context.Context, msgs MessageBatch) (context.Context, error) {
+	f.prepared += len(msgs)
+	return ctx, nil
+}
+
+func TestBatchOutputAirGapOptionalBatchContext(t *testing.T) {
+	plain := newAirGapBatchWriter(&fnBatchOutput{})
+	_, ok := plain.(componentoutput.BatchContextPreparer)
+	assert.False(t, ok)
+
+	contextualOutput := &contextFnBatchOutput{fnBatchOutput: &fnBatchOutput{}}
+	contextual := newAirGapBatchWriter(contextualOutput)
+	preparer, ok := contextual.(componentoutput.BatchContextPreparer)
+	require.True(t, ok)
+
+	_, err := preparer.PrepareBatchContext(context.Background(), message.QuickBatch([][]byte{[]byte("one"), []byte("two")}))
+	require.NoError(t, err)
+	assert.Equal(t, 2, contextualOutput.prepared)
 }
 
 func TestBatchOutputAirGapShutdown(t *testing.T) {

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -59,6 +59,7 @@ output:
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
     prefix: "" # No default (optional)
     suffix: ON CONFLICT (name) DO NOTHING # No default (optional)
+    clickhouse_settings: {}
     max_in_flight: 64
     init_files: [] # No default (optional)
     init_statement: | # No default (optional)
@@ -111,6 +112,7 @@ output:
 <Tabs defaultValue="Table Insert (MySQL)" values={[
 { label: 'Table Insert (MySQL)', value: 'Table Insert (MySQL)', },
 { label: 'Table Insert (DuckDB)', value: 'Table Insert (DuckDB)', },
+{ label: 'ClickHouse Batch Deduplication', value: 'ClickHouse Batch Deduplication', },
 ]}>
 
 <TabItem value="Table Insert (MySQL)">
@@ -153,6 +155,27 @@ output:
         duck       VARCHAR,
         gold_coins BIGINT
       )
+```
+
+</TabItem>
+<TabItem value="ClickHouse Batch Deduplication">
+
+Assign a unique deduplication token to each dispatched Bento output batch. All rows in the batch and any connection retry of that output transaction use the same token.
+
+```yaml
+output:
+  sql_insert:
+    driver: clickhouse
+    dsn: clickhouse://default:@localhost:9000/default
+    table: events
+    columns: [event_id, payload]
+    args_mapping: 'root = [this.event_id, this]'
+    clickhouse_settings:
+      insert_deduplication_token: '${! uuid_v4() }'
+      deduplicate_blocks_in_dependent_materialized_views: '1'
+    batching:
+      count: 1000
+      period: 1s
 ```
 
 </TabItem>
@@ -279,6 +302,24 @@ Type: `string`
 # Examples
 
 suffix: ON CONFLICT (name) DO NOTHING
+```
+
+### `clickhouse_settings`
+
+A map of ClickHouse query settings to apply to each insert batch. Values support interpolation and are evaluated once against the first message in each dispatched output batch. The resolved settings are reused unchanged if Bento reconnects and retries that output transaction. An upstream nack and reprocessing creates a new output transaction and reevaluates the settings.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `object`  
+Default: `{}`  
+Requires version 1.20.0 or newer  
+
+```yml
+# Examples
+
+clickhouse_settings:
+  deduplicate_blocks_in_dependent_materialized_views: "1"
+  insert_deduplication_token: ${! uuid_v4() }
 ```
 
 ### `max_in_flight`


### PR DESCRIPTION
🤖 Adds batch-scoped ClickHouse query settings to `sql_insert`, primarily to support native insert deduplication without falling back to `http_client` URL parameters.

## Motivation

ClickHouse deduplication requires an `insert_deduplication_token` that is unique between logical batches but stable when the same insert is retried. The existing `sql_insert` output had no way to attach clickhouse-go settings to the native prepared batch.

## API and semantics

```yaml
output:
  sql_insert:
    driver: clickhouse
    dsn: clickhouse://default:@localhost:9000/default
    table: events
    columns: [event_id, payload]
    args_mapping: 'root = [this.event_id, this]'
    clickhouse_settings:
      insert_deduplication_token: '${! uuid_v4() }'
      deduplicate_blocks_in_dependent_materialized_views: '1'
    batching:
      count: 1000
      period: 1s
```

Each interpolated setting is resolved exactly once against the first message of a dispatched output batch. The resulting ClickHouse context is shared by every row appended to the native prepared batch and reused unchanged across Bento's `ErrNotConnected` reconnect retry for that output transaction.

An upstream nack/reprocessing, process restart, or later rebatching is a new output transaction and reevaluates the settings. This feature therefore preserves retry identity inside the `sql_insert` dispatch lifecycle; it does not provide a durable token across arbitrary upstream replays.

## Design trade-offs

- Adds a generic, optional `BatchOutputContextPreparer` extension so lifecycle-owned values can be derived at the actual output-batch boundary and reused by the reconnect loop.
- Keeps `clickhouse_settings` explicitly ClickHouse-only because `database/sql` has no portable query-settings contract.
- Wraps only configured ClickHouse outputs with the optional hook. Existing drivers and configurations keep the previous writer and `Prepare` paths unchanged.
- Uses `Tx.PrepareContext`, which clickhouse-go maps to its native `PrepareBatch`; per-record `Exec` calls append rows to that one batch before commit.

Relevant driver behavior: [clickhouse-go `PrepareContext`](https://github.com/ClickHouse/clickhouse-go/blob/v2.43.0/clickhouse_std.go#L301-L364) and [native batch preparation](https://github.com/ClickHouse/clickhouse-go/blob/v2.43.0/conn_batch.go#L22-L65). ClickHouse documents [`insert_deduplication_token`](https://clickhouse.com/docs/operations/settings/settings#insert_deduplication_token) and [`deduplicate_blocks_in_dependent_materialized_views`](https://clickhouse.com/docs/operations/settings/settings#deduplicate_blocks_in_dependent_materialized_views).

## Verification

- `mise exec -- go test ./internal/component/output ./internal/impl/sql ./public/service`
- `mise exec -- go test ./internal/impl/sql -run '^TestIntegrationClickhouse$' -timeout 5m -count=1 -v`
- `mise x golangci-lint@2.11.3 -- make lint` (`0 issues`)
- `mise exec -- go mod tidy` (no changes)
- Generated component docs with `make docs`

The new focused tests cover different tokens between batches, one token across all native row appends, stable identity on reconnect retry, preparation failure behavior, non-ClickHouse rejection, and unchanged optional-hook behavior for existing outputs. The live ClickHouse integration inserts the same two-row batch twice with a fixed token and verifies only two rows remain.

The repository-wide `mise exec -- make test` completed all changed packages successfully but failed in five pre-existing macOS filesystem-event tests under `internal/impl/io` due `CHMOD`/`WRITE` event ordering and subdirectory watch timing. The full docs lint phase is locally blocked by its CGO/libzmq requirement; the generated `sql_insert` documentation is included, and upstream CI installs `libzmq3-dev` for that matrix.

## Rollback

Revert this commit. The new configuration field is opt-in and requires no data migration.
