### PR TITLE
align YAML merge key (<<:) handling between lint & run subcommands

### DIFF
--- a/internal/docs/format_yaml.go
+++ b/internal/docs/format_yaml.go
@@ -681,8 +681,7 @@ func (f FieldSpecs) LintYAML(ctx LintContext, node *yaml.Node) []Lint {
 		specNamesAll[field.Name] = field
 	}
 
-	var walkNodeContent func(*yaml.Node)
-	walkNodeContent = func(walkNode *yaml.Node) {
+	walkNodeContent := func(walkNode *yaml.Node) {
 		for i := 0; i < len(walkNode.Content)-1; i += 2 {
 			if walkNode.Content[i].Tag == "!!merge" {
 				continue

--- a/internal/docs/format_yaml.go
+++ b/internal/docs/format_yaml.go
@@ -684,8 +684,7 @@ func (f FieldSpecs) LintYAML(ctx LintContext, node *yaml.Node) []Lint {
 	var walkNodeContent func(*yaml.Node)
 	walkNodeContent = func(walkNode *yaml.Node) {
 		for i := 0; i < len(walkNode.Content)-1; i += 2 {
-			if walkNode.Content[i].Tag == "!!merge" && walkNode.Content[i+1].Alias != nil {
-				walkNodeContent(walkNode.Content[i+1].Alias)
+			if walkNode.Content[i].Tag == "!!merge" {
 				continue
 			}
 			spec, exists := specNamesAll[walkNode.Content[i].Value]

--- a/internal/docs/format_yaml_test.go
+++ b/internal/docs/format_yaml_test.go
@@ -1028,67 +1028,6 @@ testlintfooinput:
 	}
 }
 
-func TestYAMLLintYAMLMerge(t *testing.T) {
-	prov := docs.NewMappedDocsProvider()
-	prov.RegisterDocs(docs.ComponentSpec{
-		Name: "meowthing",
-		Type: docs.TypeInput,
-		Config: docs.FieldComponent().WithChildren(
-			docs.FieldString("foo", ""),
-			docs.FieldString("bar", "").Optional(),
-		),
-	})
-
-	lConf := docs.NewLintConfig(bundle.GlobalEnvironment)
-	lConf.DocsProvider = prov
-
-	lintConf := func(t *testing.T, name, conf string, expected []docs.Lint) {
-		t.Run(name, func(t *testing.T) {
-			var node yaml.Node
-			require.NoError(t, yaml.Unmarshal([]byte(conf), &node))
-			lints := docs.FieldInput("root", "").Map().LintYAML(docs.NewLintContext(lConf), &node)
-			assert.Equal(t, expected, lints)
-		})
-	}
-
-	lintConf(t, "no lint errors", `
-first:
-  meowthing: &a
-    foo: one
-second:
-  meowthing:
-    <<: *a
-    bar: two
-`, nil)
-
-	lintConf(t, "unknown field from", `
-first:
-  meowthing: &a
-    foo: one
-    baz: three
-second:
-  meowthing:
-    <<: *a
-    bar: two
-`, []docs.Lint{
-		{Line: 5, Column: 1, Level: docs.LintError, Type: docs.LintUnknown, What: "field baz not recognised"},
-		{Line: 5, Column: 1, Level: docs.LintError, Type: docs.LintUnknown, What: "field baz not recognised"},
-	})
-
-	lintConf(t, "unknown field into", `
-first:
-  meowthing: &a
-    foo: one
-    bar: two
-second:
-  meowthing:
-    <<: *a
-    baz: three
-`, []docs.Lint{
-		{Line: 9, Column: 1, Level: docs.LintError, Type: docs.LintUnknown, What: "field baz not recognised"},
-	})
-}
-
 func TestYAMLLinting(t *testing.T) {
 	type testCase struct {
 		name      string


### PR DESCRIPTION
fixes #872 

It seems odd how the `lint` subcommand is able to handle YAML merge keys but running a stream that has merge keys will fail to init components.

This PR will alter the `lint` subcommand such it will behave the same as `run`. Issue #872 describes a situation where `lint` was called in CI on a config, and reported no errors, but then subsequently `run` failed. 

Related to #969 - which enables Bento to work with <<: merge commands. 
