### PR TITLE
fix(fsevent): reconnect on watcher error instead of stalling

### DIFF
--- a/internal/impl/io/input_fsevent.go
+++ b/internal/impl/io/input_fsevent.go
@@ -205,7 +205,15 @@ func (f *fsEventWatcher) Connect(ctx context.Context) error {
 				if !ok {
 					return
 				}
-				f.log.Errorf("error: %v", err)
+				// A watcher error (for example a watched path backed by an SMB
+				// share reporting "The specified network name is no longer
+				// available" once the session is torn down) leaves the
+				// underlying fsnotify watch dead with no way to recover it in
+				// place. Stop the read loop so that Read surfaces a disconnect
+				// and the framework rebuilds the watcher via Connect, instead of
+				// silently blocking until the process is restarted.
+				f.log.Errorf("filesystem watcher error, reconnecting: %v", err)
+				return
 			}
 		}
 	}()
@@ -230,8 +238,15 @@ func (f *fsEventWatcher) Read(ctx context.Context) (*service.Message, service.Ac
 			f.cMut.Lock()
 			defer f.cMut.Unlock()
 			f.eventChan = nil
-			f.watcher = nil
-			return nil, nil, service.ErrEndOfInput
+			if f.watcher != nil {
+				_ = f.watcher.Close()
+				f.watcher = nil
+			}
+			// The watch loop stopped (the watcher errored, or was closed
+			// because nothing remained to watch). Report a disconnect rather
+			// than end-of-input so the framework reconnects and rebuilds the
+			// watch, instead of permanently terminating the input.
+			return nil, nil, service.ErrNotConnected
 		}
 
 		message := service.NewMessage(nil)

--- a/internal/impl/io/input_fsevent_reconnect_test.go
+++ b/internal/impl/io/input_fsevent_reconnect_test.go
@@ -1,0 +1,88 @@
+package io
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+// TestFSEventReconnectsOnWatcherError is a regression test for the nightly
+// "watcher stops picking up new files" stall observed on Windows when the
+// watched paths are symlinks to SMB shares.
+//
+// When the SMB session is torn down (typically overnight) the underlying
+// fsnotify watch reports an error such as:
+//
+//	GetQueuedCompletionPort: The specified network name is no longer available.
+//
+// Previously this error was only logged and the read loop kept running against
+// a dead watch, so Read blocked forever and no new files were picked up until
+// the process was manually restarted. The input must instead surface a
+// disconnect (ErrNotConnected) so the framework rebuilds the watcher.
+func TestFSEventReconnectsOnWatcherError(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	conf, err := fsEventInputSpec().ParseYAML(fmt.Sprintf("paths: [ %q ]\n", dir), nil)
+	require.NoError(t, err)
+
+	f, err := fsEventWatcherFromParsed(conf, service.MockResources())
+	require.NoError(t, err)
+
+	require.NoError(t, f.Connect(ctx))
+
+	// Simulate fsnotify surfacing a fatal watcher error (the SMB share going
+	// away). Before the fix this was swallowed with a log line.
+	select {
+	case f.watcher.Errors <- errors.New("simulated: the specified network name is no longer available"):
+	case <-time.After(5 * time.Second):
+		t.Fatal("could not inject watcher error")
+	}
+
+	// Read must return ErrNotConnected so the framework reconnects, rather than
+	// blocking forever on a dead watch.
+	readErrCh := make(chan error, 1)
+	go func() {
+		_, _, rerr := f.Read(ctx)
+		readErrCh <- rerr
+	}()
+	select {
+	case rerr := <-readErrCh:
+		require.ErrorIs(t, rerr, service.ErrNotConnected)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Read blocked after watcher error instead of returning ErrNotConnected")
+	}
+
+	// Reconnecting must rebuild the watch and resume picking up new files.
+	require.NoError(t, f.Connect(ctx))
+	time.Sleep(500 * time.Millisecond)
+
+	newFile := filepath.Join(dir, "after-reconnect.txt")
+	require.NoError(t, os.WriteFile(newFile, []byte("hi"), 0o644))
+
+	var gotPath string
+	for i := 0; i < 10 && gotPath != newFile; i++ {
+		readCtx, readCancel := context.WithTimeout(ctx, 3*time.Second)
+		msg, _, rerr := f.Read(readCtx)
+		readCancel()
+		if rerr != nil {
+			require.ErrorIs(t, rerr, context.DeadlineExceeded)
+			continue
+		}
+		if p, ok := msg.MetaGet("fsevent_path"); ok {
+			gotPath = p
+		}
+	}
+	require.Equal(t, newFile, gotPath, "watcher did not pick up a new file after reconnect")
+
+	require.NoError(t, f.Close(ctx))
+}


### PR DESCRIPTION
The fsevent input had no recovery path when the underlying fsnotify watch died. On Windows, when a watched path is a symlink to an SMB share and the SMB session is torn down (typically overnight), the async read completes with ERROR_NETNAME_DELETED ("The specified network name is no longer available"). This surfaced two dead ends, both requiring a manual process restart:

  - the watcher error was only logged while the read loop kept running against a dead watch, so Read blocked forever (silent stall); and
  - the broken-watch path returned ErrEndOfInput, which the enclosing `sequence` input treats as graceful termination and shuts down.

On a watcher error we now tear down the read loop, and the closed-watch path in Read returns ErrNotConnected (closing the dead watcher) instead of ErrEndOfInput. The framework's async reader then re-runs Connect with backoff, rebuilding the watch and resuming file pickup with no restart.

Adds a white-box regression test that injects a watcher error and asserts Read returns ErrNotConnected and that new files are picked up after reconnect. Verified failing before the fix (Read blocks) and passing after.