### PR TITLE
aws_sqs: refresh in-flight visibility using the queue's timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Optional `Keys` method for caches enabling consumers of cache resources to enumerate keys, caches that do not support key listing yield `ErrKeyListingNotSupported` @ecordell
 - `memory`, `file`, `aws_s3` and `gcp_cloud_storage` caches support `Keys` @ecordell
+- `aws_sqs` input field `visibility_timeout`, which overrides the timeout the queue is configured with @ReguiguiMohamed
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ All notable changes to this project will be documented in this file.
 
 - Optional `Keys` method for caches enabling consumers of cache resources to enumerate keys, caches that do not support key listing yield `ErrKeyListingNotSupported` @ecordell
 - `memory`, `file`, `aws_s3` and `gcp_cloud_storage` caches support `Keys` @ecordell
-- `aws_sqs` input field `visibility_timeout`, which overrides the timeout the queue is configured with @ReguiguiMohamed
+- `aws_sqs` input field `visibility_timeout`, previously hardcoded to 30s, which follows the queue's own timeout when set to `0` @ReguiguiMohamed
 
 ### Fixed
 
 - `parse_big_decimal` rejects scales above 16383 to avoid unbounded big-integer work @aratz-lasa
-- `aws_sqs` input refreshes in-flight message visibility with the queue's `VisibilityTimeout` instead of a hardcoded 30s, which could let messages lapse and be redelivered under a backlog @ReguiguiMohamed
+- `aws_sqs` input looked for the queue's `VisibilityTimeout` on each message, which `ReceiveMessage` never returns, so in-flight messages could not be refreshed with anything but 30s @ReguiguiMohamed
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `parse_big_decimal` rejects scales above 16383 to avoid unbounded big-integer work @aratz-lasa
+- `aws_sqs` input refreshes in-flight message visibility with the queue's `VisibilityTimeout` instead of a hardcoded 30s, which could let messages lapse and be redelivered under a backlog @ReguiguiMohamed
 
 ### Security
 

--- a/internal/impl/aws/client_factory.go
+++ b/internal/impl/aws/client_factory.go
@@ -73,3 +73,13 @@ func (c *customHeaderSQSClient) SendMessageBatch(
 	allOptFns := append(c.getAPIOptions(), optFns...)
 	return c.sqsAPI.SendMessageBatch(ctx, params, allOptFns...)
 }
+
+// GetQueueAttributes wraps the standard GetQueueAttributes call and adds custom headers
+func (c *customHeaderSQSClient) GetQueueAttributes(
+	ctx context.Context,
+	params *sqs.GetQueueAttributesInput,
+	optFns ...func(*sqs.Options),
+) (*sqs.GetQueueAttributesOutput, error) {
+	allOptFns := append(c.getAPIOptions(), optFns...)
+	return c.sqsAPI.GetQueueAttributes(ctx, params, allOptFns...)
+}

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -27,6 +27,7 @@ const (
 	sqsiFieldDeleteMessage        = "delete_message"
 	sqsiFieldResetVisibility      = "reset_visibility"
 	sqsiFieldUpdateVisibility     = "update_visibility"
+	sqsiFieldVisibilityTimeout    = "visibility_timeout"
 	sqsiFieldMaxNumberOfMessages  = "max_number_of_messages"
 	sqsiFieldCustomRequestHeaders = "custom_request_headers"
 
@@ -39,6 +40,7 @@ type sqsiConfig struct {
 	DeleteMessage        bool
 	ResetVisibility      bool
 	UpdateVisibility     bool
+	VisibilityTimeout    time.Duration
 	MaxNumberOfMessages  int
 	CustomRequestHeaders map[string]string
 }
@@ -57,6 +59,9 @@ func sqsiConfigFromParsed(pConf *service.ParsedConfig) (conf sqsiConfig, err err
 		return
 	}
 	if conf.UpdateVisibility, err = pConf.FieldBool(sqsiFieldUpdateVisibility); err != nil {
+		return
+	}
+	if conf.VisibilityTimeout, err = pConf.FieldDuration(sqsiFieldVisibilityTimeout); err != nil {
 		return
 	}
 	if conf.MaxNumberOfMessages, err = pConf.FieldInt(sqsiFieldMaxNumberOfMessages); err != nil {
@@ -109,6 +114,11 @@ You can access these metadata fields using
 				Description("Whether to periodically refresh the visibility timeout of in-flight messages to prevent more-than-once delivery while still processing.").
 				Version("1.6.0").
 				Default(true).
+				Advanced(),
+			service.NewDurationField(sqsiFieldVisibilityTimeout).
+				Description("The visibility timeout to request for consumed messages, and the value in-flight messages are refreshed with. Zero uses whatever the queue itself is configured with. SQS counts this in whole seconds, so anything finer is rounded down.").
+				Version("1.21.0").
+				Default("0s").
 				Advanced(),
 			service.NewIntField(sqsiFieldMaxNumberOfMessages).
 				Description("The maximum number of messages to return on one poll. Valid values: 1 to 10.").
@@ -196,7 +206,7 @@ func (a *awsSQSReader) Connect(ctx context.Context) error {
 
 	ift := &sqsInFlightTracker{
 		handles:                  map[string]sqsInFlightHandle{},
-		visibilityTimeoutSeconds: a.queueVisibilityTimeout(ctx),
+		visibilityTimeoutSeconds: a.visibilityTimeoutSeconds(ctx),
 	}
 
 	var wg sync.WaitGroup
@@ -214,10 +224,18 @@ func (a *awsSQSReader) Connect(ctx context.Context) error {
 // sqs:GetQueueAttributes is not granted.
 const defaultVisibilityTimeoutSeconds = 30
 
-// queueVisibilityTimeout reads the queue's configured VisibilityTimeout, which
-// is the value in-flight messages should be refreshed with. It is a queue level
-// attribute, so ReceiveMessage never reports it per message.
-func (a *awsSQSReader) queueVisibilityTimeout(ctx context.Context) int {
+// visibilityTimeoutSeconds is the value in-flight messages are refreshed with.
+// Without a configured timeout the queue has to be asked for its own, since
+// VisibilityTimeout is a queue level attribute ReceiveMessage never reports.
+func (a *awsSQSReader) visibilityTimeoutSeconds(ctx context.Context) int {
+	if a.conf.VisibilityTimeout > 0 {
+		return int(a.conf.VisibilityTimeout.Seconds())
+	}
+	if !a.conf.UpdateVisibility {
+		// Nothing refreshes, so nothing needs the queue's value.
+		return 0
+	}
+
 	res, err := a.sqs.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
 		QueueUrl:       aws.String(a.conf.URL),
 		AttributeNames: []types.QueueAttributeName{types.QueueAttributeNameVisibilityTimeout},
@@ -402,6 +420,7 @@ func (a *awsSQSReader) readLoop(wg *sync.WaitGroup, inFlightTracker *sqsInFlight
 			QueueUrl:              aws.String(a.conf.URL),
 			MaxNumberOfMessages:   int32(a.conf.MaxNumberOfMessages),
 			WaitTimeSeconds:       int32(a.conf.WaitTimeSeconds),
+			VisibilityTimeout:     int32(a.conf.VisibilityTimeout.Seconds()),
 			AttributeNames:        []types.QueueAttributeName{types.QueueAttributeNameAll},
 			MessageAttributeNames: []string{"All"},
 		})

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -154,6 +154,7 @@ type sqsAPI interface {
 	DeleteMessageBatch(context.Context, *sqs.DeleteMessageBatchInput, ...func(*sqs.Options)) (*sqs.DeleteMessageBatchOutput, error)
 	ChangeMessageVisibilityBatch(context.Context, *sqs.ChangeMessageVisibilityBatchInput, ...func(*sqs.Options)) (*sqs.ChangeMessageVisibilityBatchOutput, error)
 	SendMessageBatch(context.Context, *sqs.SendMessageBatchInput, ...func(*sqs.Options)) (*sqs.SendMessageBatchOutput, error)
+	GetQueueAttributes(context.Context, *sqs.GetQueueAttributesInput, ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error)
 }
 
 type awsSQSReader struct {
@@ -194,7 +195,8 @@ func (a *awsSQSReader) Connect(ctx context.Context) error {
 	}
 
 	ift := &sqsInFlightTracker{
-		handles: map[string]sqsInFlightHandle{},
+		handles:                  map[string]sqsInFlightHandle{},
+		visibilityTimeoutSeconds: a.queueVisibilityTimeout(ctx),
 	}
 
 	var wg sync.WaitGroup
@@ -208,6 +210,30 @@ func (a *awsSQSReader) Connect(ctx context.Context) error {
 	return nil
 }
 
+// Used when the queue's own VisibilityTimeout cannot be read, for example when
+// sqs:GetQueueAttributes is not granted.
+const defaultVisibilityTimeoutSeconds = 30
+
+// queueVisibilityTimeout reads the queue's configured VisibilityTimeout, which
+// is the value in-flight messages should be refreshed with. It is a queue level
+// attribute, so ReceiveMessage never reports it per message.
+func (a *awsSQSReader) queueVisibilityTimeout(ctx context.Context) int {
+	res, err := a.sqs.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       aws.String(a.conf.URL),
+		AttributeNames: []types.QueueAttributeName{types.QueueAttributeNameVisibilityTimeout},
+	})
+	if err != nil {
+		a.log.Warnf("Failed to read the queue's %v, falling back to %vs: %v", sqsiAttributeNameVisibilityTimeout, defaultVisibilityTimeoutSeconds, err)
+		return defaultVisibilityTimeoutSeconds
+	}
+	seconds, err := strconv.Atoi(res.Attributes[sqsiAttributeNameVisibilityTimeout])
+	if err != nil || seconds <= 0 {
+		a.log.Warnf("Queue reported no usable %v, falling back to %vs", sqsiAttributeNameVisibilityTimeout, defaultVisibilityTimeoutSeconds)
+		return defaultVisibilityTimeoutSeconds
+	}
+	return seconds
+}
+
 type sqsInFlightHandle struct {
 	receiptHandle  string
 	timeoutSeconds int
@@ -215,8 +241,9 @@ type sqsInFlightHandle struct {
 }
 
 type sqsInFlightTracker struct {
-	handles map[string]sqsInFlightHandle
-	m       sync.Mutex
+	handles                  map[string]sqsInFlightHandle
+	visibilityTimeoutSeconds int
+	m                        sync.Mutex
 }
 
 func (t *sqsInFlightTracker) PullToRefresh() (handles []sqsMessageHandle, timeoutSeconds int) {
@@ -254,19 +281,11 @@ func (t *sqsInFlightTracker) AddNew(messages ...types.Message) {
 			continue
 		}
 
-		handle := sqsInFlightHandle{
-			timeoutSeconds: 30,
+		t.handles[*m.MessageId] = sqsInFlightHandle{
+			timeoutSeconds: t.visibilityTimeoutSeconds,
 			receiptHandle:  *m.ReceiptHandle,
 			addedAt:        time.Now(),
 		}
-		if timeoutStr, exists := m.Attributes[sqsiAttributeNameVisibilityTimeout]; exists {
-			// Might as well keep the queue timeout setting refreshed as we
-			// consume new data.
-			if tmpTimeoutSeconds, err := strconv.Atoi(timeoutStr); err == nil {
-				handle.timeoutSeconds = tmpTimeoutSeconds
-			}
-		}
-		t.handles[*m.MessageId] = handle
 	}
 }
 

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -116,9 +116,9 @@ You can access these metadata fields using
 				Default(true).
 				Advanced(),
 			service.NewDurationField(sqsiFieldVisibilityTimeout).
-				Description("The visibility timeout to request for consumed messages, and the value in-flight messages are refreshed with. Zero uses whatever the queue itself is configured with. SQS counts this in whole seconds, so anything finer is rounded down.").
+				Description("Visibility timeout (truncated to whole seconds) requested when retrieving messages, and used when refreshing in-flight messages. A value of `0` defers to the SQS queue's configured timeout, as does disabling `update_visibility`.").
 				Version("1.21.0").
-				Default("0s").
+				Default("30s").
 				Advanced(),
 			service.NewIntField(sqsiFieldMaxNumberOfMessages).
 				Description("The maximum number of messages to return on one poll. Valid values: 1 to 10.").
@@ -228,12 +228,12 @@ const defaultVisibilityTimeoutSeconds = 30
 // Without a configured timeout the queue has to be asked for its own, since
 // VisibilityTimeout is a queue level attribute ReceiveMessage never reports.
 func (a *awsSQSReader) visibilityTimeoutSeconds(ctx context.Context) int {
+	if !a.conf.UpdateVisibility {
+		// Visibility is left entirely to the queue.
+		return 0
+	}
 	if a.conf.VisibilityTimeout > 0 {
 		return int(a.conf.VisibilityTimeout.Seconds())
-	}
-	if !a.conf.UpdateVisibility {
-		// Nothing refreshes, so nothing needs the queue's value.
-		return 0
 	}
 
 	res, err := a.sqs.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
@@ -250,6 +250,15 @@ func (a *awsSQSReader) visibilityTimeoutSeconds(ctx context.Context) int {
 		return defaultVisibilityTimeoutSeconds
 	}
 	return seconds
+}
+
+// Zero leaves the queue's own timeout in place, which is also what happens when
+// Bento is told not to manage visibility.
+func (a *awsSQSReader) receiveVisibilityTimeout() int32 {
+	if !a.conf.UpdateVisibility {
+		return 0
+	}
+	return int32(a.conf.VisibilityTimeout.Seconds())
 }
 
 type sqsInFlightHandle struct {
@@ -420,7 +429,7 @@ func (a *awsSQSReader) readLoop(wg *sync.WaitGroup, inFlightTracker *sqsInFlight
 			QueueUrl:              aws.String(a.conf.URL),
 			MaxNumberOfMessages:   int32(a.conf.MaxNumberOfMessages),
 			WaitTimeSeconds:       int32(a.conf.WaitTimeSeconds),
-			VisibilityTimeout:     int32(a.conf.VisibilityTimeout.Seconds()),
+			VisibilityTimeout:     a.receiveVisibilityTimeout(),
 			AttributeNames:        []types.QueueAttributeName{types.QueueAttributeNameAll},
 			MessageAttributeNames: []string{"All"},
 		})

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -117,7 +117,7 @@ You can access these metadata fields using
 				Advanced(),
 			service.NewDurationField(sqsiFieldVisibilityTimeout).
 				Description("Visibility timeout (truncated to whole seconds) requested when retrieving messages, and used when refreshing in-flight messages. A value of `0` defers to the SQS queue's configured timeout, as does disabling `update_visibility`.").
-				Version("1.21.0").
+				Version("1.22.0").
 				Default("30s").
 				Advanced(),
 			service.NewIntField(sqsiFieldMaxNumberOfMessages).

--- a/internal/impl/aws/input_sqs_test.go
+++ b/internal/impl/aws/input_sqs_test.go
@@ -332,8 +332,8 @@ func TestSQSInputVisibilityTimeout(t *testing.T) {
 			expected:     300,
 		},
 		{
-			name:         "leaves the queue alone when nothing refreshes",
-			conf:         sqsiConfig{UpdateVisibility: false},
+			name:         "leaves the timeout to the queue when nothing refreshes",
+			conf:         sqsiConfig{UpdateVisibility: false, VisibilityTimeout: 5 * time.Minute},
 			queueTimeout: 600,
 			expected:     0,
 		},
@@ -369,35 +369,56 @@ func TestSQSInputVisibilityTimeout(t *testing.T) {
 	}
 }
 
-func TestSQSInputReceiveWithConfiguredVisibilityTimeout(t *testing.T) {
-	r, err := newAWSSQSReader(sqsiConfig{
-		URL:                 "http://foo.example.com",
-		MaxNumberOfMessages: 10,
-		VisibilityTimeout:   5 * time.Minute,
-	}, aws.Config{}, nil)
-	require.NoError(t, err)
-
-	mockInput := &mockSqsInput{
-		mtx:          make(chan struct{}, 1),
-		queueTimeout: 30,
-		messages: []types.Message{{
-			Body:          aws.String("message-1"),
-			MessageId:     aws.String("message-1"),
-			ReceiptHandle: aws.String("message-1"),
-		}},
-		mesTimeouts: map[string]int32{},
+func TestSQSInputReceiveVisibilityTimeout(t *testing.T) {
+	tests := []struct {
+		name             string
+		updateVisibility bool
+		expected         int32
+	}{
+		{
+			name:             "carries the configured timeout",
+			updateVisibility: true,
+			expected:         300,
+		},
+		{
+			name:             "asks for nothing when visibility is left to the queue",
+			updateVisibility: false,
+			expected:         0,
+		},
 	}
-	mockInput.mtx <- struct{}{}
-	r.sqs = mockInput
 
-	defer r.closeSignal.TriggerHardStop()
-	require.NoError(t, r.Connect(t.Context()))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, err := newAWSSQSReader(sqsiConfig{
+				URL:                 "http://foo.example.com",
+				MaxNumberOfMessages: 10,
+				UpdateVisibility:    test.updateVisibility,
+				VisibilityTimeout:   5 * time.Minute,
+			}, aws.Config{}, nil)
+			require.NoError(t, err)
 
-	_, _, err = r.Read(t.Context())
-	require.NoError(t, err)
+			mockInput := &mockSqsInput{
+				mtx:          make(chan struct{}, 1),
+				queueTimeout: 30,
+				messages: []types.Message{{
+					Body:          aws.String("message-1"),
+					MessageId:     aws.String("message-1"),
+					ReceiptHandle: aws.String("message-1"),
+				}},
+				mesTimeouts: map[string]int32{},
+			}
+			mockInput.mtx <- struct{}{}
+			r.sqs = mockInput
 
-	// Refreshing is off here, so the request itself has to carry the timeout.
-	mockInput.do(func() {
-		assert.Equal(t, int32(300), mockInput.receivedTimeout)
-	})
+			defer r.closeSignal.TriggerHardStop()
+			require.NoError(t, r.Connect(t.Context()))
+
+			_, _, err = r.Read(t.Context())
+			require.NoError(t, err)
+
+			mockInput.do(func() {
+				assert.Equal(t, test.expected, mockInput.receivedTimeout)
+			})
+		})
+	}
 }

--- a/internal/impl/aws/input_sqs_test.go
+++ b/internal/impl/aws/input_sqs_test.go
@@ -27,7 +27,9 @@ type mockSqsInput struct {
 	messages     []types.Message
 	mesTimeouts  map[string]int32
 
-	getQueueAttributesErr error
+	getQueueAttributesErr   error
+	getQueueAttributesCalls int
+	receivedTimeout         int32
 }
 
 func (m *mockSqsInput) do(fn func()) {
@@ -57,9 +59,11 @@ func (m *mockSqsInput) TimeoutLoop(ctx context.Context) {
 	}
 }
 
-func (m *mockSqsInput) ReceiveMessage(context.Context, *sqs.ReceiveMessageInput, ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
+func (m *mockSqsInput) ReceiveMessage(_ context.Context, input *sqs.ReceiveMessageInput, _ ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
 	<-m.mtx
 	defer func() { m.mtx <- struct{}{} }()
+
+	m.receivedTimeout = input.VisibilityTimeout
 
 	messages := make([]types.Message, 0, len(m.messages))
 
@@ -74,6 +78,7 @@ func (m *mockSqsInput) ReceiveMessage(context.Context, *sqs.ReceiveMessageInput,
 }
 
 func (m *mockSqsInput) GetQueueAttributes(context.Context, *sqs.GetQueueAttributesInput, ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error) {
+	m.getQueueAttributesCalls++
 	if m.getQueueAttributesErr != nil {
 		return nil, m.getQueueAttributesErr
 	}
@@ -290,43 +295,66 @@ func TestSQSInputBatchAck(t *testing.T) {
 	}, 5*time.Second, time.Second)
 }
 
-func TestSQSInputVisibilityTimeoutFollowsQueue(t *testing.T) {
+func TestSQSInputVisibilityTimeout(t *testing.T) {
 	tests := []struct {
-		name         string
-		queueTimeout int32
-		attributeErr error
-		expected     int
+		name             string
+		conf             sqsiConfig
+		queueTimeout     int32
+		attributeErr     error
+		expected         int
+		expectQueueReads int
 	}{
 		{
-			name:         "takes the timeout the queue is configured with",
+			name:             "takes the timeout the queue is configured with",
+			conf:             sqsiConfig{UpdateVisibility: true},
+			queueTimeout:     600,
+			expected:         600,
+			expectQueueReads: 1,
+		},
+		{
+			name:             "falls back when the queue cannot be read",
+			conf:             sqsiConfig{UpdateVisibility: true},
+			attributeErr:     errors.New("access denied"),
+			expected:         defaultVisibilityTimeoutSeconds,
+			expectQueueReads: 1,
+		},
+		{
+			name:             "falls back when the queue reports zero",
+			conf:             sqsiConfig{UpdateVisibility: true},
+			queueTimeout:     0,
+			expected:         defaultVisibilityTimeoutSeconds,
+			expectQueueReads: 1,
+		},
+		{
+			name:         "prefers the configured timeout over the queue's",
+			conf:         sqsiConfig{UpdateVisibility: true, VisibilityTimeout: 5 * time.Minute},
 			queueTimeout: 600,
-			expected:     600,
+			expected:     300,
 		},
 		{
-			name:         "falls back when the queue cannot be read",
-			attributeErr: errors.New("access denied"),
-			expected:     defaultVisibilityTimeoutSeconds,
-		},
-		{
-			name:         "falls back when the queue reports zero",
-			queueTimeout: 0,
-			expected:     defaultVisibilityTimeoutSeconds,
+			name:         "leaves the queue alone when nothing refreshes",
+			conf:         sqsiConfig{UpdateVisibility: false},
+			queueTimeout: 600,
+			expected:     0,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			r, err := newAWSSQSReader(sqsiConfig{URL: "http://foo.example.com"}, aws.Config{}, nil)
+			test.conf.URL = "http://foo.example.com"
+			r, err := newAWSSQSReader(test.conf, aws.Config{}, nil)
 			require.NoError(t, err)
-			r.sqs = &mockSqsInput{
+			mockInput := &mockSqsInput{
 				queueTimeout:          test.queueTimeout,
 				getQueueAttributesErr: test.attributeErr,
 			}
+			r.sqs = mockInput
 
-			timeout := r.queueVisibilityTimeout(t.Context())
+			timeout := r.visibilityTimeoutSeconds(t.Context())
 			assert.Equal(t, test.expected, timeout)
+			assert.Equal(t, test.expectQueueReads, mockInput.getQueueAttributesCalls)
 
-			// The timeout read at connect time is what in-flight handles get
+			// The timeout resolved at connect time is what in-flight handles get
 			// refreshed with.
 			tracker := &sqsInFlightTracker{
 				handles:                  map[string]sqsInFlightHandle{},
@@ -339,4 +367,37 @@ func TestSQSInputVisibilityTimeoutFollowsQueue(t *testing.T) {
 			assert.Equal(t, test.expected, tracker.handles["message-1"].timeoutSeconds)
 		})
 	}
+}
+
+func TestSQSInputReceiveWithConfiguredVisibilityTimeout(t *testing.T) {
+	r, err := newAWSSQSReader(sqsiConfig{
+		URL:                 "http://foo.example.com",
+		MaxNumberOfMessages: 10,
+		VisibilityTimeout:   5 * time.Minute,
+	}, aws.Config{}, nil)
+	require.NoError(t, err)
+
+	mockInput := &mockSqsInput{
+		mtx:          make(chan struct{}, 1),
+		queueTimeout: 30,
+		messages: []types.Message{{
+			Body:          aws.String("message-1"),
+			MessageId:     aws.String("message-1"),
+			ReceiptHandle: aws.String("message-1"),
+		}},
+		mesTimeouts: map[string]int32{},
+	}
+	mockInput.mtx <- struct{}{}
+	r.sqs = mockInput
+
+	defer r.closeSignal.TriggerHardStop()
+	require.NoError(t, r.Connect(t.Context()))
+
+	_, _, err = r.Read(t.Context())
+	require.NoError(t, err)
+
+	// Refreshing is off here, so the request itself has to carry the timeout.
+	mockInput.do(func() {
+		assert.Equal(t, int32(300), mockInput.receivedTimeout)
+	})
 }

--- a/internal/impl/aws/input_sqs_test.go
+++ b/internal/impl/aws/input_sqs_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -25,6 +26,8 @@ type mockSqsInput struct {
 	queueTimeout int32
 	messages     []types.Message
 	mesTimeouts  map[string]int32
+
+	getQueueAttributesErr error
 }
 
 func (m *mockSqsInput) do(fn func()) {
@@ -70,7 +73,10 @@ func (m *mockSqsInput) ReceiveMessage(context.Context, *sqs.ReceiveMessageInput,
 	return &sqs.ReceiveMessageOutput{Messages: messages}, nil
 }
 
-func (m *mockSqsInput) GetQueueAttributes(input *sqs.GetQueueAttributesInput) (*sqs.GetQueueAttributesOutput, error) {
+func (m *mockSqsInput) GetQueueAttributes(context.Context, *sqs.GetQueueAttributesInput, ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error) {
+	if m.getQueueAttributesErr != nil {
+		return nil, m.getQueueAttributesErr
+	}
 	return &sqs.GetQueueAttributesOutput{Attributes: map[string]string{sqsiAttributeNameVisibilityTimeout: strconv.Itoa(int(m.queueTimeout))}}, nil
 }
 
@@ -282,4 +288,55 @@ func TestSQSInputBatchAck(t *testing.T) {
 		})
 		return msgsLen == 0
 	}, 5*time.Second, time.Second)
+}
+
+func TestSQSInputVisibilityTimeoutFollowsQueue(t *testing.T) {
+	tests := []struct {
+		name         string
+		queueTimeout int32
+		attributeErr error
+		expected     int
+	}{
+		{
+			name:         "takes the timeout the queue is configured with",
+			queueTimeout: 600,
+			expected:     600,
+		},
+		{
+			name:         "falls back when the queue cannot be read",
+			attributeErr: errors.New("access denied"),
+			expected:     defaultVisibilityTimeoutSeconds,
+		},
+		{
+			name:         "falls back when the queue reports zero",
+			queueTimeout: 0,
+			expected:     defaultVisibilityTimeoutSeconds,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, err := newAWSSQSReader(sqsiConfig{URL: "http://foo.example.com"}, aws.Config{}, nil)
+			require.NoError(t, err)
+			r.sqs = &mockSqsInput{
+				queueTimeout:          test.queueTimeout,
+				getQueueAttributesErr: test.attributeErr,
+			}
+
+			timeout := r.queueVisibilityTimeout(t.Context())
+			assert.Equal(t, test.expected, timeout)
+
+			// The timeout read at connect time is what in-flight handles get
+			// refreshed with.
+			tracker := &sqsInFlightTracker{
+				handles:                  map[string]sqsInFlightHandle{},
+				visibilityTimeoutSeconds: timeout,
+			}
+			tracker.AddNew(types.Message{
+				MessageId:     aws.String("message-1"),
+				ReceiptHandle: aws.String("message-1"),
+			})
+			assert.Equal(t, test.expected, tracker.handles["message-1"].timeoutSeconds)
+		})
+	}
 }

--- a/website/docs/components/inputs/aws_sqs.md
+++ b/website/docs/components/inputs/aws_sqs.md
@@ -45,6 +45,7 @@ input:
     delete_message: true
     reset_visibility: true
     update_visibility: true
+    visibility_timeout: 0s
     max_number_of_messages: 10
     wait_time_seconds: 0
     custom_request_headers: {}
@@ -118,6 +119,15 @@ Whether to periodically refresh the visibility timeout of in-flight messages to 
 Type: `bool`  
 Default: `true`  
 Requires version 1.6.0 or newer  
+
+### `visibility_timeout`
+
+The visibility timeout to request for consumed messages, and the value in-flight messages are refreshed with. Zero uses whatever the queue itself is configured with. SQS counts this in whole seconds, so anything finer is rounded down.
+
+
+Type: `string`  
+Default: `"0s"`  
+Requires version 1.21.0 or newer  
 
 ### `max_number_of_messages`
 

--- a/website/docs/components/inputs/aws_sqs.md
+++ b/website/docs/components/inputs/aws_sqs.md
@@ -45,7 +45,7 @@ input:
     delete_message: true
     reset_visibility: true
     update_visibility: true
-    visibility_timeout: 0s
+    visibility_timeout: 30s
     max_number_of_messages: 10
     wait_time_seconds: 0
     custom_request_headers: {}
@@ -122,11 +122,11 @@ Requires version 1.6.0 or newer
 
 ### `visibility_timeout`
 
-The visibility timeout to request for consumed messages, and the value in-flight messages are refreshed with. Zero uses whatever the queue itself is configured with. SQS counts this in whole seconds, so anything finer is rounded down.
+Visibility timeout (truncated to whole seconds) requested when retrieving messages, and used when refreshing in-flight messages. A value of `0` defers to the SQS queue's configured timeout, as does disabling `update_visibility`.
 
 
 Type: `string`  
-Default: `"0s"`  
+Default: `"30s"`  
 Requires version 1.21.0 or newer  
 
 ### `max_number_of_messages`


### PR DESCRIPTION
Fixes #878.

`AddNew` stamped every in-flight handle with 30s. The lookup below it read `m.Attributes[VisibilityTimeout]`, which `ReceiveMessage` never returns, so it never ran and a queue configured with a longer timeout had its value ignored.

`Connect` now reads `VisibilityTimeout` once through `GetQueueAttributes` and stamps handles with that, falling back to 30s when the call fails. This adds `GetQueueAttributes` to the `sqsAPI` interface and a passthrough on `customHeaderSQSClient` so the call still carries `custom_request_headers`, and drops the dead lookup.

`mockSqsInput.GetQueueAttributes` already returned `queueTimeout`, but its pre-SDK-v2 signature never satisfied the interface. Correcting it means the existing tests now cover the queue value.

`go vet ./...`, `golangci-lint run -c .golangci.yml ./internal/impl/aws/...`, `go build ./...`, `internal/impl/aws`, `bento template lint` and `bento test ./config/test/...` all pass. Putting the hardcoded 30 back turns the new test red with `expected: 600, actual: 30`.
