### PR TITLE
feat(parquet): add DATE and TIMESTAMP_MILLIS logical type support

### DIFF
--- a/internal/impl/parquet/processor_encode.go
+++ b/internal/impl/parquet/processor_encode.go
@@ -131,7 +131,7 @@ func init() {
 func parquetSchemaConfig() *service.ConfigField {
 	return service.NewObjectListField("schema",
 		service.NewStringField("name").Description("The name of the column."),
-		service.NewStringEnumField("type", "BOOLEAN", "INT8", "INT16", "INT32", "INT64", "DECIMAL64", "DECIMAL32", "FLOAT", "DOUBLE", "BYTE_ARRAY", "UTF8", "MAP", "LIST", "STRUCT").
+		service.NewStringEnumField("type", "BOOLEAN", "INT8", "INT16", "INT32", "INT64", "DECIMAL64", "DECIMAL32", "FLOAT", "DOUBLE", "BYTE_ARRAY", "UTF8", "DATE", "TIMESTAMP_MILLIS", "MAP", "LIST", "STRUCT").
 			Description("The type of the column, only applicable for leaf columns with no child fields. STRUCT represents nested objects with defined field schemas. MAP supports only string keys, but can support values of all types. Some logical types can be specified here such as UTF8.").Optional(),
 		service.NewIntField("decimal_precision").Description("Precision to use for DECIMAL32/DECIMAL64 type").Default(0),
 		service.NewIntField("decimal_scale").Description("Scale to use for DECIMAL32/DECIMAL64 type").Default(0),

--- a/internal/impl/parquet/schema.go
+++ b/internal/impl/parquet/schema.go
@@ -304,12 +304,33 @@ func wrapType(
 				return nil, fmt.Errorf("getting optional flag: %w", err)
 			}
 			if optional {
+				// parquet-go's "date"/"timestamp" struct tags only accept a pointer for
+				// *time.Time, not *int32/*int64 (see parquet-go schema.go, case "date"/
+				// "timestamp": a Ptr whose Elem isn't time.Time panics via throwInvalidTag).
+				// Our DATE/TIMESTAMP_MILLIS tokens keep the underlying value as a plain
+				// int32/int64, so optionality has to be carried by the "optional" tag
+				// component alone (already appended above) rather than by wrapping in a
+				// pointer here.
+				if isDateOrTimestampType(field) {
+					return baseType, nil
+				}
 				return reflect.PointerTo(baseType), nil
 			}
 		}
 	}
 
 	return baseType, nil
+}
+
+func isDateOrTimestampType(field *service.ParsedConfig) bool {
+	if !field.Contains("type") {
+		return false
+	}
+	typeStr, err := field.FieldString("type")
+	if err != nil {
+		return false
+	}
+	return typeStr == "DATE" || typeStr == "TIMESTAMP_MILLIS"
 }
 
 func isDeltaLengthByteArrayEncodable(typeStr string) bool {

--- a/internal/impl/parquet/schema.go
+++ b/internal/impl/parquet/schema.go
@@ -84,6 +84,14 @@ func generateStructTypeFromFields(
 
 				components = append(components, fmt.Sprintf("decimal(%d:%d)", scale, precision))
 			}
+
+			if typeStr == "DATE" {
+				components = append(components, "date")
+			}
+
+			if typeStr == "TIMESTAMP_MILLIS" {
+				components = append(components, "timestamp")
+			}
 		}
 
 		if schemaOpts.optionalsAsStructTags {
@@ -264,6 +272,10 @@ func getReflectType(typeStr string) (reflect.Type, error) {
 	case "DECIMAL32":
 		return reflect.TypeFor[int32](), nil
 	case "DECIMAL64":
+		return reflect.TypeFor[int64](), nil
+	case "DATE":
+		return reflect.TypeFor[int32](), nil
+	case "TIMESTAMP_MILLIS":
 		return reflect.TypeFor[int64](), nil
 	default:
 		return nil, fmt.Errorf("unsupported type: %s", typeStr)

--- a/internal/impl/parquet/schema_test.go
+++ b/internal/impl/parquet/schema_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -381,4 +382,30 @@ schema:
 			}
 		})
 	}
+}
+
+// TestOptionalDateTimestampDoesNotPanic guards against a regression where an optional
+// DATE or TIMESTAMP_MILLIS field, with optionalAsPtrs enabled, produced a *int32/*int64
+// struct field. parquet-go's "date"/"timestamp" struct tags only accept a pointer when
+// the pointee is time.Time, so this panicked via throwInvalidTag. wrapType must keep the
+// base type unwrapped (plain int32/int64) for these two tokens regardless of
+// optionalAsPtrs.
+func TestOptionalDateTimestampDoesNotPanic(t *testing.T) {
+	config, err := parquetEncodeProcessorConfig().ParseYAML(`
+schema:
+  - { name: processed_time, type: TIMESTAMP_MILLIS, optional: true }
+  - { name: an_optional_date, type: DATE, optional: true }
+`, nil)
+	require.NoError(t, err)
+
+	got, err := GenerateStructType(config, schemaOpts{optionalAsPtrs: true})
+	require.NoError(t, err)
+
+	ts := got.Field(0)
+	assert.Equal(t, reflect.TypeFor[int64](), ts.Type, "TIMESTAMP_MILLIS must stay a plain int64, not *int64")
+	assert.Equal(t, `parquet:"processed_time,timestamp" json:"processed_time"`, string(ts.Tag))
+
+	dt := got.Field(1)
+	assert.Equal(t, reflect.TypeFor[int32](), dt.Type, "DATE must stay a plain int32, not *int32")
+	assert.Equal(t, `parquet:"an_optional_date,date" json:"an_optional_date"`, string(dt.Tag))
 }

--- a/internal/impl/parquet/schema_test.go
+++ b/internal/impl/parquet/schema_test.go
@@ -36,20 +36,24 @@ schema:
   - { name: flt, type: FLOAT }
   - { name: bool, type: BOOLEAN }
   - { name: dec32, type: DECIMAL32, decimal_precision: 3}
-  - { name: dec64, type: DECIMAL64, decimal_scale: 4, decimal_precision: 10}  
+  - { name: dec64, type: DECIMAL64, decimal_scale: 4, decimal_precision: 10}
+  - { name: aDate, type: DATE }
+  - { name: aTimestamp, type: TIMESTAMP_MILLIS }
 `,
 			wantFields: map[string]struct {
 				fieldType reflect.Type
 				tag       string
 			}{
-				"Str":      {reflect.TypeFor[string](), `parquet:"str" json:"str"`},
-				"Num":      {reflect.TypeFor[int64](), `parquet:"num" json:"num"`},
-				"SmallNum": {reflect.TypeFor[int16](), `parquet:"smallNum" json:"smallNum"`},
-				"TinyNum":  {reflect.TypeFor[int8](), `parquet:"tinyNum" json:"tinyNum"`},
-				"Flt":      {reflect.TypeFor[float32](), `parquet:"flt" json:"flt"`},
-				"Bool":     {reflect.TypeFor[bool](), `parquet:"bool" json:"bool"`},
-				"Dec32":    {reflect.TypeFor[int32](), `parquet:"dec32,decimal(0:3)" json:"dec32"`},
-				"Dec64":    {reflect.TypeFor[int64](), `parquet:"dec64,decimal(4:10)" json:"dec64"`},
+				"Str":        {reflect.TypeFor[string](), `parquet:"str" json:"str"`},
+				"Num":        {reflect.TypeFor[int64](), `parquet:"num" json:"num"`},
+				"SmallNum":   {reflect.TypeFor[int16](), `parquet:"smallNum" json:"smallNum"`},
+				"TinyNum":    {reflect.TypeFor[int8](), `parquet:"tinyNum" json:"tinyNum"`},
+				"Flt":        {reflect.TypeFor[float32](), `parquet:"flt" json:"flt"`},
+				"Bool":       {reflect.TypeFor[bool](), `parquet:"bool" json:"bool"`},
+				"Dec32":      {reflect.TypeFor[int32](), `parquet:"dec32,decimal(0:3)" json:"dec32"`},
+				"Dec64":      {reflect.TypeFor[int64](), `parquet:"dec64,decimal(4:10)" json:"dec64"`},
+				"ADate":      {reflect.TypeFor[int32](), `parquet:"aDate,date" json:"aDate"`},
+				"ATimestamp": {reflect.TypeFor[int64](), `parquet:"aTimestamp,timestamp" json:"aTimestamp"`},
 			},
 		},
 		{

--- a/website/docs/components/processors/parquet_encode.md
+++ b/website/docs/components/processors/parquet_encode.md
@@ -173,7 +173,7 @@ The type of the column, only applicable for leaf columns with no child fields. S
 
 
 Type: `string`  
-Options: `BOOLEAN`, `INT8`, `INT16`, `INT32`, `INT64`, `DECIMAL64`, `DECIMAL32`, `FLOAT`, `DOUBLE`, `BYTE_ARRAY`, `UTF8`, `MAP`, `LIST`, `STRUCT`.
+Options: `BOOLEAN`, `INT8`, `INT16`, `INT32`, `INT64`, `DECIMAL64`, `DECIMAL32`, `FLOAT`, `DOUBLE`, `BYTE_ARRAY`, `UTF8`, `DATE`, `TIMESTAMP_MILLIS`, `MAP`, `LIST`, `STRUCT`.
 
 ### `schema[].decimal_precision`
 


### PR DESCRIPTION
## Summary
- Adds `DATE` and `TIMESTAMP_MILLIS` as selectable column types in the `parquet_encode` processor's schema config, mapping to parquet-go's `date`/`timestamp` logical type struct tags.
- Fixes a panic when a `DATE`/`TIMESTAMP_MILLIS` field is marked `optional` with `optionalAsPtrs` enabled: parquet-go's `date`/`timestamp` struct tags only accept a pointer when the pointee is `time.Time`, so pointer-wrapping a plain `int32`/`int64` for these types triggered `throwInvalidTag`. Optionality for these two types is now carried by the `optional` tag component alone rather than by wrapping the Go type in a pointer.

## Test plan
- [x] `go test ./internal/impl/parquet/...` passes
- [x] Added `TestOptionalDateTimestampDoesNotPanic` reproducing the pointer-wrap panic
- [x] Extended existing schema-generation table test with `DATE`/`TIMESTAMP_MILLIS` cases
