### PR TITLE
Resolve YAML merge keys when converting a config node to a map

### DIFF
--- a/internal/docs/format_yaml.go
+++ b/internal/docs/format_yaml.go
@@ -977,9 +977,7 @@ func (f FieldSpecs) YAMLToMap(node *yaml.Node, conf ToValueConfig) (map[string]a
 	resultMap := map[string]any{}
 
 	// Resolve YAML merge keys ("<<") so that fields supplied via an anchor are
-	// recognised, matching how linting resolves them (LintYAML). Without this a
-	// config that lints clean fails at init with the merged fields reported as
-	// missing. Explicit keys take precedence over merged ones.
+	// recognised. Explicit keys take precedence over merged ones.
 	seen := map[string]struct{}{}
 	for _, pair := range resolveMergeKeys(node) {
 		fieldName := pair.key.Value

--- a/internal/docs/format_yaml.go
+++ b/internal/docs/format_yaml.go
@@ -920,6 +920,49 @@ func (f FieldSpec) YAMLToValue(node *yaml.Node, conf ToValueConfig) (any, error)
 	return node, nil
 }
 
+type yamlNodePair struct {
+	key   *yaml.Node
+	value *yaml.Node
+}
+
+// mergeAliases returns the mapping nodes referenced by a "<<" merge-key value,
+// which may be a single alias or a sequence of aliases.
+func mergeAliases(node *yaml.Node) []*yaml.Node {
+	switch node.Kind {
+	case yaml.AliasNode:
+		if node.Alias != nil {
+			return []*yaml.Node{node.Alias}
+		}
+	case yaml.SequenceNode:
+		var out []*yaml.Node
+		for _, item := range node.Content {
+			if item.Kind == yaml.AliasNode && item.Alias != nil {
+				out = append(out, item.Alias)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// resolveMergeKeys flattens a mapping node's key/value pairs, expanding any YAML
+// merge keys ("<<": *anchor, or "<<": [*a, *b]) into additional pairs. Pairs set
+// explicitly on the node are returned before merged ones so that explicit keys
+// win, following YAML merge semantics.
+func resolveMergeKeys(node *yaml.Node) []yamlNodePair {
+	var explicit, merged []yamlNodePair
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Tag == "!!merge" {
+			for _, alias := range mergeAliases(node.Content[i+1]) {
+				merged = append(merged, resolveMergeKeys(alias)...)
+			}
+			continue
+		}
+		explicit = append(explicit, yamlNodePair{node.Content[i], node.Content[i+1]})
+	}
+	return append(explicit, merged...)
+}
+
 // YAMLToMap converts a yaml node into a generic map structure by referencing
 // expected fields, adding default values to the map when the node does not
 // contain them.
@@ -933,18 +976,27 @@ func (f FieldSpecs) YAMLToMap(node *yaml.Node, conf ToValueConfig) (map[string]a
 
 	resultMap := map[string]any{}
 
-	for i := 0; i < len(node.Content)-1; i += 2 {
-		fieldName := node.Content[i].Value
+	// Resolve YAML merge keys ("<<") so that fields supplied via an anchor are
+	// recognised, matching how linting resolves them (LintYAML). Without this a
+	// config that lints clean fails at init with the merged fields reported as
+	// missing. Explicit keys take precedence over merged ones.
+	seen := map[string]struct{}{}
+	for _, pair := range resolveMergeKeys(node) {
+		fieldName := pair.key.Value
+		if _, ok := seen[fieldName]; ok {
+			continue
+		}
+		seen[fieldName] = struct{}{}
 
 		if f, exists := pendingFieldsMap[fieldName]; exists {
 			delete(pendingFieldsMap, f.Name)
 			var err error
-			if resultMap[fieldName], err = f.YAMLToValue(node.Content[i+1], conf); err != nil {
+			if resultMap[fieldName], err = f.YAMLToValue(pair.value, conf); err != nil {
 				return nil, fmt.Errorf("field '%v': %w", fieldName, err)
 			}
 		} else {
 			var v any
-			if err := node.Content[i+1].Decode(&v); err != nil {
+			if err := pair.value.Decode(&v); err != nil {
 				return nil, err
 			}
 			resultMap[fieldName] = v

--- a/internal/docs/format_yaml_test.go
+++ b/internal/docs/format_yaml_test.go
@@ -1401,3 +1401,41 @@ processors:
 		})
 	}
 }
+
+func TestFieldsNodeToMapMergeKeys(t *testing.T) {
+	spec := docs.FieldSpecs{
+		docs.FieldString("driver", ""),
+		docs.FieldString("dsn", ""),
+		docs.FieldString("query", "").HasDefault("select 1"),
+	}
+
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(`
+defaults: &defaults
+  driver: postgres
+  dsn: postgres://localhost
+config:
+  <<: *defaults
+  dsn: postgres://override
+`), &doc))
+
+	// The "config" mapping pulls driver/dsn in via a "<<" merge key; without
+	// resolving it those required fields would be reported missing (issue #872).
+	top := doc.Content[0]
+	var configNode *yaml.Node
+	for i := 0; i < len(top.Content)-1; i += 2 {
+		if top.Content[i].Value == "config" {
+			configNode = top.Content[i+1]
+		}
+	}
+	require.NotNil(t, configNode)
+
+	generic, err := spec.YAMLToMap(configNode, docs.ToValueConfig{})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"driver": "postgres",            // merged in via <<
+		"dsn":    "postgres://override", // explicit key overrides the merged one
+		"query":  "select 1",            // default
+	}, generic)
+}

--- a/internal/docs/format_yaml_test.go
+++ b/internal/docs/format_yaml_test.go
@@ -1403,39 +1403,193 @@ processors:
 }
 
 func TestFieldsNodeToMapMergeKeys(t *testing.T) {
-	spec := docs.FieldSpecs{
+	specSimple := docs.FieldSpecs{
+		docs.FieldInt("x", ""),
+		docs.FieldInt("y", ""),
+		docs.FieldInt("r", ""),
+		docs.FieldString("label", ""),
+	}
+
+	specSQL := docs.FieldSpecs{
 		docs.FieldString("driver", ""),
 		docs.FieldString("dsn", ""),
 		docs.FieldString("query", "").HasDefault("select 1"),
 	}
 
-	var doc yaml.Node
-	require.NoError(t, yaml.Unmarshal([]byte(`
+	expectedSimple := map[string]any{
+		"x":     1,
+		"y":     2,
+		"r":     10,
+		"label": "center/big",
+	}
+
+	expectedSQL := map[string]any{
+		"driver": "postgres",
+		"dsn":    "postgres://override",
+		"query":  "select 1",
+	}
+
+	tests := map[string]struct {
+		spec       docs.FieldSpecs
+		yamlConfig string
+		expected   map[string]any
+	}{
+		"Explicit Keys": {
+			spec: specSimple,
+			yamlConfig: `
+config:
+  x: 1
+  y: 2
+  r: 10
+  label: center/big
+`,
+			expected: expectedSimple,
+		},
+		"Merge one map": {
+			spec: specSimple,
+			yamlConfig: `
+CENTER: &CENTER
+  x: 1
+  y: 2
+config:
+  << : *CENTER
+  r: 10
+  label: center/big
+`,
+			expected: expectedSimple,
+		}, "Merge multiple maps": {
+			spec: specSimple,
+			yamlConfig: `
+CENTER: &CENTER
+  x: 1
+  y: 2
+BIG: &BIG
+  r: 10
+config:
+  << : [*CENTER, *BIG]
+  label: center/big
+`,
+			expected: expectedSimple,
+		},
+		"Override": {
+			spec: specSimple,
+			yamlConfig: `
+BIG: &BIG
+  r: 10
+LEFT: &LEFT
+  x: 0
+  y: 2
+SMALL: &SMALL
+  r: 1
+config:
+  << : [*BIG, *LEFT, *SMALL]
+  x: 1
+  label: center/big
+`,
+			expected: expectedSimple,
+		},
+		"SQL merge one map": {
+			spec: specSQL,
+			yamlConfig: `
 defaults: &defaults
   driver: postgres
   dsn: postgres://localhost
 config:
   <<: *defaults
   dsn: postgres://override
-`), &doc))
-
-	// The "config" mapping pulls driver/dsn in via a "<<" merge key; without
-	// resolving it those required fields would be reported missing (issue #872).
-	top := doc.Content[0]
-	var configNode *yaml.Node
-	for i := 0; i < len(top.Content)-1; i += 2 {
-		if top.Content[i].Value == "config" {
-			configNode = top.Content[i+1]
-		}
+`,
+			expected: expectedSQL,
+		},
+		"SQL merge two maps": {
+			spec: specSQL,
+			yamlConfig: `
+defaults: &defaults
+  driver: postgres
+  dsn: postgres://localhost
+defaults_two: &defaults_two
+  driver: mssql
+config:
+  <<: [*defaults, *defaults_two]
+  dsn: postgres://override
+`,
+			expected: expectedSQL,
+		},
+		"SQL check precendence": {
+			spec: specSQL,
+			yamlConfig: `
+defaults: &defaults
+  driver: postgres
+  dsn: postgres://localhost
+defaults_two: &defaults_two
+  driver: mssql
+config:
+  <<: [*defaults_two, *defaults]
+  dsn: postgres://override
+`,
+			expected: map[string]any{
+				"driver": "mssql",
+				"dsn":    "postgres://override",
+				"query":  "select 1",
+			},
+		},
+		"Nested": {
+			spec: specSimple,
+			yamlConfig: `
+ONE: &ONE
+  x: 1
+TWO: &TWO
+  <<: *ONE
+  y: 2
+THREE: &THREE
+  <<: *TWO
+  r: 10
+config:
+  <<: *THREE
+  label: center/big
+`,
+			expected: expectedSimple,
+		},
+		"Nested with scalar reference": {
+			spec: specSimple,
+			yamlConfig: `
+defaults:
+  x: &REF 1
+ONE: &ONE
+  x: *REF
+TWO: &TWO
+  <<: *ONE
+  y: 2
+THREE: &THREE
+  <<: *TWO
+  r: 10
+config:
+  <<: *THREE
+  label: center/big
+`,
+			expected: expectedSimple,
+		},
 	}
-	require.NotNil(t, configNode)
 
-	generic, err := spec.YAMLToMap(configNode, docs.ToValueConfig{})
-	require.NoError(t, err)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	assert.Equal(t, map[string]any{
-		"driver": "postgres",            // merged in via <<
-		"dsn":    "postgres://override", // explicit key overrides the merged one
-		"query":  "select 1",            // default
-	}, generic)
+			var doc yaml.Node
+			require.NoError(t, yaml.Unmarshal([]byte(test.yamlConfig), &doc))
+
+			top := doc.Content[0]
+			var configNode *yaml.Node
+			for i := 0; i < len(top.Content)-1; i += 2 {
+				if top.Content[i].Value == "config" {
+					configNode = top.Content[i+1]
+				}
+			}
+			require.NotNil(t, configNode)
+
+			generic, err := test.spec.YAMLToMap(configNode, docs.ToValueConfig{})
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, generic)
+		})
+	}
 }


### PR DESCRIPTION
### Summary

Fixes #872. A config that uses YAML merge keys (`<<: *anchor`) passes `bento lint` but fails at startup with the merged fields reported missing (e.g. `field 'driver' is required and was not present`).

### Root cause

Linting resolves merge keys: `FieldSpecs.LintYAML` checks `Content[i].Tag == "!!merge"` and recurses into the alias, so merged fields are seen. But `FieldSpecs.YAMLToMap` (used to build the `ParsedConfig` every component reads at init) did not: it iterated the raw key/value pairs, and the `<<` key matched no field spec, so it stored the anchor's contents under a literal `"<<"` key. The merged fields never reached the top level and, being required-with-no-default, init errored.

### Fix

Resolve merge keys before mapping fields (`resolveMergeKeys`), mirroring the lint behaviour. Explicit keys take precedence over merged ones (YAML merge semantics), and both the single-alias (`<<: *a`) and sequence (`<<: [*a, *b]`) forms are handled. The existing non-merge path is unchanged.

### Test

Added `TestFieldsNodeToMapMergeKeys` to `internal/docs`: a config whose fields come via `<<: *defaults` with one explicit override. Before the fix `YAMLToMap` errors (`field 'driver' is required`); after, the merged and overriding fields resolve correctly. `go test ./internal/docs/` passes with no regressions.

---

Disclosure: prepared with AI assistance (Claude); I reviewed it and verified the red-green test and package suite.
