### PR TITLE
fix kafka franz output: broker_write_max_bytes misconfigured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 1.21.1 - 2026-08-21
+
+### Fixed
+
+- `kafka_franz` output field `broker_write_max_bytes` misconfigured (introduced in version 1.21.0) @jem-davies
+
 ## 1.21.0 - 2026-08-21
 
 ### Added

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -269,7 +269,7 @@ func newFranzKafkaWriterFromConfig(conf *service.ParsedConfig, log *service.Logg
 	if brokerWriteMaxBytes > uint64(math.MaxInt32) {
 		return nil, fmt.Errorf("invalid broker_write_max_bytes, must not exceed %v", math.MaxInt32)
 	}
-	f.brokerWriteMaxBytes = int32(maxBufferedBytes)
+	f.brokerWriteMaxBytes = int32(brokerWriteMaxBytes)
 
 	if conf.Contains("compression") {
 		cStr, err := conf.FieldString("compression")


### PR DESCRIPTION
fixes #992 