### PR TITLE
Feat: support HTTPS URLs in the -c/--config flag

### DIFF
--- a/internal/cli/common/reader.go
+++ b/internal/cli/common/reader.go
@@ -1,6 +1,10 @@
 package common
 
 import (
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/warpstreamlabs/bento/internal/config"
 	"github.com/warpstreamlabs/bento/internal/filepath/ifs"
 
@@ -22,11 +26,18 @@ func ReadConfig(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) (mainPath st
 			}
 		}
 	}
+
+	if strings.HasPrefix(path, "https://") && c.Bool("watcher") {
+		fmt.Fprintln(os.Stderr, "error: --watcher is not supported with a remote config URL")
+		os.Exit(1)
+	}
+
 	opts := []config.OptFunc{
 		config.OptSetFullSpec(cliOpts.MainConfigSpecCtor),
 		config.OptAddOverrides(c.StringSlice("set")...),
 		config.OptTestSuffix("_bento_test"),
 		config.OptSetLintConfigWarnDeprecated(),
+		config.OptSetConfigHeaders(c.StringSlice("config-header")),
 	}
 	if streamsMode {
 		opts = append(opts, config.OptSetStreamPaths(c.Args().Slice()...))

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -197,6 +197,10 @@ func App(opts *common.CLIOpts) *cli.App {
 			Value:   "",
 			Usage:   "a path to a configuration file",
 		},
+		&cli.StringSliceFlag{
+			Name:  "config-header",
+			Usage: "an HTTP header to send when fetching a remote config via HTTPS URL, in \"Name: Value\" format (repeatable)",
+		},
 		&cli.BoolFlag{
 			Name:   "help-autocomplete",
 			Value:  false,

--- a/internal/config/lint.go
+++ b/internal/config/lint.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -16,9 +17,28 @@ import (
 // ReadYAMLFileLinted will attempt to read a configuration file path into a
 // structure. Returns an array of lint messages or an error.
 func ReadYAMLFileLinted(fs ifs.FS, spec docs.FieldSpecs, path string, skipEnvVarCheck bool, lConf docs.LintConfig) (Type, []docs.Lint, error) {
-	configBytes, lints, _, err := ReadFileEnvSwap(fs, path, os.LookupEnv)
-	if err != nil {
-		return Type{}, nil, err
+	var configBytes []byte
+	var lints []docs.Lint
+	var err error
+
+	if strings.HasPrefix(path, "https://") {
+		if configBytes, err = fetchRemoteConfig(path, nil); err != nil {
+			return Type{}, nil, err
+		}
+		if configBytes, err = ReplaceEnvVariables(configBytes, os.LookupEnv); err != nil {
+			var errEnvMissing *ErrMissingEnvVars
+			if errors.As(err, &errEnvMissing) {
+				configBytes = errEnvMissing.BestAttempt
+				lints = append(lints, docs.NewLintError(1, docs.LintMissingEnvVar, err))
+			} else {
+				return Type{}, nil, err
+			}
+		}
+	} else {
+		configBytes, lints, _, err = ReadFileEnvSwap(fs, path, os.LookupEnv)
+		if err != nil {
+			return Type{}, nil, err
+		}
 	}
 
 	if skipEnvVarCheck {

--- a/internal/config/lint_test.go
+++ b/internal/config/lint_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/warpstreamlabs/bento/internal/bundle"
+	"github.com/warpstreamlabs/bento/internal/docs"
+)
+
+func TestReadYAMLFileLintedRemoteSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`
+input:
+  label: fooin
+  inproc: foo
+
+output:
+  label: fooout
+  inproc: bar
+`))
+	}))
+	defer srv.Close()
+
+	conf, lints, err := ReadYAMLFileLinted(nil, Spec(), srv.URL, false, docs.NewLintConfig(bundle.GlobalEnvironment))
+	require.NoError(t, err)
+	require.Empty(t, lints)
+	assert.Equal(t, "fooin", conf.Input.Label)
+}
+
+func TestReadYAMLFileLintedRemoteNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, _, err := ReadYAMLFileLinted(nil, Spec(), srv.URL, false, docs.NewLintConfig(bundle.GlobalEnvironment))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestReadYAMLFileLintedRemoteEnvVar(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`
+input:
+  label: ${BENTO_TEST_LINT_LABEL:fooin}
+  inproc: foo
+
+output:
+  label: fooout
+  inproc: bar
+`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("BENTO_TEST_LINT_LABEL", "customlabel")
+
+	conf, lints, err := ReadYAMLFileLinted(nil, Spec(), srv.URL, false, docs.NewLintConfig(bundle.GlobalEnvironment))
+	require.NoError(t, err)
+	require.Empty(t, lints)
+	assert.Equal(t, "customlabel", conf.Input.Label)
+}
+
+func TestReadYAMLFileLintedRemoteSkipEnvVarCheck(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`
+input:
+  label: ${BENTO_TEST_MISSING_VAR}
+  inproc: foo
+
+output:
+  label: fooout
+  inproc: bar
+`))
+	}))
+	defer srv.Close()
+
+	_, lints, err := ReadYAMLFileLinted(nil, Spec(), srv.URL, true, docs.NewLintConfig(bundle.GlobalEnvironment))
+	require.NoError(t, err)
+	require.Empty(t, lints)
+}

--- a/internal/config/reader.go
+++ b/internal/config/reader.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -84,11 +86,12 @@ type Reader struct {
 	changeFlushPeriod  time.Duration
 	changeDelayPeriod  time.Duration
 	filesRefreshPeriod time.Duration
+	configHeaders      []string
 }
 
 // NewReader creates a new config reader.
 func NewReader(mainPath string, resourcePaths []string, opts ...OptFunc) *Reader {
-	if mainPath != "" {
+	if mainPath != "" && !strings.HasPrefix(mainPath, "https://") {
 		mainPath = filepath.Clean(mainPath)
 	}
 	r := &Reader{
@@ -120,6 +123,14 @@ func NewReader(mainPath string, resourcePaths []string, opts ...OptFunc) *Reader
 
 // OptFunc is an opt function that changes the behaviour of a config reader.
 type OptFunc func(*Reader)
+
+// OptSetConfigHeaders sets HTTP headers to send when fetching a remote config
+// via HTTPS URL. Each entry should be in "Name: Value" format.
+func OptSetConfigHeaders(headers []string) OptFunc {
+	return func(r *Reader) {
+		r.configHeaders = headers
+	}
+}
 
 // OptSetFullSpec overrides the default general config spec with the provided
 // one.
@@ -302,13 +313,24 @@ func (r *Reader) readMain(mainPath string) (conf Type, pConf *docs.ParsedConfig,
 	if mainPath != "" {
 		var dLints []docs.Lint
 		var modTime time.Time
-		if confBytes, dLints, modTime, err = ReadFileEnvSwap(r.fs, mainPath, os.LookupEnv); err != nil {
-			return
+		if strings.HasPrefix(mainPath, "https://") {
+			if confBytes, err = fetchRemoteConfig(mainPath, r.configHeaders); err != nil {
+				return
+			}
+			if confBytes, err = ReplaceEnvVariables(confBytes, os.LookupEnv); err != nil {
+				return
+			}
+		} else {
+			if confBytes, dLints, modTime, err = ReadFileEnvSwap(r.fs, mainPath, os.LookupEnv); err != nil {
+				return
+			}
+			r.modTimeLastRead[mainPath] = modTime
 		}
+
+		// dLints only populated for file-based configs via ReadFileEnvSwap
 		for _, l := range dLints {
 			lints = append(lints, l.Error())
 		}
-		r.modTimeLastRead[mainPath] = modTime
 
 		if rawNode, err = docs.UnmarshalYAML(confBytes); err != nil {
 			return
@@ -363,6 +385,9 @@ func (r *Reader) readMain(mainPath string) (conf Type, pConf *docs.ParsedConfig,
 // the provided main update func, and apply changes to resources to the provided
 // manager as appropriate.
 func (r *Reader) TriggerMainUpdate(mgr bundle.NewManagement, strict bool, newPath string) error {
+	if strings.HasPrefix(r.mainPath, "https://") {
+		return nil
+	}
 	conf, _, lints, lintWarns, err := r.readMain(newPath)
 	if errors.Is(err, fs.ErrNotExist) {
 		if r.mainPath != newPath {
@@ -427,4 +452,33 @@ func (r *Reader) TriggerMainUpdate(mgr bundle.NewManagement, strict bool, newPat
 		mgr.Logger().Info("Updated main config")
 	}
 	return nil
+}
+
+func fetchRemoteConfig(url string, headers []string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("invalid config URL: %w", err)
+	}
+	for _, h := range headers {
+		name, value, ok := strings.Cut(h, ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid config header %q: expected Name: Value format", h)
+		}
+		req.Header.Add(strings.TrimSpace(name), strings.TrimSpace(value))
+	}
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch remote config: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("remote config server returned status %s", resp.Status)
+	}
+	return io.ReadAll(resp.Body)
 }

--- a/internal/config/reader_test.go
+++ b/internal/config/reader_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -240,4 +242,121 @@ processor_resources:
 	assert.True(t, testMgr.ProbeProcessor("b"))
 	assert.True(t, testMgr.ProbeProcessor("c"))
 	assert.True(t, testMgr.ProbeProcessor("d"))
+}
+
+func TestFetchRemoteConfigSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer mytoken", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`
+input:
+  label: fooin
+  inproc: foo
+
+output:
+  label: fooout
+  inproc: bar
+`))
+	}))
+	defer srv.Close()
+
+	got, err := fetchRemoteConfig(srv.URL, []string{"Authorization: Bearer mytoken"})
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "fooin")
+}
+
+func TestFetchRemoteConfigNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := fetchRemoteConfig(srv.URL, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestFetchRemoteConfigBadHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("input:\n  generate:\n    mapping: 'root = {}'\n"))
+	}))
+	defer srv.Close()
+
+	_, err := fetchRemoteConfig(srv.URL, []string{"BadHeader"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected Name: Value format")
+}
+
+func TestReaderRemoteConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`
+input:
+  label: fooin
+  inproc: foo
+
+output:
+  label: fooout
+  inproc: bar
+`))
+	}))
+	defer srv.Close()
+
+	rdr := newDummyReader(srv.URL, nil)
+	conf, _, lints, lintWarns, err := rdr.Read()
+	require.NoError(t, err)
+	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
+
+	assert.Equal(t, "fooin", conf.Input.Label)
+	assert.Equal(t, "fooout", conf.Output.Label)
+}
+
+func TestReaderRemoteConfigEnvVar(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`
+input:
+  label: ${BENTO_TEST_LABEL:fooin}
+  inproc: foo
+
+output:
+  label: fooout
+  inproc: bar
+`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("BENTO_TEST_LABEL", "customlabel")
+
+	rdr := newDummyReader(srv.URL, nil)
+	conf, _, lints, lintWarns, err := rdr.Read()
+	require.NoError(t, err)
+	require.Empty(t, lints)
+	require.Empty(t, lintWarns)
+
+	assert.Equal(t, "customlabel", conf.Input.Label)
+}
+
+func TestTriggerMainUpdateSkippedForRemote(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`
+input:
+  label: fooin
+  inproc: foo
+
+output:
+  label: fooout
+  inproc: bar
+`))
+	}))
+	defer srv.Close()
+
+	rdr := newDummyReader(srv.URL, nil)
+	_, _, _, _, err := rdr.Read()
+	require.NoError(t, err)
+
+	testMgr, err := manager.New(manager.ResourceConfig{})
+	require.NoError(t, err)
+
+	// TriggerMainUpdate should be a no-op for remote configs
+	err = rdr.TriggerMainUpdate(testMgr, true, srv.URL)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

Implements #939, allows `-c`/`--config` to accept an `https://` URL 
in addition to a local file path.

## Changes

- `internal/config/reader.go` — URL detection, fetch logic, watcher guard
- `internal/config/lint.go` — URL support for `ReadYAMLFileLinted`
- `internal/cli/run.go` — `--config-header` flag definition
- `internal/cli/common/reader.go` — watcher fatal error, headers wired into `NewReader`
- `internal/config/reader_test.go` — added unit tests for `fetchRemoteConfig` and remote reader behaviour
- `internal/config/lint_test.go` — new file, unit tests for `ReadYAMLFileLinted` with remote URLs

## Behaviour

- `https://` prefix → remote fetch before config parsing
- Everything else → unchanged file path behaviour
- Non-2xx response → exits with status code in error message
- `--watcher` + URL → exits with fatal error immediately
- env var interpolation (`${FOO:default}`) still works after fetch
- `--config-header "Name: Value"` (repeatable) for auth headers

## Testing

- bento -c _url_ → stream starts correctly
- bento -c _url_ echo → prints normalised config
- bento -c _url_ streams → streams mode works
- bento lint _url_ → lints remote config
- bento -c _url_ --config-header "K: V" → auth header forwarded
- bento -c _url_ --config-header "bad" → clear format error
- bento -c _url-returning-404_ → clear 404 error
- bento -c _url-returning-401_ → clear 401 error
- bento -c _url_ --watcher → fatal error on startup
- bento -c _path/to/file.yaml_ → unchanged behaviour

## Known limitations

- Only `https://` URLs are supported. plain `http://` falls back to 
  file path behaviour.
- `bento lint <url>` works for public endpoints but does not support 
  `--config-header`. `ReadYAMLFileLinted` has no access to CLI flags 
  at that call site. Can be addressed in a follow-up.
  
  ## Open question

As noted in #939. happy to move to a dedicated `--config-url` flag if that is preferred over extending `-c`.