### PR TITLE
aws_sqs: refresh in-flight visibility using the queue's timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `parse_big_decimal` rejects scales above 16383 to avoid unbounded big-integer work @aratz-lasa
+- `aws_sqs` input refreshes in-flight message visibility with the queue's `VisibilityTimeout` instead of a hardcoded 30s, which could let messages lapse and be redelivered under a backlog @ReguiguiMohamed
 
 ### Security
 

--- a/internal/impl/aws/client_factory.go
+++ b/internal/impl/aws/client_factory.go
@@ -73,3 +73,13 @@ func (c *customHeaderSQSClient) SendMessageBatch(
 	allOptFns := append(c.getAPIOptions(), optFns...)
 	return c.sqsAPI.SendMessageBatch(ctx, params, allOptFns...)
 }
+
+// GetQueueAttributes wraps the standard GetQueueAttributes call and adds custom headers
+func (c *customHeaderSQSClient) GetQueueAttributes(
+	ctx context.Context,
+	params *sqs.GetQueueAttributesInput,
+	optFns ...func(*sqs.Options),
+) (*sqs.GetQueueAttributesOutput, error) {
+	allOptFns := append(c.getAPIOptions(), optFns...)
+	return c.sqsAPI.GetQueueAttributes(ctx, params, allOptFns...)
+}

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -154,6 +154,7 @@ type sqsAPI interface {
 	DeleteMessageBatch(context.Context, *sqs.DeleteMessageBatchInput, ...func(*sqs.Options)) (*sqs.DeleteMessageBatchOutput, error)
 	ChangeMessageVisibilityBatch(context.Context, *sqs.ChangeMessageVisibilityBatchInput, ...func(*sqs.Options)) (*sqs.ChangeMessageVisibilityBatchOutput, error)
 	SendMessageBatch(context.Context, *sqs.SendMessageBatchInput, ...func(*sqs.Options)) (*sqs.SendMessageBatchOutput, error)
+	GetQueueAttributes(context.Context, *sqs.GetQueueAttributesInput, ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error)
 }
 
 type awsSQSReader struct {
@@ -194,7 +195,8 @@ func (a *awsSQSReader) Connect(ctx context.Context) error {
 	}
 
 	ift := &sqsInFlightTracker{
-		handles: map[string]sqsInFlightHandle{},
+		handles:                  map[string]sqsInFlightHandle{},
+		visibilityTimeoutSeconds: a.queueVisibilityTimeout(ctx),
 	}
 
 	var wg sync.WaitGroup
@@ -208,6 +210,30 @@ func (a *awsSQSReader) Connect(ctx context.Context) error {
 	return nil
 }
 
+// Used when the queue's own VisibilityTimeout cannot be read, for example when
+// sqs:GetQueueAttributes is not granted.
+const defaultVisibilityTimeoutSeconds = 30
+
+// queueVisibilityTimeout reads the queue's configured VisibilityTimeout, which
+// is the value in-flight messages should be refreshed with. It is a queue level
+// attribute, so ReceiveMessage never reports it per message.
+func (a *awsSQSReader) queueVisibilityTimeout(ctx context.Context) int {
+	res, err := a.sqs.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       aws.String(a.conf.URL),
+		AttributeNames: []types.QueueAttributeName{types.QueueAttributeNameVisibilityTimeout},
+	})
+	if err != nil {
+		a.log.Warnf("Failed to read the queue's %v, falling back to %vs: %v", sqsiAttributeNameVisibilityTimeout, defaultVisibilityTimeoutSeconds, err)
+		return defaultVisibilityTimeoutSeconds
+	}
+	seconds, err := strconv.Atoi(res.Attributes[sqsiAttributeNameVisibilityTimeout])
+	if err != nil || seconds <= 0 {
+		a.log.Warnf("Queue reported no usable %v, falling back to %vs", sqsiAttributeNameVisibilityTimeout, defaultVisibilityTimeoutSeconds)
+		return defaultVisibilityTimeoutSeconds
+	}
+	return seconds
+}
+
 type sqsInFlightHandle struct {
 	receiptHandle  string
 	timeoutSeconds int
@@ -215,8 +241,9 @@ type sqsInFlightHandle struct {
 }
 
 type sqsInFlightTracker struct {
-	handles map[string]sqsInFlightHandle
-	m       sync.Mutex
+	handles                  map[string]sqsInFlightHandle
+	visibilityTimeoutSeconds int
+	m                        sync.Mutex
 }
 
 func (t *sqsInFlightTracker) PullToRefresh() (handles []sqsMessageHandle, timeoutSeconds int) {
@@ -254,19 +281,11 @@ func (t *sqsInFlightTracker) AddNew(messages ...types.Message) {
 			continue
 		}
 
-		handle := sqsInFlightHandle{
-			timeoutSeconds: 30,
+		t.handles[*m.MessageId] = sqsInFlightHandle{
+			timeoutSeconds: t.visibilityTimeoutSeconds,
 			receiptHandle:  *m.ReceiptHandle,
 			addedAt:        time.Now(),
 		}
-		if timeoutStr, exists := m.Attributes[sqsiAttributeNameVisibilityTimeout]; exists {
-			// Might as well keep the queue timeout setting refreshed as we
-			// consume new data.
-			if tmpTimeoutSeconds, err := strconv.Atoi(timeoutStr); err == nil {
-				handle.timeoutSeconds = tmpTimeoutSeconds
-			}
-		}
-		t.handles[*m.MessageId] = handle
 	}
 }
 

--- a/internal/impl/aws/input_sqs_test.go
+++ b/internal/impl/aws/input_sqs_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -25,6 +26,8 @@ type mockSqsInput struct {
 	queueTimeout int32
 	messages     []types.Message
 	mesTimeouts  map[string]int32
+
+	getQueueAttributesErr error
 }
 
 func (m *mockSqsInput) do(fn func()) {
@@ -70,7 +73,10 @@ func (m *mockSqsInput) ReceiveMessage(context.Context, *sqs.ReceiveMessageInput,
 	return &sqs.ReceiveMessageOutput{Messages: messages}, nil
 }
 
-func (m *mockSqsInput) GetQueueAttributes(input *sqs.GetQueueAttributesInput) (*sqs.GetQueueAttributesOutput, error) {
+func (m *mockSqsInput) GetQueueAttributes(context.Context, *sqs.GetQueueAttributesInput, ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error) {
+	if m.getQueueAttributesErr != nil {
+		return nil, m.getQueueAttributesErr
+	}
 	return &sqs.GetQueueAttributesOutput{Attributes: map[string]string{sqsiAttributeNameVisibilityTimeout: strconv.Itoa(int(m.queueTimeout))}}, nil
 }
 
@@ -282,4 +288,55 @@ func TestSQSInputBatchAck(t *testing.T) {
 		})
 		return msgsLen == 0
 	}, 5*time.Second, time.Second)
+}
+
+func TestSQSInputVisibilityTimeoutFollowsQueue(t *testing.T) {
+	tests := []struct {
+		name         string
+		queueTimeout int32
+		attributeErr error
+		expected     int
+	}{
+		{
+			name:         "takes the timeout the queue is configured with",
+			queueTimeout: 600,
+			expected:     600,
+		},
+		{
+			name:         "falls back when the queue cannot be read",
+			attributeErr: errors.New("access denied"),
+			expected:     defaultVisibilityTimeoutSeconds,
+		},
+		{
+			name:         "falls back when the queue reports zero",
+			queueTimeout: 0,
+			expected:     defaultVisibilityTimeoutSeconds,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, err := newAWSSQSReader(sqsiConfig{URL: "http://foo.example.com"}, aws.Config{}, nil)
+			require.NoError(t, err)
+			r.sqs = &mockSqsInput{
+				queueTimeout:          test.queueTimeout,
+				getQueueAttributesErr: test.attributeErr,
+			}
+
+			timeout := r.queueVisibilityTimeout(t.Context())
+			assert.Equal(t, test.expected, timeout)
+
+			// The timeout read at connect time is what in-flight handles get
+			// refreshed with.
+			tracker := &sqsInFlightTracker{
+				handles:                  map[string]sqsInFlightHandle{},
+				visibilityTimeoutSeconds: timeout,
+			}
+			tracker.AddNew(types.Message{
+				MessageId:     aws.String("message-1"),
+				ReceiptHandle: aws.String("message-1"),
+			})
+			assert.Equal(t, test.expected, tracker.handles["message-1"].timeoutSeconds)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #878.

The in-flight tracker stamped every handle with a hardcoded 30s. It tried to read the queue's value from `m.Attributes[VisibilityTimeout]`, but `ReceiveMessage` only returns message system attributes and `VisibilityTimeout` is a queue level one, so that branch never ran. A queue set to a longer timeout had it silently overridden, and under a backlog big enough that the refresher could not cycle every handle within 30s, messages lapsed, got redelivered, and the cached receipt handles went stale with `ReceiptHandleIsInvalid`.

`Connect` now reads the queue's `VisibilityTimeout` once through `GetQueueAttributes` and stamps handles with it, falling back to 30s when the call fails or `sqs:GetQueueAttributes` is not granted. That is the auto-detect option from the issue, so it stays backward compatible. Glad to add a config override instead, or on top, if you'd prefer.

Two supporting changes, both needed for the above rather than separate fixes:

- `GetQueueAttributes` added to the internal `sqsAPI` interface, with a passthrough on `customHeaderSQSClient` so the new call still carries `custom_request_headers`. Without it the call would skip them and fall back to 30s for anyone using that field.
- `mockSqsInput.GetQueueAttributes` already existed and already returned `queueTimeout`, but with a pre-SDK-v2 signature that never satisfied the interface. Corrected, so the existing tests now exercise the queue value.

The dead per-message lookup is gone.

### Testing

- `go vet ./...` clean, and `golangci-lint run -c .golangci.yml ./internal/impl/aws/...` clean.
- `go build ./...`, `bento template lint`, and `bento test ./config/test/...` all pass.
- `internal/impl/aws` passes in full, over several repeat runs.
- Reverting just the `AddNew` line back to the hardcoded 30 turns the new test red with `expected: 600, actual: 30`.
- No docs regeneration, since no config field was added.
- I did not run the integration suite.

Worth flagging: now that the queue value is honored, `TestSQSInput` refreshes at its 10s `queueTimeout` rather than a fixed 30s, so its tolerance for a stalled refresher is narrower. I hit one failure there that I could not reproduce across six later runs, and the mock's `panic("nope")`, which fires when an ack races a visibility refresh, looks like the likely trigger.

Separately, and unrelated to this change, `internal/impl/sql` fails three tests on my Windows machine (`TestBufferSQLiteCloseWithPending`, `TestBufferSQLiteCloseAfterNack`, `TestConnSettingsInitFiles`). They fail identically on main.
