### PR TITLE
fix(fsevent): preserve file create events when watching new subdirs

### DIFF
--- a/internal/impl/io/input_fsevent.go
+++ b/internal/impl/io/input_fsevent.go
@@ -182,18 +182,12 @@ func (f *fsEventWatcher) Connect(ctx context.Context) error {
 					st, err := os.Stat(event.Name)
 					if err != nil {
 						f.log.Warnf("Cannot check for new subpath: %s", err)
-						continue
-					}
-
-					// if it is a file dont add it.
-					if !st.IsDir() {
-						continue
-					}
-
-					// adding the same path more than once is a noop,
-					// so safe even though it is already in the watchlist
-					if err := f.watcher.Add(event.Name); err != nil {
-						f.log.Warnf("Failed to add path %v: %s", event.Name, err)
+					} else if st.IsDir() {
+						// adding the same path more than once is a noop,
+						// so safe even though it is already in the watchlist
+						if err := f.watcher.Add(event.Name); err != nil {
+							f.log.Warnf("Failed to add path %v: %s", event.Name, err)
+						}
 					}
 				}
 

--- a/internal/impl/io/input_fsevent_test.go
+++ b/internal/impl/io/input_fsevent_test.go
@@ -234,7 +234,7 @@ fsevent:
 	time.Sleep(time.Second)
 
 	fileInSubdir := filepath.Join(subdir, "file.txt")
-	require.NoError(t, os.WriteFile(fileInSubdir, []byte("content"), 0o644))
+	require.NoError(t, os.WriteFile(fileInSubdir, nil, 0o644))
 
 	// We should receive events for both the subdir creation and the file creation
 	var subdirCreated, fileCreated bool
@@ -251,7 +251,7 @@ fsevent:
 
 			if eventPath == subdir && operation == "CREATE" {
 				subdirCreated = true
-			} else if eventPath == fileInSubdir && (operation == "WRITE" || operation == "CREATE") {
+			} else if eventPath == fileInSubdir && operation == "CREATE" {
 				fileCreated = true
 			}
 


### PR DESCRIPTION
## Summary

- preserve ordinary file CREATE events when watch_new_subdirs is enabled
- add new paths to the watcher only when they are confirmed directories
- keep emitting the original event when directory inspection fails
- strengthen the regression test with an empty file and an exact CREATE assertion

Closes #942

## Testing

- macOS fsevent enabled/disabled regression: 5 repeated passes plus a final post-lint pass
- Linux Go 1.26.5 container: relevant fsevent controls and regression passed twice from the exact commit
- full io package passed on macOS, excluding two upstream event-variant assertions validated by the Linux run
- full Cypher package passed against Colima; transient socket-server test passed 3 repeated runs
- all remaining Go packages passed in the repository-wide sweep
- go vet passed; golangci-lint v2.11.3 reported 0 issues
- component template lint and config tests passed

## Documentation

No documentation changes are required. The existing fsevent contract already states that CREATE events are emitted and that watch_new_subdirs watches events from newly created subdirectories.