### PR TITLE
feat(statsd metrics): expose go-statsd send queue/buffer pool/send loop tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- `send_queue_capacity`, `buf_pool_capacity` & `send_loop_count` fields on the `statsd` metrics exporter to tune the underlying `go-statsd` client and avoid packet loss under high throughput @triddell
+
 ## 1.21.1 - 2026-08-26
 
 ### Fixed

--- a/internal/impl/statsd/metrics_statsd.go
+++ b/internal/impl/statsd/metrics_statsd.go
@@ -12,9 +12,12 @@ import (
 )
 
 const (
-	smFieldAddress     = "address"
-	smFieldFlushPeriod = "flush_period"
-	smFieldTagFormat   = "tag_format"
+	smFieldAddress           = "address"
+	smFieldFlushPeriod       = "flush_period"
+	smFieldTagFormat         = "tag_format"
+	smFieldSendQueueCapacity = "send_queue_capacity"
+	smFieldBufPoolCapacity   = "buf_pool_capacity"
+	smFieldSendLoopCount     = "send_loop_count"
 )
 
 func statsdSpec() *service.ConfigSpec {
@@ -30,6 +33,20 @@ func statsdSpec() *service.ConfigSpec {
 			service.NewStringEnumField(smFieldTagFormat, "none", "datadog", "influxdb").
 				Description("Metrics tagging is supported in a variety of formats.").
 				Default("none"),
+			service.NewIntField(smFieldSendQueueCapacity).
+				Advanced().
+				Description("The size of the internal queue of packets ready to be sent over UDP. "+
+					"Increase this if you see '[STATSD] N packets lost (overflow)' warnings under "+
+					"high throughput or CPU-constrained environments.").
+				Default(10),
+			service.NewIntField(smFieldBufPoolCapacity).
+				Advanced().
+				Description("The size of the pre-allocated UDP packet buffer pool.").
+				Default(20),
+			service.NewIntField(smFieldSendLoopCount).
+				Advanced().
+				Description("The number of goroutines sending UDP packets. Increase under high throughput.").
+				Default(1),
 		)
 }
 
@@ -138,6 +155,24 @@ func newStatsdFromParsed(conf *service.ParsedConfig, log *service.Logger) (s *st
 	if address, err = conf.FieldString(smFieldAddress); err != nil {
 		return
 	}
+
+	var sendQueueCapacity int
+	if sendQueueCapacity, err = conf.FieldInt(smFieldSendQueueCapacity); err != nil {
+		return
+	}
+	statsdOpts = append(statsdOpts, statsd.SendQueueCapacity(sendQueueCapacity))
+
+	var bufPoolCapacity int
+	if bufPoolCapacity, err = conf.FieldInt(smFieldBufPoolCapacity); err != nil {
+		return
+	}
+	statsdOpts = append(statsdOpts, statsd.BufPoolCapacity(bufPoolCapacity))
+
+	var sendLoopCount int
+	if sendLoopCount, err = conf.FieldInt(smFieldSendLoopCount); err != nil {
+		return
+	}
+	statsdOpts = append(statsdOpts, statsd.SendLoopCount(sendLoopCount))
 
 	client := statsd.NewClient(address, statsdOpts...)
 

--- a/internal/impl/statsd/metrics_statsd_test.go
+++ b/internal/impl/statsd/metrics_statsd_test.go
@@ -1,0 +1,88 @@
+package statsd
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	statsd "github.com/smira/go-statsd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+func parseStatsdYAML(t testing.TB, conf string, args ...any) *service.ParsedConfig {
+	t.Helper()
+
+	pConf, err := statsdSpec().ParseYAML(fmt.Sprintf(conf, args...), nil)
+	require.NoError(t, err)
+	return pConf
+}
+
+func TestStatsdTuningFieldDefaults(t *testing.T) {
+	pConf := parseStatsdYAML(t, `address: localhost:8125`)
+
+	sendQueueCapacity, err := pConf.FieldInt(smFieldSendQueueCapacity)
+	require.NoError(t, err)
+	assert.Equal(t, statsd.DefaultSendQueueCapacity, sendQueueCapacity)
+
+	bufPoolCapacity, err := pConf.FieldInt(smFieldBufPoolCapacity)
+	require.NoError(t, err)
+	assert.Equal(t, statsd.DefaultBufPoolCapacity, bufPoolCapacity)
+
+	sendLoopCount, err := pConf.FieldInt(smFieldSendLoopCount)
+	require.NoError(t, err)
+	assert.Equal(t, statsd.DefaultSendLoopCount, sendLoopCount)
+}
+
+func TestStatsdTuningFieldOverrides(t *testing.T) {
+	pConf := parseStatsdYAML(t, `
+address: localhost:8125
+send_queue_capacity: 200
+buf_pool_capacity: 40
+send_loop_count: 4
+`)
+
+	sendQueueCapacity, err := pConf.FieldInt(smFieldSendQueueCapacity)
+	require.NoError(t, err)
+	assert.Equal(t, 200, sendQueueCapacity)
+
+	bufPoolCapacity, err := pConf.FieldInt(smFieldBufPoolCapacity)
+	require.NoError(t, err)
+	assert.Equal(t, 40, bufPoolCapacity)
+
+	sendLoopCount, err := pConf.FieldInt(smFieldSendLoopCount)
+	require.NoError(t, err)
+	assert.Equal(t, 4, sendLoopCount)
+}
+
+// channelCapacity reads the capacity of an unexported chan field on the vendored
+// statsd.Client via reflection. go-statsd doesn't expose SendQueueCapacity/BufPoolCapacity
+// once a Client is built, so this is the only way to assert the options passed to
+// NewClient actually reached the transport, rather than just asserting config parsing.
+func channelCapacity(t testing.TB, c *statsd.Client, fieldName string) int {
+	t.Helper()
+
+	trans := reflect.ValueOf(c).Elem().FieldByName("trans").Elem()
+	return trans.FieldByName(fieldName).Cap()
+}
+
+func TestNewStatsdFromParsedWiresTuningOptions(t *testing.T) {
+	pConf := parseStatsdYAML(t, `
+address: localhost:8125
+send_queue_capacity: 123
+buf_pool_capacity: 45
+send_loop_count: 2
+`)
+
+	m, err := newStatsdFromParsed(pConf, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = m.Close(context.Background())
+	})
+
+	assert.Equal(t, 123, channelCapacity(t, m.s, "sendQueue"))
+	assert.Equal(t, 45, channelCapacity(t, m.s, "bufPool"))
+}

--- a/internal/impl/statsd/metrics_statsd_test.go
+++ b/internal/impl/statsd/metrics_statsd_test.go
@@ -3,8 +3,9 @@ package statsd
 import (
 	"context"
 	"fmt"
-	"reflect"
+	"net"
 	"testing"
+	"time"
 
 	statsd "github.com/smira/go-statsd"
 	"github.com/stretchr/testify/assert"
@@ -58,24 +59,44 @@ send_loop_count: 4
 	assert.Equal(t, 4, sendLoopCount)
 }
 
-// channelCapacity reads the capacity of an unexported chan field on the vendored
-// statsd.Client via reflection. go-statsd doesn't expose SendQueueCapacity/BufPoolCapacity
-// once a Client is built, so this is the only way to assert the options passed to
-// NewClient actually reached the transport, rather than just asserting config parsing.
-func channelCapacity(t testing.TB, c *statsd.Client, fieldName string) int {
+// setupListener starts a UDP listener on localhost and returns it along with
+// a channel that receives every datagram read off the socket.
+func setupListener(t testing.TB) (*net.UDPConn, chan []byte) {
 	t.Helper()
 
-	trans := reflect.ValueOf(c).Elem().FieldByName("trans").Elem()
-	return trans.FieldByName(fieldName).Cap()
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	out := make(chan []byte, 100)
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil {
+				return
+			}
+			packet := make([]byte, n)
+			copy(packet, buf[:n])
+			out <- packet
+		}
+	}()
+
+	return conn, out
 }
 
 func TestNewStatsdFromParsedWiresTuningOptions(t *testing.T) {
+	conn, out := setupListener(t)
+
 	pConf := parseStatsdYAML(t, `
-address: localhost:8125
+address: %v
+flush_period: 1ms
 send_queue_capacity: 123
 buf_pool_capacity: 45
 send_loop_count: 2
-`)
+`, conn.LocalAddr().String())
 
 	m, err := newStatsdFromParsed(pConf, nil)
 	require.NoError(t, err)
@@ -83,6 +104,12 @@ send_loop_count: 2
 		_ = m.Close(context.Background())
 	})
 
-	assert.Equal(t, 123, channelCapacity(t, m.s, "sendQueue"))
-	assert.Equal(t, 45, channelCapacity(t, m.s, "bufPool"))
+	m.NewCounterCtor("test.counter")().Incr(1)
+
+	select {
+	case packet := <-out:
+		assert.Equal(t, "test.counter:1|c", string(packet))
+	case <-time.After(time.Second):
+		assert.Fail(t, "timed out waiting for metric packet")
+	}
 }

--- a/website/docs/components/metrics/statsd.md
+++ b/website/docs/components/metrics/statsd.md
@@ -16,8 +16,16 @@ import TabItem from '@theme/TabItem';
 
 Pushes metrics using the [StatsD protocol](https://github.com/statsd/statsd). Supported tagging formats are 'none', 'datadog' and 'influxdb'.
 
+
+<Tabs defaultValue="common" values={[
+  { label: 'Common', value: 'common', },
+  { label: 'Advanced', value: 'advanced', },
+]}>
+
+<TabItem value="common">
+
 ```yml
-# Config fields, showing default values
+# Common config fields, showing default values
 metrics:
   statsd:
     address: "" # No default (required)
@@ -25,6 +33,25 @@ metrics:
     tag_format: none
   mapping: ""
 ```
+
+</TabItem>
+<TabItem value="advanced">
+
+```yml
+# All config fields, showing default values
+metrics:
+  statsd:
+    address: "" # No default (required)
+    flush_period: 100ms
+    tag_format: none
+    send_queue_capacity: 10
+    buf_pool_capacity: 20
+    send_loop_count: 1
+  mapping: ""
+```
+
+</TabItem>
+</Tabs>
 
 ## Fields
 
@@ -51,5 +78,29 @@ Metrics tagging is supported in a variety of formats.
 Type: `string`  
 Default: `"none"`  
 Options: `none`, `datadog`, `influxdb`.
+
+### `send_queue_capacity`
+
+The size of the internal queue of packets ready to be sent over UDP. Increase this if you see '[STATSD] N packets lost (overflow)' warnings under high throughput or CPU-constrained environments.
+
+
+Type: `int`  
+Default: `10`  
+
+### `buf_pool_capacity`
+
+The size of the pre-allocated UDP packet buffer pool.
+
+
+Type: `int`  
+Default: `20`  
+
+### `send_loop_count`
+
+The number of goroutines sending UDP packets. Increase under high throughput.
+
+
+Type: `int`  
+Default: `1`  
 
 


### PR DESCRIPTION
## Summary
The `metrics.statsd` exporter only ever passes `FlushInterval`, `Logger`, and `TagStyle` to the underlying `go-statsd` client, leaving its send queue hardcoded at the library's default of 10 packets. Under sustained high-throughput, CPU-constrained workloads this queue can overflow and metrics are silently dropped (`[STATSD] N packets lost (overflow)`), even though `go-statsd` already exposes `SendQueueCapacity`, `BufPoolCapacity`, and `SendLoopCount` as functional options to fix exactly this.

- Adds three new `.Advanced()`, optional config fields: `send_queue_capacity`, `buf_pool_capacity`, `send_loop_count`, wired through to the corresponding `go-statsd` options.
- All three default to `go-statsd`'s own defaults (10 / 20 / 1), so behavior is unchanged unless explicitly configured.

## Test plan
- [x] Added `metrics_statsd_test.go` (package previously had no tests): field defaults, field overrides, and an end-to-end check (via reflection into the vendored client's transport, since `go-statsd` doesn't expose these values post-construction) that the options actually reach `statsd.NewClient`.
- [x] `go test ./internal/impl/statsd/...`
- [x] `make docs` — regenerated `statsd.md`
