### PR TITLE
docs: fix stale buffer example path in internal/impl README

### DIFF
--- a/internal/impl/README.md
+++ b/internal/impl/README.md
@@ -8,4 +8,4 @@ If you intend to create a new component type then use the docs at [https://pkg.g
 - Input example: [./nats/input_jetstream.go](./nats/input_jetstream.go)
 - Output example: [./nats/output_jetstream.go](./nats/output_jetstream.go)
 - Processor example: [./confluent/processor_schema_registry_encode.go](./confluent/processor_schema_registry_encode.go)
-- Buffer example: [./generic/buffer_system_window.go](./generic/buffer_system_window.go)
+- Buffer example: [./pure/buffer_system_window.go](./pure/buffer_system_window.go)


### PR DESCRIPTION
The buffer example in `internal/impl/README.md` links `./generic/buffer_system_window.go`, but there is no `internal/impl/generic/` directory. The file lives at `internal/impl/pure/buffer_system_window.go`, so the link 404s.

This points it at the correct path. The README's other example links (`nats/input_jetstream.go`, `nats/output_jetstream.go`, `confluent/processor_schema_registry_encode.go`) all resolve — only the buffer link was stale.

---
AI disclosure: this one-line docs fix was prepared with AI assistance (Claude Code) and reviewed before submitting.
