### PR TITLE
fix: support JSON Schema drafts 2019-09 and 2020-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `parse_big_decimal` rejects scales above 16383 to avoid unbounded big-integer work @aratz-lasa
+- **Breaking:** JSON Schema validation understands drafts 2019-09 and 2020-12, replacing `github.com/xeipuuv/gojsonschema` with `github.com/santhosh-tekuri/jsonschema/v6`. Schemas declaring either draft previously loaded with the newer keywords silently ignored, so `json_schema` checks that pass today may start failing. Schemas without a `$schema` that mix draft-4 spellings no longer compile, and validation error messages have changed shape @slachiewicz
 
 ### Security
 

--- a/go.mod
+++ b/go.mod
@@ -130,6 +130,7 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/rickb777/period v1.0.7
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/segmentio/ksuid v1.0.4
 	github.com/sijms/go-ora/v2 v2.8.22
 	github.com/sirupsen/logrus v1.9.4
@@ -146,7 +147,6 @@ require (
 	github.com/urfave/cli/v2 v2.27.7
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/xdg-go/scram v1.1.2
-	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	go.etcd.io/etcd/api/v3 v3.6.5
 	go.etcd.io/etcd/client/v3 v3.6.5
@@ -238,6 +238,7 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/theparanoids/crypki v1.20.9 // indirect
 	github.com/twpayne/go-geom v1.6.1 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/yalue/onnxruntime_go v1.30.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1777,6 +1777,8 @@ github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfF
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
 github.com/s2-streamstore/s2-sdk-go v0.13.3 h1:JBZFchhA45XMBdQxpy7a/BbAeS1ZJloVtUbtU6hwllM=
 github.com/s2-streamstore/s2-sdk-go v0.13.3/go.mod h1:1a+v2sGqU+s5neI8XwqRJz78ktStkR+mZH/JEi9HNSo=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/schollz/progressbar/v3 v3.19.0 h1:Ea18xuIRQXLAUidVDox3AbwfUhD0/1IvohyTutOIFoc=
 github.com/schollz/progressbar/v3 v3.19.0/go.mod h1:IsO3lpbaGuzh8zIMzgY3+J8l4C8GjO0Y9S69eFvNsec=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/internal/bloblang/query/methods_structured.go
+++ b/internal/bloblang/query/methods_structured.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/Jeffail/gabs/v2"
-	jsonschema "github.com/xeipuuv/gojsonschema"
+	"github.com/warpstreamlabs/bento/internal/jsonschema"
 
 	"github.com/warpstreamlabs/bento/internal/value"
 )
@@ -763,7 +763,7 @@ var _ = registerSimpleMethod(
 			`{"foo":"bar"}`,
 			`{"foo":"bar"}`,
 			`{"foo":5}`,
-			`Error("failed assignment (line 1): field `+"`this`"+`: foo invalid type. expected: string, given: integer")`,
+			`Error("failed assignment (line 1): field `+"`this`"+`: - at '/foo': got number, want string")`,
 		),
 		NewExampleSpec(
 			"In order to load a schema from a file use the `file` function.",
@@ -775,28 +775,13 @@ var _ = registerSimpleMethod(
 		if err != nil {
 			return nil, err
 		}
-		schema, err := jsonschema.NewSchema(jsonschema.NewStringLoader(schemaStr))
+		schema, err := jsonschema.CompileString(schemaStr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse json schema definition: %w", err)
 		}
 		return func(res any, ctx FunctionContext) (any, error) {
-			result, err := schema.Validate(jsonschema.NewGoLoader(res))
-			if err != nil {
+			if err := jsonschema.Validate(schema, res); err != nil {
 				return nil, err
-			}
-			if !result.Valid() {
-				var errStr string
-				for i, desc := range result.Errors() {
-					if i > 0 {
-						errStr += "\n"
-					}
-					description := strings.ToLower(desc.Description())
-					if property := desc.Details()["property"]; property != nil {
-						description = property.(string) + strings.TrimPrefix(description, strings.ToLower(property.(string)))
-					}
-					errStr = errStr + desc.Field() + " " + description
-				}
-				return nil, errors.New(errStr)
 			}
 			return res, nil
 		}, nil

--- a/internal/impl/confluent/serde_json.go
+++ b/internal/impl/confluent/serde_json.go
@@ -4,29 +4,29 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/xeipuuv/gojsonschema"
-
+	"github.com/warpstreamlabs/bento/internal/jsonschema"
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
-func resolveJSONSchema(ctx context.Context, client *schemaRegistryClient, info SchemaInfo) (*gojsonschema.Schema, error) {
-	sl := gojsonschema.NewSchemaLoader()
+// jsonSchemaRootName is the synthetic name given to the schema being compiled,
+// so that references supplied by the registry resolve as its siblings.
+const jsonSchemaRootName = "bento-schema-root.json"
 
-	if len(info.References) == 0 {
-		if err := sl.AddSchemas(); err != nil {
-			return nil, fmt.Errorf("failed to parse root schema: %w", err)
-		}
-
-		return sl.Compile(gojsonschema.NewStringLoader(info.Schema))
-	}
+func resolveJSONSchema(ctx context.Context, client *schemaRegistryClient, info SchemaInfo) (*jsonschema.Schema, error) {
+	compiler := jsonschema.NewRegistryCompiler()
 
 	if err := client.WalkReferences(ctx, info.References, func(ctx context.Context, name string, info SchemaInfo) error {
-		return sl.AddSchemas(gojsonschema.NewStringLoader(info.Schema))
+		return jsonschema.AddResourceString(compiler, jsonschema.RegistryURL(name), info.Schema)
 	}); err != nil {
 		return nil, err
 	}
 
-	return sl.Compile(gojsonschema.NewStringLoader(info.Schema))
+	rootURL := jsonschema.RegistryURL(jsonSchemaRootName)
+	if err := jsonschema.AddResourceString(compiler, rootURL, info.Schema); err != nil {
+		return nil, fmt.Errorf("failed to parse root schema: %w", err)
+	}
+
+	return compiler.Compile(rootURL)
 }
 
 func (s *schemaRegistryEncoder) getJSONEncoder(ctx context.Context, info SchemaInfo) (schemaEncoder, error) {
@@ -52,13 +52,13 @@ func getJSONTranscoder(ctx context.Context, cl *schemaRegistryClient, info Schem
 		}
 
 		// -- verify the json message against the schema
-		res, err := sch.Validate(gojsonschema.NewBytesLoader(b))
+		doc, err := jsonschema.UnmarshalBytes(b)
 		if err != nil {
 			return err
 		}
 
-		if !res.Valid() {
-			return fmt.Errorf("json message does not conform to schema: %v", res.Errors())
+		if err := sch.Validate(doc); err != nil {
+			return fmt.Errorf("json message does not conform to schema: %v", jsonschema.FormatError(err))
 		}
 
 		return nil

--- a/internal/impl/pure/processor_jsonschema.go
+++ b/internal/impl/pure/processor_jsonschema.go
@@ -9,12 +9,10 @@ import (
 	"github.com/warpstreamlabs/bento/internal/bundle"
 	"github.com/warpstreamlabs/bento/internal/component/interop"
 	"github.com/warpstreamlabs/bento/internal/component/processor"
-	"github.com/warpstreamlabs/bento/internal/filepath/ifs"
+	"github.com/warpstreamlabs/bento/internal/jsonschema"
 	"github.com/warpstreamlabs/bento/internal/log"
 	"github.com/warpstreamlabs/bento/internal/message"
 	"github.com/warpstreamlabs/bento/public/service"
-
-	jsonschema "github.com/xeipuuv/gojsonschema"
 )
 
 const (
@@ -122,12 +120,12 @@ func newJSONSchema(schemaStr, schemaPath string, mgr bundle.NewManagement) (proc
 			return nil, errors.New("invalid schema_path provided, must start with file:// or http://")
 		}
 
-		schema, err = jsonschema.NewSchema(jsonschema.NewReferenceLoaderFileSystem(schemaPath, ifs.ToHTTP(mgr.FS())))
+		schema, err = jsonschema.CompilePath(schemaPath, mgr.FS())
 		if err != nil {
 			return nil, fmt.Errorf("failed to load JSON schema definition: %v", err)
 		}
 	} else if schemaStr != "" {
-		schema, err = jsonschema.NewSchema(jsonschema.NewStringLoader(schemaStr))
+		schema, err = jsonschema.CompileString(schemaStr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load JSON schema definition: %v", err)
 		}
@@ -152,27 +150,9 @@ func (s *jsonSchemaProc) Process(ctx context.Context, part *message.Part) ([]*me
 		return nil, err
 	}
 
-	partLoader := jsonschema.NewGoLoader(jsonPart)
-	result, err := s.schema.Validate(partLoader)
-	if err != nil {
-		s.log.Debug("Failed to validate json: %v", err)
-		return nil, err
-	}
-
-	if !result.Valid() {
+	if err := jsonschema.Validate(s.schema, jsonPart); err != nil {
 		s.log.Debug("The document is not valid")
-		var errStr strings.Builder
-		for i, desc := range result.Errors() {
-			if i > 0 {
-				errStr.WriteString("\n")
-			}
-			description := strings.ToLower(desc.Description())
-			if property := desc.Details()["property"]; property != nil {
-				description = property.(string) + strings.TrimPrefix(description, strings.ToLower(property.(string)))
-			}
-			errStr.WriteString(desc.Field() + " " + description)
-		}
-		return nil, errors.New(errStr.String())
+		return nil, err
 	}
 
 	s.log.Debug("The document is valid")

--- a/internal/impl/pure/processor_jsonschema_test.go
+++ b/internal/impl/pure/processor_jsonschema_test.go
@@ -125,7 +125,7 @@ func TestJSONSchemaExternalSchemaCheck(t *testing.T) {
 				[]byte(`{"firstName":"John","lastName":"Doe","age":-20}`),
 			},
 			output: `{"firstName":"John","lastName":"Doe","age":-20}`,
-			err:    `age must be greater than or equal to 0`,
+			err:    `- at '/age': minimum: got -20, want 0`,
 		},
 	}
 	for _, tt := range tests {
@@ -216,7 +216,7 @@ func TestJSONSchemaInlineSchemaCheck(t *testing.T) {
 				[]byte(`{"firstName":"John","lastName":"Doe","age":-20}`),
 			},
 			output: `{"firstName":"John","lastName":"Doe","age":-20}`,
-			err:    `age must be greater than or equal to 0`,
+			err:    `- at '/age': minimum: got -20, want 0`,
 		},
 	}
 	for _, tt := range tests {
@@ -253,7 +253,7 @@ json_schema:
 	}
 }
 
-func TestJSONSchemaLowercaseDescriptionCheck(t *testing.T) {
+func TestJSONSchemaNestedRequiredCheck(t *testing.T) {
 	schema := `{
   "$id": "https://example.com/person.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -321,7 +321,7 @@ func TestJSONSchemaLowercaseDescriptionCheck(t *testing.T) {
 				[]byte(`{"firstName":"John","addresses":[{"postCode":"RG1"},{"cityName":"London", "postCode":"E1"}]}`),
 			},
 			output: `{"firstName":"John","addresses":[{"postCode":"RG1"},{"cityName":"London", "postCode":"E1"}]}`,
-			err:    `addresses.0 cityName is required`,
+			err:    `- at '/addresses/0': missing property 'cityName'`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/jsonschema/jsonschema.go
+++ b/internal/jsonschema/jsonschema.go
@@ -1,0 +1,192 @@
+// Package jsonschema centralises the JSON Schema implementation used across
+// Bento components, so that schema compilation, instance normalisation and
+// error rendering stay consistent between them.
+package jsonschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// Schema is a compiled JSON Schema definition.
+type Schema = jsonschema.Schema
+
+// Compiler accumulates schema documents before compiling them.
+type Compiler = jsonschema.Compiler
+
+// registryBase is the synthetic base for schemas whose references are resolved
+// by name rather than by location, as with a schema registry.
+const registryBase = "registry:///"
+
+// inlineURL names schemas supplied literally in a config rather than loaded
+// from a path. It serves as the base for relative references and is stripped
+// from validation errors so it never reaches users.
+const inlineURL = "inline://schema.json"
+
+// remoteTimeout bounds fetching a schema over HTTP. The previous
+// implementation used the default client, which has no timeout at all.
+const remoteTimeout = time.Second * 30
+
+func newCompiler() *jsonschema.Compiler {
+	c := jsonschema.NewCompiler()
+
+	// Drafts 2019-09 and later treat `format` as an annotation unless asserted,
+	// whereas the previous implementation asserted it for every draft.
+	c.AssertFormat()
+
+	return c
+}
+
+// CompileString compiles a schema supplied inline.
+func CompileString(schema string) (*Schema, error) {
+	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(schema))
+	if err != nil {
+		return nil, err
+	}
+
+	c := newCompiler()
+	if err := c.AddResource(inlineURL, doc); err != nil {
+		return nil, err
+	}
+	return c.Compile(inlineURL)
+}
+
+// CompilePath compiles a schema from a file:// or http(s):// location. Files
+// are read through the provided filesystem, and remote references are only
+// resolved for the schemes registered here.
+func CompilePath(path string, f fs.FS) (*Schema, error) {
+	remote := &httpLoader{client: &http.Client{Timeout: remoteTimeout}}
+
+	c := newCompiler()
+	c.UseLoader(jsonschema.SchemeURLLoader{
+		"file":  fileLoader{fs: f},
+		"http":  remote,
+		"https": remote,
+	})
+	return c.Compile(path)
+}
+
+// RegistryURL names a registry-supplied schema. Relative references within a
+// registry schema resolve against this base, so they match sibling reference
+// names rather than paths on the host running Bento.
+func RegistryURL(name string) string {
+	return registryBase + name
+}
+
+// NewRegistryCompiler returns a compiler for registry-supplied schemas. It
+// keeps the default file-only loader, so a reference the registry did not
+// supply fails to compile rather than being fetched over the network.
+func NewRegistryCompiler() *Compiler {
+	return newCompiler()
+}
+
+// AddResourceString registers a schema document under a URL.
+func AddResourceString(c *Compiler, url, schema string) error {
+	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(schema))
+	if err != nil {
+		return err
+	}
+	return c.AddResource(url, doc)
+}
+
+// UnmarshalBytes decodes a JSON document for validation, preserving numbers
+// exactly as written.
+func UnmarshalBytes(b []byte) (any, error) {
+	return jsonschema.UnmarshalJSON(bytes.NewReader(b))
+}
+
+// Normalise converts a value into the types the validator accepts. The previous
+// implementation round-tripped every instance through encoding/json, which
+// rendered []byte as base64 and time.Time as RFC3339. Both remain reachable
+// here as Bloblang values, so the round trip is preserved rather than dropped.
+func Normalise(v any) (any, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return jsonschema.UnmarshalJSON(bytes.NewReader(b))
+}
+
+// Validate checks a value against a schema, normalising it first.
+func Validate(s *Schema, v any) error {
+	doc, err := Normalise(v)
+	if err != nil {
+		return err
+	}
+	return FormatError(s.Validate(doc))
+}
+
+// FormatError rewrites a validation failure for display. The first line of the
+// underlying message names the schema resource, which for inline schemas is a
+// synthetic URL, so it is dropped and the tree of causes beneath it kept.
+func FormatError(err error) error {
+	var verr *jsonschema.ValidationError
+	if !errors.As(err, &verr) {
+		return err
+	}
+
+	lines := strings.Split(verr.Error(), "\n")
+	if len(lines) < 2 {
+		return err
+	}
+	return errors.New(strings.Join(lines[1:], "\n"))
+}
+
+// fileLoader resolves file:// URLs through a Bento filesystem.
+type fileLoader struct {
+	fs fs.FS
+}
+
+func (l fileLoader) Load(rawURL string) (any, error) {
+	// Deliberately not url.Parse: a scheme-relative location such as
+	// file://../schema.json parses `..` as the host and loses path segments.
+	// The previous implementation trimmed the prefix verbatim and existing
+	// configs depend on that.
+	path := strings.TrimPrefix(rawURL, "file://")
+
+	path, err := url.QueryUnescape(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if runtime.GOOS == "windows" {
+		path = strings.TrimPrefix(path, "/")
+		path = filepath.FromSlash(path)
+	}
+
+	file, err := l.fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return jsonschema.UnmarshalJSON(file)
+}
+
+// httpLoader resolves http(s):// URLs with a bounded timeout.
+type httpLoader struct {
+	client *http.Client
+}
+
+func (l *httpLoader) Load(rawURL string) (any, error) {
+	resp, err := l.client.Get(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, errors.New("failed to fetch schema: " + resp.Status)
+	}
+	return jsonschema.UnmarshalJSON(resp.Body)
+}

--- a/internal/jsonschema/jsonschema.go
+++ b/internal/jsonschema/jsonschema.go
@@ -47,7 +47,10 @@ func newCompiler() *jsonschema.Compiler {
 	return c
 }
 
-// CompileString compiles a schema supplied inline.
+// CompileString compiles a schema supplied inline. An inline schema has no
+// location to resolve relative references against, but absolute ones are
+// resolved on the same terms as CompilePath so that both config fields of a
+// component behave alike.
 func CompileString(schema string) (*Schema, error) {
 	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(schema))
 	if err != nil {
@@ -55,6 +58,8 @@ func CompileString(schema string) (*Schema, error) {
 	}
 
 	c := newCompiler()
+	c.UseLoader(remoteOnlyLoader())
+
 	if err := c.AddResource(inlineURL, doc); err != nil {
 		return nil, err
 	}
@@ -74,6 +79,16 @@ func CompilePath(path string, f fs.FS) (*Schema, error) {
 		"https": remote,
 	})
 	return c.Compile(path)
+}
+
+// remoteOnlyLoader resolves absolute http(s) references but no file ones, for
+// schemas that did not come from a path on disk.
+func remoteOnlyLoader() jsonschema.SchemeURLLoader {
+	remote := &httpLoader{client: &http.Client{Timeout: remoteTimeout}}
+	return jsonschema.SchemeURLLoader{
+		"http":  remote,
+		"https": remote,
+	}
 }
 
 // RegistryURL names a registry-supplied schema. Relative references within a

--- a/internal/jsonschema/jsonschema_test.go
+++ b/internal/jsonschema/jsonschema_test.go
@@ -1,0 +1,84 @@
+package jsonschema
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/warpstreamlabs/bento/internal/filepath/ifs"
+)
+
+// A schema reaching a sibling document by absolute URL must compile whether it
+// was supplied inline or loaded from a path. The two entry points install their
+// loaders separately, so this guards against them drifting apart.
+func TestCompileResolvesAbsoluteRefs(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{
+  "$id": %q,
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": { "Positive": { "type": "integer", "minimum": 0 } }
+}`, srv.URL+"/root.json")
+	}))
+	t.Cleanup(srv.Close)
+
+	schema := fmt.Sprintf(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": { "n": { "$ref": "%s/root.json#/$defs/Positive" } }
+}`, srv.URL)
+
+	assertRef := func(t *testing.T, s *Schema) {
+		t.Helper()
+		require.NoError(t, Validate(s, map[string]any{"n": 5}))
+		require.Error(t, Validate(s, map[string]any{"n": -5}))
+	}
+
+	t.Run("inline", func(t *testing.T) {
+		s, err := CompileString(schema)
+		require.NoError(t, err)
+		assertRef(t, s)
+	})
+
+	t.Run("path", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "facet.json")
+		require.NoError(t, os.WriteFile(p, []byte(schema), 0o600))
+
+		s, err := CompilePath("file://"+p, ifs.OS())
+		require.NoError(t, err)
+		assertRef(t, s)
+	})
+}
+
+// Values that only became JSON-compatible through the previous implementation's
+// implicit marshal round trip must still validate.
+func TestValidateNormalisesGoValues(t *testing.T) {
+	s, err := CompileString(`{
+  "type": "object",
+  "properties": { "b": { "type": "string" } }
+}`)
+	require.NoError(t, err)
+
+	assert.NoError(t, Validate(s, map[string]any{"b": []byte("hello")}))
+}
+
+// Newer drafts must be enforced rather than silently skipped.
+func TestValidateEnforces2020Keywords(t *testing.T) {
+	s, err := CompileString(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": { "positive": { "type": "integer", "minimum": 0 } },
+  "type": "object",
+  "properties": { "n": { "$ref": "#/$defs/positive", "maximum": 10 } }
+}`)
+	require.NoError(t, err)
+
+	// The sibling `maximum` alongside `$ref` applies from 2019-09 onwards.
+	assert.Error(t, Validate(s, map[string]any{"n": 50}))
+	assert.NoError(t, Validate(s, map[string]any{"n": 5}))
+}

--- a/public/service/stream_schema_test.go
+++ b/public/service/stream_schema_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 
-	jsonschema "github.com/xeipuuv/gojsonschema"
+	"github.com/warpstreamlabs/bento/internal/jsonschema"
 
 	"github.com/warpstreamlabs/bento/public/bloblang"
 	"github.com/warpstreamlabs/bento/public/service"
@@ -205,10 +205,10 @@ func TestJSONSchema(t *testing.T) {
 	testSchema, err := env.FullConfigSchema("xxx", "yyy").MarshalJSONSchema()
 	require.NoError(t, err)
 
-	schema, err := jsonschema.NewSchema(jsonschema.NewStringLoader(string(testSchema)))
+	schema, err := jsonschema.CompileString(string(testSchema))
 	require.NoError(t, err)
 
-	res, err := schema.Validate(jsonschema.NewGoLoader(map[string]any{
+	err = jsonschema.Validate(schema, map[string]any{
 		"input": map[string]any{
 			"testinput": map[string]any{
 				"woof": "uhhhhh, woof!",
@@ -221,7 +221,6 @@ func TestJSONSchema(t *testing.T) {
 				},
 			},
 		},
-	}))
+	})
 	require.NoError(t, err)
-	require.Empty(t, res.Errors())
 }

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -2456,7 +2456,7 @@ root = this.json_schema("""{
 # Out: {"foo":"bar"}
 
 # In:  {"foo":5}
-# Out: Error("failed assignment (line 1): field `this`: foo invalid type. expected: string, given: integer")
+# Out: Error("failed assignment (line 1): field `this`: - at '/foo': got number, want string")
 ```
 
 In order to load a schema from a file use the `file` function.


### PR DESCRIPTION
Fixes #963.

Draft while the breaking-change framing in the issue is still open — the three questions there decide whether this lands as-is.

`xeipuuv/gojsonschema` implements drafts 4/6/7 and has no newer release, so this swaps it for `santhosh-tekuri/jsonschema/v6` across the `json_schema` processor, the Bloblang method, and the schema registry path. The shared wrapper in `internal/jsonschema` exists so compilation, instance handling and error rendering stay identical between the three.

## Things a reviewer would otherwise read as mistakes

Instances are round-tripped through `encoding/json` before validation. `NewGoLoader` did this implicitly, and it is what renders `[]byte` as base64 and `time.Time` as RFC3339 — both still reachable as Bloblang values, so removing the round trip would silently break validation of messages carrying bytes or timestamps.

The file loader trims the `file://` prefix instead of parsing the URL, because `url.Parse` reads `..` in a scheme-relative path as the host and drops segments. `TestJSONSchemaExternalSchemaRelativePath` depends on that not happening.

Registry schemas compile under a synthetic `registry:///` base, so a relative `$ref` resolves to a sibling reference name rather than a path on the host running Bento.

## Behaviour changes

Schemas declaring 2019-09 or 2020-12 are validated with those drafts rather than having the newer keywords silently skipped, so messages that pass today may start failing. Schemas without a `$schema` that mix draft-4 spellings no longer compile — that fails at pipeline startup, not at runtime.

Error text changes and is not shimmed: the old wording came from a locale table with no upstream equivalent, and reproducing it would mean tracking v6 releases indefinitely. Updated in the two tests and the Bloblang example; `website/docs/guides/bloblang/methods.md` is regenerated via `make docs`, not hand-edited.

A second commit fixes an asymmetry found after the first: `CompilePath` registered file and http loaders but `CompileString` used the bare compiler, so an absolute `$ref` inside an inline `schema:` failed to compile where the previous implementation fetched it. Inline schemas now get the same loaders rather than `schema_path` losing them, so the swap removes no capability. Both paths gained a request timeout, which the previous default client did not have.

Not included: a field mapping schema URLs to local files, so a pipeline need not reach the network at startup at all. It belongs on top of this change rather than inside it, and can only be built once the new compiler is in. Happy to add it here if you would rather review them together.

`gojsonschema` does not leave `go.mod` — `ory/dockertest/v3` pulls it through `docker/cli`, so it becomes indirect. It does leave the production binary: `go list -deps ./cmd/bento` no longer contains any `xeipuuv/*` package. (#965 removes it from the graph entirely.)

Verified: `golangci-lint run -c .golangci.yml` over the changed packages, 0 findings in changed files. Note `make lint` runs with `--fix` and rewrites ~24 unrelated files carrying pre-existing `modernize` findings; those are deliberately not included.

Full `make test` was not run green locally — `internal/impl/cypher` needs Docker and `TestFSEvent*` fails on macOS, both confirmed failing identically on an unmodified `upstream/main` worktree. CI is the authority on the suite.
