### PR TITLE
feat(gcp): add service account impersonation to GCP components

### DIFF
--- a/internal/impl/gcp/cache_cloud_storage.go
+++ b/internal/impl/gcp/cache_cloud_storage.go
@@ -21,7 +21,8 @@ func gcpCloudStorageCacheConfig() *service.ConfigSpec {
 		Field(service.NewStringField("bucket").
 			Description("The Google Cloud Storage bucket to store items in.")).
 		Field(service.NewStringField("content_type").
-			Description("Optional field to explicitly set the Content-Type.").Optional())
+			Description("Optional field to explicitly set the Content-Type.").Optional()).
+		Field(gcpCredentialsField())
 
 	return spec
 }
@@ -51,7 +52,12 @@ func newGcpCloudStorageCacheFromConfig(parsedConf *service.ParsedConfig) (*gcpCl
 		}
 	}
 
-	client, err := storage.NewClient(context.Background())
+	opts, err := gcpClientOptionsFromParsed(parsedConf)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := storage.NewClient(context.Background(), opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/gcp/credentials.go
+++ b/internal/impl/gcp/credentials.go
@@ -1,0 +1,74 @@
+package gcp
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/api/impersonate"
+	"google.golang.org/api/option"
+
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+const (
+	gcpFieldCredentials               = "credentials"
+	gcpFieldImpersonateServiceAccount = "impersonate_service_account"
+	gcpFieldImpersonateDelegates      = "impersonate_delegates"
+
+	// gcpImpersonationScope grants the impersonated token access to all GCP
+	// APIs, mirroring the scope granted to Application Default Credentials.
+	gcpImpersonationScope = "https://www.googleapis.com/auth/cloud-platform"
+)
+
+// gcpCredentialsField defines a re-usable set of config fields for
+// customising the credentials used by GCP components. By default components
+// rely on Application Default Credentials.
+func gcpCredentialsField() *service.ConfigField {
+	return service.NewObjectField(gcpFieldCredentials,
+		service.NewStringField(gcpFieldImpersonateServiceAccount).
+			Description("The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `"+gcpFieldImpersonateDelegates+"` is set.").
+			Example("target@my-project.iam.gserviceaccount.com").
+			Default(""),
+		service.NewStringListField(gcpFieldImpersonateDelegates).
+			Description("An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `"+gcpFieldImpersonateServiceAccount+"`.").
+			Default([]any{}),
+	).
+		Description("Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).").
+		Advanced().
+		Version("1.22.0").
+		LintRule(`root = if this.impersonate_delegates.length() > 0 && this.impersonate_service_account == "" { "impersonate_delegates requires impersonate_service_account to be set" }`)
+}
+
+// gcpClientOptionsFromParsed returns client options that apply the credentials
+// configuration to a GCP client. When no credentials are configured the
+// returned options are empty and clients fall back to Application Default
+// Credentials.
+func gcpClientOptionsFromParsed(pConf *service.ParsedConfig) ([]option.ClientOption, error) {
+	if !pConf.Contains(gcpFieldCredentials) {
+		return nil, nil
+	}
+	cConf := pConf.Namespace(gcpFieldCredentials)
+
+	target, err := cConf.FieldString(gcpFieldImpersonateServiceAccount)
+	if err != nil {
+		return nil, err
+	}
+	if target == "" {
+		return nil, nil
+	}
+
+	delegates, err := cConf.FieldStringList(gcpFieldImpersonateDelegates)
+	if err != nil {
+		return nil, err
+	}
+
+	ts, err := impersonate.CredentialsTokenSource(context.Background(), impersonate.CredentialsConfig{
+		TargetPrincipal: target,
+		Delegates:       delegates,
+		Scopes:          []string{gcpImpersonationScope},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create impersonated credentials for %v: %w", target, err)
+	}
+	return []option.ClientOption{option.WithTokenSource(ts)}, nil
+}

--- a/internal/impl/gcp/credentials_test.go
+++ b/internal/impl/gcp/credentials_test.go
@@ -1,0 +1,99 @@
+package gcp
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+func testCredentialsSpec() *service.ConfigSpec {
+	return service.NewConfigSpec().Field(gcpCredentialsField())
+}
+
+// setFakeADC points GOOGLE_APPLICATION_CREDENTIALS at a syntactically valid
+// service account key so that base credentials can be resolved offline.
+func setFakeADC(t *testing.T) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pemKey := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	saJSON, err := json.Marshal(map[string]string{
+		"type":           "service_account",
+		"project_id":     "test-project",
+		"private_key_id": "abc123",
+		"private_key":    string(pemKey),
+		"client_email":   "base@test-project.iam.gserviceaccount.com",
+		"client_id":      "123456789",
+		"token_uri":      "https://oauth2.googleapis.com/token",
+	})
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "sa.json")
+	require.NoError(t, os.WriteFile(path, saJSON, 0o600))
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
+}
+
+func TestGCPCredentialsDefaultNoOptions(t *testing.T) {
+	pConf, err := testCredentialsSpec().ParseYAML(`{}`, nil)
+	require.NoError(t, err)
+
+	opts, err := gcpClientOptionsFromParsed(pConf)
+	require.NoError(t, err)
+	require.Empty(t, opts)
+}
+
+func TestGCPCredentialsImpersonation(t *testing.T) {
+	setFakeADC(t)
+
+	pConf, err := testCredentialsSpec().ParseYAML(`
+credentials:
+  impersonate_service_account: target@test-project.iam.gserviceaccount.com
+  impersonate_delegates:
+    - hop@test-project.iam.gserviceaccount.com
+`, nil)
+	require.NoError(t, err)
+
+	opts, err := gcpClientOptionsFromParsed(pConf)
+	require.NoError(t, err)
+	require.Len(t, opts, 1)
+}
+
+func TestGCPCredentialsTargetOnlyLintHappy(t *testing.T) {
+	err := service.NewStreamBuilder().SetYAML(`
+input:
+  gcp_pubsub:
+    project: foo
+    subscription: bar
+    credentials:
+      impersonate_service_account: target@test-project.iam.gserviceaccount.com
+output:
+  drop: {}
+`)
+	require.NoError(t, err)
+}
+
+func TestGCPCredentialsDelegatesWithoutTargetLint(t *testing.T) {
+	err := service.NewStreamBuilder().SetYAML(`
+input:
+  gcp_pubsub:
+    project: foo
+    subscription: bar
+    credentials:
+      impersonate_delegates:
+        - hop@test-project.iam.gserviceaccount.com
+output:
+  drop: {}
+`)
+	require.ErrorContains(t, err, "impersonate_delegates requires impersonate_service_account")
+}

--- a/internal/impl/gcp/input_bigquery_select.go
+++ b/internal/impl/gcp/input_bigquery_select.go
@@ -22,6 +22,7 @@ type bigQuerySelectInputConfig struct {
 	argsMapping   *bloblang.Executor
 	queryPriority bigquery.QueryPriority
 	jobLabels     map[string]string
+	clientOptions []option.ClientOption
 }
 
 func bigQuerySelectInputConfigFromParsed(inConf *service.ParsedConfig) (conf bigQuerySelectInputConfig, err error) {
@@ -29,6 +30,10 @@ func bigQuerySelectInputConfigFromParsed(inConf *service.ParsedConfig) (conf big
 	conf.queryParts = queryParts
 
 	if conf.project, err = inConf.FieldString("project"); err != nil {
+		return
+	}
+
+	if conf.clientOptions, err = gcpClientOptionsFromParsed(inConf); err != nil {
 		return
 	}
 
@@ -105,6 +110,7 @@ func newBigQuerySelectInputConfig() *service.ConfigSpec {
 		Field(service.NewStringField("suffix").
 			Description("An optional suffix to append to the select query.").
 			Optional()).
+		Field(gcpCredentialsField()).
 		Example("Word counts",
 			`
 Here we query the public corpus of Shakespeare's works to generate a stream of the top 10 words that are 3 or more characters long:`,
@@ -155,7 +161,7 @@ func newBigQuerySelectInput(inConf *service.ParsedConfig, logger *service.Logger
 		logger:        logger,
 		config:        &conf,
 		shutdownSig:   shutdown.NewSignaller(),
-		clientOptions: clientOptions,
+		clientOptions: append(conf.clientOptions, clientOptions...),
 	}, nil
 }
 

--- a/internal/impl/gcp/input_cloud_storage.go
+++ b/internal/impl/gcp/input_cloud_storage.go
@@ -10,6 +10,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 
 	"github.com/warpstreamlabs/bento/public/service"
 	"github.com/warpstreamlabs/bento/public/service/codec"
@@ -27,6 +28,7 @@ type csiConfig struct {
 	Prefix        *service.InterpolatedString
 	DeleteObjects bool
 	Codec         codec.DeprecatedFallbackCodec
+	ClientOptions []option.ClientOption
 }
 
 func csiConfigFromParsed(pConf *service.ParsedConfig) (conf csiConfig, err error) {
@@ -40,6 +42,9 @@ func csiConfigFromParsed(pConf *service.ParsedConfig) (conf csiConfig, err error
 		return
 	}
 	if conf.DeleteObjects, err = pConf.FieldBool(csiFieldDeleteObjects); err != nil {
+		return
+	}
+	if conf.ClientOptions, err = gcpClientOptionsFromParsed(pConf); err != nil {
 		return
 	}
 	return
@@ -83,6 +88,7 @@ By default Bento will use a shared credentials file when connecting to GCP servi
 				Description("Whether to delete downloaded objects from the bucket once they are processed.").
 				Advanced().
 				Default(false),
+			gcpCredentialsField(),
 		)
 }
 
@@ -258,7 +264,7 @@ func newGCPCloudStorageInput(conf csiConfig, res *service.Resources) (*gcpCloudS
 // Cloud Storage bucket.
 func (g *gcpCloudStorageInput) Connect(ctx context.Context) error {
 	var err error
-	g.client, err = storage.NewClient(context.Background())
+	g.client, err = storage.NewClient(context.Background(), g.conf.ClientOptions...)
 	if err != nil {
 		return err
 	}

--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -34,6 +34,7 @@ type pbiConfig struct {
 	Sync                   bool
 	CreateEnabled          bool
 	CreateTopicID          string
+	ClientOptions          []option.ClientOption
 }
 
 func pbiConfigFromParsed(pConf *service.ParsedConfig) (conf pbiConfig, err error) {
@@ -63,6 +64,9 @@ func pbiConfigFromParsed(pConf *service.ParsedConfig) (conf pbiConfig, err error
 		if conf.CreateTopicID, err = createConf.FieldString(pbiFieldCreateSubTopicID); err != nil {
 			return
 		}
+	}
+	if conf.ClientOptions, err = gcpClientOptionsFromParsed(pConf); err != nil {
+		return
 	}
 	return
 }
@@ -119,6 +123,7 @@ You can access these metadata fields using [function interpolation](/docs/config
 				Advanced(),
 			service.NewExtractTracingSpanMappingField().Version("1.21.0"),
 			service.NewRootSpanWithLinkField().Version("1.21.0"),
+			gcpCredentialsField(),
 		)
 }
 
@@ -178,9 +183,9 @@ type gcpPubSubReader struct {
 }
 
 func newGCPPubSubReader(conf pbiConfig, res *service.Resources) (*gcpPubSubReader, error) {
-	var opt []option.ClientOption
+	opt := conf.ClientOptions
 	if strings.TrimSpace(conf.Endpoint) != "" {
-		opt = []option.ClientOption{option.WithEndpoint(conf.Endpoint)}
+		opt = append(opt, option.WithEndpoint(conf.Endpoint))
 	}
 
 	client, err := pubsub.NewClient(context.Background(), conf.ProjectID, opt...)

--- a/internal/impl/gcp/input_spanner_cdc.go
+++ b/internal/impl/gcp/input_spanner_cdc.go
@@ -13,6 +13,7 @@ import (
 	"cloud.google.com/go/spanner"
 	"github.com/Jeffail/shutdown"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 
 	types "github.com/warpstreamlabs/bento/internal/impl/gcp/types"
@@ -47,6 +48,7 @@ type cdcConfig struct {
 	StartTime            *time.Time
 	EndTime              *time.Time
 	HeartbeatInterval    time.Duration
+	ClientOptions        []option.ClientOption
 
 	prefetchCount int
 }
@@ -91,6 +93,10 @@ func cdcConfigFromParsed(pConf *service.ParsedConfig) (conf cdcConfig, err error
 	}
 
 	if conf.HeartbeatInterval, err = pConf.FieldDuration(cdcFieldHeartbeatInterval); err != nil {
+		return
+	}
+
+	if conf.ClientOptions, err = gcpClientOptionsFromParsed(pConf); err != nil {
 		return
 	}
 
@@ -146,6 +152,7 @@ This input adds the following metadata fields to each message:
 				Example(1024).
 				Default(1024).
 				LintRule(`root = if this < 0 { ["prefetch count must be greater than or equal to zero"] }`),
+			gcpCredentialsField(),
 		)
 }
 
@@ -185,7 +192,7 @@ type changeRecord struct {
 }
 
 func newGcpSpannerCDCInput(conf cdcConfig, res *service.Resources) (*gcpSpannerCDCInput, error) {
-	client, err := spanner.NewClient(context.Background(), conf.SpannerDSN)
+	client, err := spanner.NewClient(context.Background(), conf.SpannerDSN, conf.ClientOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +219,7 @@ func (c *gcpSpannerCDCInput) Connect(ctx context.Context) error {
 	}
 
 	if c.streamClient == nil {
-		client, err := spanner.NewClient(ctx, c.conf.SpannerDSN)
+		client, err := spanner.NewClient(ctx, c.conf.SpannerDSN, c.conf.ClientOptions...)
 		if err != nil {
 			return err
 		}

--- a/internal/impl/gcp/output_bigquery.go
+++ b/internal/impl/gcp/output_bigquery.go
@@ -59,6 +59,7 @@ type gcpBigQueryOutputConfig struct {
 	IgnoreUnknownValues bool
 	MaxBadRecords       int
 	JobLabels           map[string]string
+	ClientOptions       []option.ClientOption
 
 	// CSV options
 	CSVOptions  gcpBigQueryCSVConfig
@@ -103,6 +104,9 @@ func gcpBigQueryOutputConfigFromParsed(conf *service.ParsedConfig) (gconf gcpBig
 		return
 	}
 	if gconf.CSVOptions, err = gcpBigQueryCSVConfigFromParsed(conf.Namespace("csv")); err != nil {
+		return
+	}
+	if gconf.ClientOptions, err = gcpClientOptionsFromParsed(conf); err != nil {
 		return
 	}
 	return
@@ -219,7 +223,8 @@ The table to insert messages to.`)).
 				Advanced().
 				Default(1),
 		).Description("Specify how CSV data should be interpretted.")).
-		Field(service.NewBatchPolicyField("batching"))
+		Field(service.NewBatchPolicyField("batching")).
+		Field(gcpCredentialsField())
 }
 
 func init() {
@@ -312,7 +317,7 @@ func (g *gcpBigQueryOutput) Connect(ctx context.Context) (err error) {
 	defer g.connMut.Unlock()
 
 	var client *bigquery.Client
-	var opts []option.ClientOption
+	opts := g.conf.ClientOptions
 	if g.conf.Endpoint != "" {
 		opts = append(opts, option.WithoutAuthentication(), option.WithEndpoint(g.conf.Endpoint))
 	}

--- a/internal/impl/gcp/output_bigquery_storage.go
+++ b/internal/impl/gcp/output_bigquery_storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
@@ -68,7 +69,8 @@ sets the type of stream this write client is managing.`).Default(string(managedw
 		Field(service.NewBatchPolicyField("batching").Advanced().LintRule(`root = if this.byte_size >= 1000000 { "the amount of bytes in a batch cannot exceed 10 MB" }`)).
 		Field(service.NewIntField("max_in_flight").
 			Description("The maximum number of message batches to have in flight at a given time. Increase this to improve throughput.").
-			Default(64).Advanced())
+			Default(64).Advanced()).
+		Field(gcpCredentialsField())
 }
 
 func bigQueryStorageWriterConfigFromParsed(pConf *service.ParsedConfig) (conf bigQueryStorageWriterConfig, err error) {
@@ -102,6 +104,10 @@ func bigQueryStorageWriterConfigFromParsed(pConf *service.ParsedConfig) (conf bi
 	}
 
 	if conf.grpcEndpoint, err = pConf.FieldString("endpoint", "grpc"); err != nil {
+		return
+	}
+
+	if conf.clientOptions, err = gcpClientOptionsFromParsed(pConf); err != nil {
 		return
 	}
 
@@ -188,6 +194,8 @@ type bigQueryStorageWriterConfig struct {
 	httpEndpoint string
 	grpcEndpoint string
 
+	clientOptions []option.ClientOption
+
 	streamType managedwriter.StreamType
 
 	messageFormat string
@@ -198,7 +206,7 @@ type bigQueryStorageWriterConfig struct {
 
 func (bq *bigQueryStorageWriter) Connect(ctx context.Context) error {
 
-	var bqClientOpts []option.ClientOption
+	bqClientOpts := slices.Clone(bq.conf.clientOptions)
 	if bq.conf.httpEndpoint != "" {
 		bqClientOpts = append(bqClientOpts, option.WithoutAuthentication(), option.WithEndpoint(bq.conf.httpEndpoint))
 	}
@@ -208,7 +216,7 @@ func (bq *bigQueryStorageWriter) Connect(ctx context.Context) error {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	var storageClientOpts []option.ClientOption
+	storageClientOpts := slices.Clone(bq.conf.clientOptions)
 	if bq.conf.grpcEndpoint != "" {
 		conn, err := grpc.NewClient(bq.conf.grpcEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {

--- a/internal/impl/gcp/output_bigtable.go
+++ b/internal/impl/gcp/output_bigtable.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"cloud.google.com/go/bigtable"
+	"google.golang.org/api/option"
 
 	"github.com/warpstreamlabs/bento/public/bloblang"
 	"github.com/warpstreamlabs/bento/public/service"
@@ -96,6 +97,7 @@ This output benefits from sending messages as a batch for improved performance. 
 				Example(`json("created_at").ts_parse("2006-01-02 15:04:05")`),
 			service.NewBatchPolicyField(btoFieldBatching),
 			service.NewOutputMaxInFlightField(),
+			gcpCredentialsField(),
 		)
 }
 
@@ -110,6 +112,8 @@ type gcpBigTableOutputConfig struct {
 	ColumnFamily *service.InterpolatedString
 
 	Timestamp *bloblang.Executor
+
+	ClientOptions []option.ClientOption
 }
 
 func gcpBigTableOutputConfigFromParsed(conf *service.ParsedConfig) (gconf gcpBigTableOutputConfig, err error) {
@@ -143,6 +147,10 @@ func gcpBigTableOutputConfigFromParsed(conf *service.ParsedConfig) (gconf gcpBig
 		}
 	}
 
+	if gconf.ClientOptions, err = gcpClientOptionsFromParsed(conf); err != nil {
+		return
+	}
+
 	return
 }
 
@@ -169,7 +177,7 @@ func (g *gcpBigTableOutput) Connect(ctx context.Context) error {
 	defer g.mu.Unlock()
 
 	if g.client == nil {
-		client, err := bigtable.NewClient(ctx, g.conf.ProjectID, g.conf.InstanceID)
+		client, err := bigtable.NewClient(ctx, g.conf.ProjectID, g.conf.InstanceID, g.conf.ClientOptions...)
 		if err != nil {
 			return fmt.Errorf("could not create bigtable client: %w", err)
 		}

--- a/internal/impl/gcp/output_cloud_storage.go
+++ b/internal/impl/gcp/output_cloud_storage.go
@@ -11,6 +11,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/gofrs/uuid"
 	"go.uber.org/multierr"
+	"google.golang.org/api/option"
 
 	"github.com/warpstreamlabs/bento/public/service"
 )
@@ -48,6 +49,7 @@ type csoConfig struct {
 	ChunkSize       int
 	CollisionMode   string
 	Timeout         time.Duration
+	ClientOptions   []option.ClientOption
 }
 
 func csoConfigFromParsed(pConf *service.ParsedConfig) (conf csoConfig, err error) {
@@ -70,6 +72,9 @@ func csoConfigFromParsed(pConf *service.ParsedConfig) (conf csoConfig, err error
 		return
 	}
 	if conf.Timeout, err = pConf.FieldDuration(csoFieldTimeout); err != nil {
+		return
+	}
+	if conf.ClientOptions, err = gcpClientOptionsFromParsed(pConf); err != nil {
 		return
 	}
 	return
@@ -161,6 +166,7 @@ output:
 			service.NewOutputMaxInFlightField().
 				Description("The maximum number of message batches to have in flight at a given time. Increase this to improve throughput."),
 			service.NewBatchPolicyField(csoFieldBatching),
+			gcpCredentialsField(),
 		)
 }
 
@@ -214,7 +220,7 @@ func (g *gcpCloudStorageOutput) Connect(ctx context.Context) error {
 	defer g.connMut.Unlock()
 
 	var err error
-	g.client, err = storage.NewClient(context.Background())
+	g.client, err = storage.NewClient(context.Background(), g.conf.ClientOptions...)
 	if err != nil {
 		return err
 	}

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -91,6 +91,7 @@ pipeline:
 				Advanced(),
 			service.NewBatchPolicyField("batching").
 				Description("Configures a batching policy on this output. While the PubSub client maintains its own internal buffering mechanism, preparing larger batches of messages can further trade-off some latency for throughput."),
+			gcpCredentialsField(),
 		)
 }
 
@@ -178,9 +179,12 @@ func newPubSubOutput(conf *service.ParsedConfig) (*pubsubOutput, error) {
 		return nil, err
 	}
 
-	var opt []option.ClientOption
+	opt, err := gcpClientOptionsFromParsed(conf)
+	if err != nil {
+		return nil, err
+	}
 	if endpoint != "" {
-		opt = []option.ClientOption{option.WithEndpoint(endpoint)}
+		opt = append(opt, option.WithEndpoint(endpoint))
 	}
 
 	return &pubsubOutput{

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -21,6 +21,8 @@ type bigQuerySelectProcessorConfig struct {
 	jobLabels   map[string]string
 	argsMapping *bloblang.Executor
 	unsafeDyn   bool
+
+	clientOptions []option.ClientOption
 }
 
 func bigQuerySelectProcessorConfigFromParsed(inConf *service.ParsedConfig) (conf bigQuerySelectProcessorConfig, err error) {
@@ -28,6 +30,10 @@ func bigQuerySelectProcessorConfigFromParsed(inConf *service.ParsedConfig) (conf
 	conf.queryParts = &queryParts
 
 	if conf.project, err = inConf.FieldString("project"); err != nil {
+		return
+	}
+
+	if conf.clientOptions, err = gcpClientOptionsFromParsed(inConf); err != nil {
 		return
 	}
 
@@ -146,6 +152,7 @@ func newBigQuerySelectProcessorConfig() *service.ConfigSpec {
 			Default(false).
 			Version("1.5.0").
 			Optional()).
+		Field(gcpCredentialsField()).
 		Example("Word count",
 			`
 Given a stream of English terms, enrich the messages with the word count from Shakespeare's public works:`,
@@ -212,7 +219,7 @@ func newBigQuerySelectProcessor(inConf *service.ParsedConfig, options *bigQueryP
 
 	closeCtx, closeF := context.WithCancel(context.Background())
 
-	wrapped, err := bigquery.NewClient(closeCtx, conf.project, options.clientOptions...)
+	wrapped, err := bigquery.NewClient(closeCtx, conf.project, append(conf.clientOptions, options.clientOptions...)...)
 	if err != nil {
 		closeF()
 		return nil, fmt.Errorf("failed to create bigquery client: %w", err)

--- a/internal/impl/gcp/tracer_cloudtrace.go
+++ b/internal/impl/gcp/tracer_cloudtrace.go
@@ -37,6 +37,7 @@ func cloudTraceSpec() *service.ConfigSpec {
 			service.NewDurationField(ctFieldFlushInterval).
 				Description("The period of time between each flush of tracing spans.").
 				Optional(),
+			gcpCredentialsField(),
 		)
 }
 
@@ -64,7 +65,12 @@ func cloudTraceFromParsed(conf *service.ParsedConfig) (trace.TracerProvider, err
 		return nil, err
 	}
 
-	exp, err := gcptrace.New(gcptrace.WithProjectID(projID))
+	clientOpts, err := gcpClientOptionsFromParsed(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	exp, err := gcptrace.New(gcptrace.WithProjectID(projID), gcptrace.WithTraceClientOptions(clientOpts))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cloud trace exporter: %w", err)
 	}

--- a/website/docs/components/caches/gcp_cloud_storage.md
+++ b/website/docs/components/caches/gcp_cloud_storage.md
@@ -19,13 +19,38 @@ This component is mostly stable but breaking changes could still be made outside
 :::
 Use a Google Cloud Storage bucket as a cache.
 
+
+<Tabs defaultValue="common" values={[
+  { label: 'Common', value: 'common', },
+  { label: 'Advanced', value: 'advanced', },
+]}>
+
+<TabItem value="common">
+
 ```yml
-# Config fields, showing default values
+# Common config fields, showing default values
 label: ""
 gcp_cloud_storage:
   bucket: "" # No default (required)
   content_type: "" # No default (optional)
 ```
+
+</TabItem>
+<TabItem value="advanced">
+
+```yml
+# All config fields, showing default values
+label: ""
+gcp_cloud_storage:
+  bucket: "" # No default (required)
+  content_type: "" # No default (optional)
+  credentials:
+    impersonate_service_account: ""
+    impersonate_delegates: []
+```
+
+</TabItem>
+</Tabs>
 
 It is not possible to atomically upload cloud storage objects exclusively when the target does not already exist, therefore this cache is not suitable for deduplication.
 
@@ -44,5 +69,35 @@ Optional field to explicitly set the Content-Type.
 
 
 Type: `string`  
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/inputs/gcp_bigquery_select.md
+++ b/website/docs/components/inputs/gcp_bigquery_select.md
@@ -17,8 +17,16 @@ import TabItem from '@theme/TabItem';
 
 Executes a `SELECT` query against BigQuery and creates a message for each row received.
 
+
+<Tabs defaultValue="common" values={[
+  { label: 'Common', value: 'common', },
+  { label: 'Advanced', value: 'advanced', },
+]}>
+
+<TabItem value="common">
+
 ```yml
-# Config fields, showing default values
+# Common config fields, showing default values
 input:
   label: ""
   gcp_bigquery_select:
@@ -33,6 +41,32 @@ input:
     prefix: "" # No default (optional)
     suffix: "" # No default (optional)
 ```
+
+</TabItem>
+<TabItem value="advanced">
+
+```yml
+# All config fields, showing default values
+input:
+  label: ""
+  gcp_bigquery_select:
+    project: "" # No default (required)
+    table: bigquery-public-data.samples.shakespeare # No default (required)
+    columns: [] # No default (required)
+    where: type = ? and created_at > ? # No default (optional)
+    auto_replay_nacks: true
+    job_labels: {}
+    priority: ""
+    args_mapping: root = [ "article", now().ts_format("2006-01-02") ] # No default (optional)
+    prefix: "" # No default (optional)
+    suffix: "" # No default (optional)
+    credentials:
+      impersonate_service_account: ""
+      impersonate_delegates: []
+```
+
+</TabItem>
+</Tabs>
 
 Once the rows from the query are exhausted, this input shuts down, allowing the pipeline to gracefully terminate (or the next input in a [sequence](/docs/components/inputs/sequence) to execute).
 
@@ -161,5 +195,35 @@ An optional suffix to append to the select query.
 
 
 Type: `string`  
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/inputs/gcp_cloud_storage.md
+++ b/website/docs/components/inputs/gcp_cloud_storage.md
@@ -49,6 +49,9 @@ input:
     scanner:
       to_the_end: {}
     delete_objects: false
+    credentials:
+      impersonate_service_account: ""
+      impersonate_delegates: []
 ```
 
 </TabItem>
@@ -107,5 +110,35 @@ Whether to delete downloaded objects from the bucket once they are processed.
 
 Type: `bool`  
 Default: `false`  
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/inputs/gcp_pubsub.md
+++ b/website/docs/components/inputs/gcp_pubsub.md
@@ -57,6 +57,9 @@ input:
       topic: ""
     extract_tracing_map: root = @ # No default (optional)
     new_root_span_with_link: false # No default (optional)
+    credentials:
+      impersonate_service_account: ""
+      impersonate_delegates: []
 ```
 
 </TabItem>
@@ -181,5 +184,35 @@ EXPERIMENTAL: Starts a new root span with link to parent.
 
 Type: `bool`  
 Requires version 1.21.0 or newer  
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/inputs/gcp_spanner_cdc.md
+++ b/website/docs/components/inputs/gcp_spanner_cdc.md
@@ -22,8 +22,16 @@ Consumes Spanner Change Stream Events from a GCP Spanner instance.
 
 Introduced in version 1.11.0.
 
+
+<Tabs defaultValue="common" values={[
+  { label: 'Common', value: 'common', },
+  { label: 'Advanced', value: 'advanced', },
+]}>
+
+<TabItem value="common">
+
 ```yml
-# Config fields, showing default values
+# Common config fields, showing default values
 input:
   label: ""
   gcp_spanner_cdc:
@@ -34,6 +42,28 @@ input:
     end_time: 2006-01-02T15:04:05Z07:00 # No default (optional)
     prefetch_count: 1024
 ```
+
+</TabItem>
+<TabItem value="advanced">
+
+```yml
+# All config fields, showing default values
+input:
+  label: ""
+  gcp_spanner_cdc:
+    spanner_dsn: projects/{projectId}/instances/{instanceId}/databases/{databaseName} # No default (required)
+    stream_name: "" # No default (required)
+    heartbeat_interval: 3s
+    start_time: 2006-01-02T15:04:05Z07:00 # No default (optional)
+    end_time: 2006-01-02T15:04:05Z07:00 # No default (optional)
+    prefetch_count: 1024
+    credentials:
+      impersonate_service_account: ""
+      impersonate_delegates: []
+```
+
+</TabItem>
+</Tabs>
 
 For information on how to set up credentials check out [this guide](https://cloud.google.com/docs/authentication/production).
 
@@ -124,5 +154,35 @@ Default: `1024`
 
 prefetch_count: 1024
 ```
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/outputs/gcp_bigquery.md
+++ b/website/docs/components/outputs/gcp_bigquery.md
@@ -81,6 +81,9 @@ output:
       jitter: 0
       check: ""
       processors: [] # No default (optional)
+    credentials:
+      impersonate_service_account: ""
+      impersonate_delegates: []
 ```
 
 </TabItem>
@@ -404,5 +407,35 @@ processors:
   - archive:
       format: json_array
 ```
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/outputs/gcp_bigquery_write_api.md
+++ b/website/docs/components/outputs/gcp_bigquery_write_api.md
@@ -62,6 +62,9 @@ output:
       check: ""
       processors: [] # No default (optional)
     max_in_flight: 64
+    credentials:
+      impersonate_service_account: ""
+      impersonate_delegates: []
 ```
 
 </TabItem>
@@ -282,5 +285,35 @@ The maximum number of message batches to have in flight at a given time. Increas
 
 Type: `int`  
 Default: `64`  
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/outputs/gcp_bigtable.md
+++ b/website/docs/components/outputs/gcp_bigtable.md
@@ -72,6 +72,9 @@ output:
       check: ""
       processors: [] # No default (optional)
     max_in_flight: 64
+    credentials:
+      impersonate_service_account: ""
+      impersonate_delegates: []
 ```
 
 </TabItem>
@@ -318,5 +321,35 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 Type: `int`  
 Default: `64`  
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/outputs/gcp_cloud_storage.md
+++ b/website/docs/components/outputs/gcp_cloud_storage.md
@@ -67,6 +67,9 @@ output:
       jitter: 0
       check: ""
       processors: [] # No default (optional)
+    credentials:
+      impersonate_service_account: ""
+      impersonate_delegates: []
 ```
 
 </TabItem>
@@ -335,5 +338,35 @@ processors:
   - archive:
       format: json_array
 ```
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/outputs/gcp_pubsub.md
+++ b/website/docs/components/outputs/gcp_pubsub.md
@@ -78,6 +78,9 @@ output:
       jitter: 0
       check: ""
       processors: [] # No default (optional)
+    credentials:
+      impersonate_service_account: ""
+      impersonate_delegates: []
 ```
 
 </TabItem>
@@ -377,5 +380,35 @@ processors:
   - archive:
       format: json_array
 ```
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/processors/gcp_bigquery_select.md
+++ b/website/docs/components/processors/gcp_bigquery_select.md
@@ -56,6 +56,9 @@ gcp_bigquery_select:
   prefix: "" # No default (optional)
   suffix: "" # No default (optional)
   unsafe_dynamic_query: false
+  credentials:
+    impersonate_service_account: ""
+    impersonate_delegates: []
 ```
 
 </TabItem>
@@ -212,5 +215,35 @@ Whether to enable [interpolation functions](/docs/configuration/interpolation/#b
 Type: `bool`  
 Default: `false`  
 Requires version 1.5.0 or newer  
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/components/tracers/gcp_cloudtrace.md
+++ b/website/docs/components/tracers/gcp_cloudtrace.md
@@ -47,6 +47,9 @@ tracer:
     sampling_ratio: 1
     tags: {}
     flush_interval: "" # No default (optional)
+    credentials:
+      impersonate_service_account: ""
+      impersonate_delegates: []
 ```
 
 </TabItem>
@@ -89,5 +92,35 @@ The period of time between each flush of tracing spans.
 
 
 Type: `string`  
+
+### `credentials`
+
+Optional manual configuration of GCP credentials to use. More information can be found [in this document](/docs/guides/cloud/gcp).
+
+
+Type: `object`  
+Requires version 1.22.0 or newer  
+
+### `credentials.impersonate_service_account`
+
+The email address of a service account to impersonate. The base credentials (Application Default Credentials) must be granted `roles/iam.serviceAccountTokenCreator` on this service account, or on the first delegate when `impersonate_delegates` is set.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+impersonate_service_account: target@my-project.iam.gserviceaccount.com
+```
+
+### `credentials.impersonate_delegates`
+
+An optional chain of service account email addresses to delegate through when impersonating. Each service account must be granted `roles/iam.serviceAccountTokenCreator` on the next service account in the chain, with the final one granted on `impersonate_service_account`.
+
+
+Type: `array`  
+Default: `[]`  
 
 

--- a/website/docs/guides/cloud/gcp.md
+++ b/website/docs/guides/cloud/gcp.md
@@ -17,3 +17,38 @@ as a JSON file. Then all you need to do set the path to this JSON file in the `G
 environment variable.
 
 Please refer to [this document](https://cloud.google.com/docs/authentication/production) for details.
+
+## Service Account Impersonation
+
+Application Default Credentials are resolved once per process, which means every GCP component in a Bento instance
+shares the same identity. When running multiple streams in a single instance (for example in
+[streams mode](/docs/guides/streams_mode/about)) it is often desirable for each stream to act as its own, least-privileged
+service account instead.
+
+Every GCP component exposes an advanced `credentials` object that supports
+[service account impersonation](https://cloud.google.com/iam/docs/service-account-impersonation). When
+`impersonate_service_account` is set the component obtains short-lived tokens for that service account using the base
+Application Default Credentials, which must be granted `roles/iam.serviceAccountTokenCreator` on the target:
+
+```yaml
+input:
+  gcp_pubsub:
+    project: my-project
+    subscription: my-subscription
+    credentials:
+      impersonate_service_account: stream-a@my-project.iam.gserviceaccount.com
+```
+
+Delegated impersonation chains can be expressed with `impersonate_delegates`, where each service account must be
+granted `roles/iam.serviceAccountTokenCreator` on the next one in the chain, and the final delegate on the target:
+
+```yaml
+credentials:
+  impersonate_service_account: target@my-project.iam.gserviceaccount.com
+  impersonate_delegates:
+    - hop-one@my-project.iam.gserviceaccount.com
+    - hop-two@my-project.iam.gserviceaccount.com
+```
+
+Impersonated tokens are requested with the `https://www.googleapis.com/auth/cloud-platform` scope and are refreshed
+automatically before they expire.


### PR DESCRIPTION
Adds an advanced `credentials` object to every GCP component (gcp_pubsub input/output, gcp_cloud_storage input/output/cache, gcp_bigquery, gcp_bigquery_write_api, gcp_bigquery_select input/processor, gcp_spanner_cdc, gcp_bigtable, gcp_cloudtrace) with:

- `impersonate_service_account`: email of a service account to impersonate using the base Application Default Credentials.
- `impersonate_delegates`: optional delegation chain.

When unset, behaviour is unchanged (plain ADC). This allows a single Bento instance (e.g. streams mode on Cloud Run) to run each stream as its own least-privileged service account.

Closes #996