### PR TITLE
Reject oversized scale in parse_big_decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- `parse_big_decimal` rejects scales above 16383 to avoid unbounded big-integer work @aratz-lasa
+
 ## 1.20.0 - 2026-07-27
 
 ### Added

--- a/internal/impl/pure/bloblang_decimal.go
+++ b/internal/impl/pure/bloblang_decimal.go
@@ -9,6 +9,12 @@ import (
 	"github.com/warpstreamlabs/bento/public/bloblang"
 )
 
+// maxBigDecimalScale is the maximum scale accepted by parse_big_decimal.
+// Matches PostgreSQL NUMERIC's maximum scale and is well above Iceberg (38)
+// and typical JDBC/Connect decimals. Unbounded scale would allow DoS via
+// big.Int.Exp / FloatString.
+const maxBigDecimalScale = 16383
+
 // twosComplementToBigInt decodes decimal logical-type bytes into a signed unscaled integer.
 //
 // The value is stored as two's complement big-endian bytes. Scale and precision come from
@@ -55,7 +61,7 @@ func init() {
 		Category(query.MethodCategoryParsing).
 		Description(`Parses a [Kafka Connect](https://docs.confluent.io/platform/current/connect/conversions.html#decimal-type) / [Debezium](https://debezium.io/documentation/faq/#how_to_retrieve_decimal_field_from_binary_representation) decimal encoded as a two's complement big-endian unscaled integer and returns its decimal string representation.`).
 		Param(bloblang.NewInt64Param("scale").
-			Description("Number of digits after the decimal point.")).
+			Description(fmt.Sprintf("Number of digits after the decimal point (0-%d).", maxBigDecimalScale))).
 		Example("",
 			`root.amount = this.amount.decode("base64").parse_big_decimal(scale: 2)`,
 			[2]string{
@@ -76,8 +82,8 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			if scale < 0 {
-				return nil, fmt.Errorf("scale must be >= 0, got %d", scale)
+			if scale < 0 || scale > maxBigDecimalScale {
+				return nil, fmt.Errorf("scale must be between 0 and %d, got %d", maxBigDecimalScale, scale)
 			}
 
 			return bloblang.BytesMethod(func(input []byte) (any, error) {

--- a/internal/impl/pure/bloblang_decimal_test.go
+++ b/internal/impl/pure/bloblang_decimal_test.go
@@ -1,6 +1,8 @@
 package pure
 
 import (
+	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
@@ -94,4 +96,39 @@ func TestParseBigDecimalZeroBytes(t *testing.T) {
 	v, err := exec.Query([]byte{0x00})
 	require.NoError(t, err)
 	require.Equal(t, "0.00", v)
+}
+
+func TestParseBigDecimalScaleBounds(t *testing.T) {
+	t.Run("rejects negative scale", func(t *testing.T) {
+		_, err := bloblang.Parse(`root = this.parse_big_decimal(scale: -1)`)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "scale must be between 0 and")
+	})
+
+	t.Run("rejects scale above max", func(t *testing.T) {
+		_, err := bloblang.Parse(fmt.Sprintf(`root = this.parse_big_decimal(scale: %d)`, maxBigDecimalScale+1))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "scale must be between 0 and")
+	})
+
+	t.Run("rejects MaxInt64 scale", func(t *testing.T) {
+		_, err := bloblang.Parse(fmt.Sprintf(`root = this.parse_big_decimal(scale: %d)`, int64(math.MaxInt64)))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "scale must be between 0 and")
+	})
+
+	t.Run("accepts max scale", func(t *testing.T) {
+		exec, err := bloblang.Parse(fmt.Sprintf(`root = this.parse_big_decimal(scale: %d)`, maxBigDecimalScale))
+		require.NoError(t, err)
+
+		v, err := exec.Query([]byte{0x01})
+		require.NoError(t, err)
+
+		frac := make([]byte, maxBigDecimalScale)
+		for i := range frac {
+			frac[i] = '0'
+		}
+		frac[maxBigDecimalScale-1] = '1'
+		require.Equal(t, "0."+string(frac), v)
+	})
 }

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -3122,7 +3122,7 @@ Parses a [Kafka Connect](https://docs.confluent.io/platform/current/connect/conv
 
 #### Parameters
 
-**`scale`** &lt;integer&gt; Number of digits after the decimal point.  
+**`scale`** &lt;integer&gt; Number of digits after the decimal point (0-16383).  
 
 #### Examples
 


### PR DESCRIPTION
Rejects `parse_big_decimal` scales above 16383 so a crafted mapping cannot hang or OOM via unbounded `big.Int.Exp` / `FloatString`.