### PR TITLE
fix(aws/kinesis): stop duplicate EFO shard consumers accumulating under backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 - `send_queue_capacity`, `buf_pool_capacity` & `send_loop_count` fields on the `statsd` metrics exporter to tune the underlying `go-statsd` client and avoid packet loss under high throughput @triddell
 
+### Fixed
+
+- `aws_kinesis` input with `enhanced_fan_out` no longer accumulates duplicate shard consumers when the pipeline applies sustained backpressure, which previously grew memory usage until the process was killed @matus-tomlein
+
 ## 1.21.1 - 2026-08-26
 
 ### Fixed

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -247,6 +247,18 @@ type kinesisReader struct {
 	cMut    sync.Mutex
 	msgChan chan asyncMessage
 
+	// runningShards tracks the shards this client currently has a consumer
+	// goroutine for, keyed by streamID+shardID. The balancer consults it before
+	// claiming a shard so that a lease which looks stale — most often because
+	// the consumer is blocked waiting for a busy pipeline — cannot cause a
+	// second consumer to be started for a shard we are already consuming.
+	runningMut    sync.Mutex
+	runningShards map[string]struct{}
+
+	// checkpointFn overrides the periodic checkpoint call in tests. Nil in
+	// production, where the real checkpointer is used.
+	checkpointFn func(ctx context.Context, streamID, shardID, sequence string) (bool, error)
+
 	ctx  context.Context
 	done func()
 
@@ -255,6 +267,66 @@ type kinesisReader struct {
 }
 
 var errCannotMixBalancedShards = errors.New("it is not currently possible to include balanced and explicit shard streams in the same kinesis input")
+
+func shardKey(streamID, shardID string) string {
+	return streamID + "/" + shardID
+}
+
+// claimRunningShard registers a shard as being consumed by this client,
+// reporting false if a consumer for it is already running.
+func (k *kinesisReader) claimRunningShard(streamID, shardID string) bool {
+	key := shardKey(streamID, shardID)
+	k.runningMut.Lock()
+	defer k.runningMut.Unlock()
+	if _, exists := k.runningShards[key]; exists {
+		return false
+	}
+	k.runningShards[key] = struct{}{}
+	return true
+}
+
+// releaseRunningShard deregisters a shard once its consumer goroutine exits.
+func (k *kinesisReader) releaseRunningShard(streamID, shardID string) {
+	k.runningMut.Lock()
+	delete(k.runningShards, shardKey(streamID, shardID))
+	k.runningMut.Unlock()
+}
+
+// isShardRunning reports whether this client already has a consumer goroutine
+// for the given shard.
+func (k *kinesisReader) isShardRunning(streamID, shardID string) bool {
+	k.runningMut.Lock()
+	defer k.runningMut.Unlock()
+	_, exists := k.runningShards[shardKey(streamID, shardID)]
+	return exists
+}
+
+// startConsumer starts the appropriate consumer for a shard, guarding against
+// starting a second consumer for a shard this client is already consuming. It
+// takes ownership of the wait group increment, releasing it if the consumer is
+// not started.
+func (k *kinesisReader) startConsumer(wg *sync.WaitGroup, info streamInfo, shardID, sequence string) error {
+	if !k.claimRunningShard(info.id, shardID) {
+		k.log.Debugf(
+			"Skipping consumer for stream '%v' shard '%v': this client is already consuming it",
+			info.id, shardID,
+		)
+		wg.Done()
+		return nil
+	}
+
+	var err error
+	if k.efoEnabled {
+		err = k.runEFOConsumer(wg, info, shardID, sequence)
+	} else {
+		err = k.runConsumer(wg, info, shardID, sequence)
+	}
+	if err != nil {
+		// The consumer never started, so nothing will deregister it.
+		k.releaseRunningShard(info.id, shardID)
+	}
+	return err
+}
 
 func newKinesisReaderFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (*kinesisReader, error) {
 	conf, err := kinesisInputConfigFromParsed(pConf)
@@ -296,12 +368,13 @@ func newKinesisReaderFromConfig(conf kiConfig, batcher service.BatchPolicy, sess
 	}
 
 	k := kinesisReader{
-		conf:       conf,
-		sess:       sess,
-		batcher:    batcher,
-		log:        mgr.Logger(),
-		mgr:        mgr,
-		closedChan: make(chan struct{}),
+		conf:          conf,
+		sess:          sess,
+		batcher:       batcher,
+		log:           mgr.Logger(),
+		mgr:           mgr,
+		closedChan:    make(chan struct{}),
+		runningShards: map[string]struct{}{},
 	}
 	k.ctx, k.done = context.WithCancel(context.Background())
 
@@ -536,6 +609,7 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 			recordBatcher.Close(context.Background(), state == awsKinesisConsumerFinished)
 			boff.Reset()
 			k.boffPool.Put(boff)
+			k.releaseRunningShard(info.id, shardID)
 
 			reason := ""
 			switch state {
@@ -786,6 +860,12 @@ func (k *kinesisReader) runBalancedShards() {
 			// Have a go at grabbing any unclaimed shards
 			if len(unclaimedShards) > 0 {
 				for shardID, clientID := range unclaimedShards {
+					// A shard we are already consuming is not up for grabs,
+					// even if its lease looks stale — the consumer is most
+					// likely blocked on a busy pipeline rather than dead.
+					if k.isShardRunning(info.id, shardID) {
+						continue
+					}
 					sequence, err := k.checkpointer.Claim(k.ctx, info.id, shardID, clientID)
 					if err != nil {
 						if k.ctx.Err() != nil {
@@ -797,12 +877,7 @@ func (k *kinesisReader) runBalancedShards() {
 						continue
 					}
 					wg.Add(1)
-					if k.efoEnabled {
-						err = k.runEFOConsumer(&wg, *info, shardID, sequence)
-					} else {
-						err = k.runConsumer(&wg, *info, shardID, sequence)
-					}
-					if err != nil {
+					if err := k.startConsumer(&wg, *info, shardID, sequence); err != nil {
 						k.log.Errorf("Failed to start consumer: %v\n", err)
 					}
 				}
@@ -851,12 +926,7 @@ func (k *kinesisReader) runBalancedShards() {
 						info.id, randomShard, clientID, k.clientID,
 					)
 					wg.Add(1)
-					if k.efoEnabled {
-						err = k.runEFOConsumer(&wg, *info, randomShard, sequence)
-					} else {
-						err = k.runConsumer(&wg, *info, randomShard, sequence)
-					}
-					if err != nil {
+					if err := k.startConsumer(&wg, *info, randomShard, sequence); err != nil {
 						k.log.Errorf("Failed to start consumer: %v\n", err)
 					} else {
 						// If we successfully stole the shard then that's enough
@@ -897,11 +967,7 @@ func (k *kinesisReader) runExplicitShards() {
 				sequence, err := k.checkpointer.Claim(k.ctx, id, shardID, "")
 				if err == nil {
 					wg.Add(1)
-					if k.efoEnabled {
-						err = k.runEFOConsumer(&wg, info, shardID, sequence)
-					} else {
-						err = k.runConsumer(&wg, info, shardID, sequence)
-					}
+					err = k.startConsumer(&wg, info, shardID, sequence)
 				}
 				if err != nil {
 					if k.ctx.Err() != nil {

--- a/internal/impl/aws/input_kinesis_efo.go
+++ b/internal/impl/aws/input_kinesis_efo.go
@@ -443,6 +443,9 @@ func (k *kinesisReader) efoSubscribeAndProcess(
 			}
 
 			if lost := k.renewLease(ctx, info, shardID, recordBatcher, state, commitCtx, commitCtxClose); lost {
+				// See sendToPipeline: an unsent batch is dropped on lease loss
+				// so the consumer's exit drain cannot block on a full pipeline.
+				*pendingMsg = asyncMessage{}
 				return continuationSeq, false, nil
 			}
 
@@ -519,9 +522,20 @@ func (k *kinesisReader) checkpoint(ctx context.Context, streamID, shardID, seque
 // shard. The original consumer stays blocked here holding a decoded batch, so
 // every such generation leaks memory until the pod is OOM killed.
 //
-// Returns false if the lease was lost or the context was cancelled, in which
-// case pendingMsg is left intact for the caller to deal with. Inspect state to
-// tell the two apart: a lost lease sets awsKinesisConsumerYielding.
+// Returns false if the lease was lost or the context was cancelled. Inspect
+// state to tell the two apart: a lost lease sets awsKinesisConsumerYielding.
+//
+// On lease loss the unsent message is dropped rather than retained. Another
+// client owns the shard now, so there is nothing useful we can do with the
+// batch, and holding it would leave the consumer's exit drain blocked on the
+// same full pipeline that cost us the lease — which in turn would stop the
+// deferred cleanup from yielding the checkpoint or deregistering the shard.
+// Dropping it is safe for delivery guarantees: the yielded checkpoint uses the
+// acked sequence, which by definition sits before anything unsent, so the new
+// owner reprocesses these records.
+//
+// On context cancellation the message is left intact, since the shutdown drain
+// still has a chance to flush it.
 func (k *kinesisReader) sendToPipeline(
 	ctx context.Context,
 	info streamInfo,
@@ -543,6 +557,9 @@ func (k *kinesisReader) sendToPipeline(
 				return false
 			}
 			if lost := k.renewLease(ctx, info, shardID, recordBatcher, state, commitCtx, commitCtxClose); lost {
+				// Drop the batch: the shard is someone else's now, and keeping
+				// it would block this consumer's exit drain indefinitely.
+				*pendingMsg = asyncMessage{}
 				return false
 			}
 

--- a/internal/impl/aws/input_kinesis_efo.go
+++ b/internal/impl/aws/input_kinesis_efo.go
@@ -15,6 +15,11 @@ import (
 	"github.com/warpstreamlabs/bento/public/service"
 )
 
+// errLeaseLost is returned when a shard's lease was claimed by another client
+// while we were waiting for the pipeline. It is not a failure: the consumer
+// yields the shard and exits normally.
+var errLeaseLost = errors.New("shard lease lost to another client")
+
 // kinesisEFOAPI is the subset of kinesis.Client methods used by kinesisEFOManager.
 type kinesisEFOAPI interface {
 	RegisterStreamConsumer(ctx context.Context, params *kinesis.RegisterStreamConsumerInput, optFns ...func(*kinesis.Options)) (*kinesis.RegisterStreamConsumerOutput, error)
@@ -206,6 +211,7 @@ func (k *kinesisReader) runEFOConsumer(wg *sync.WaitGroup, info streamInfo, shar
 			recordBatcher.Close(context.Background(), state == awsKinesisConsumerFinished)
 			boff.Reset()
 			k.boffPool.Put(boff)
+			k.releaseRunningShard(info.id, shardID)
 
 			reason := ""
 			switch state {
@@ -368,7 +374,7 @@ func (k *kinesisReader) efoSubscribeAndProcess(
 		case event, ok := <-eventsChan:
 			if !ok {
 				// Stream ended — flush any remaining records in batcher before returning
-				if err := k.flushBatchedMessage(ctx, recordBatcher, pendingMsg, *commitCtx); err != nil {
+				if err := k.flushBatchedMessage(ctx, info, shardID, recordBatcher, pendingMsg, state, commitCtx, commitCtxClose); err != nil && !errors.Is(err, errLeaseLost) {
 					k.log.Errorf("Failed to flush remaining records on stream end: %v", err)
 				}
 				goto streamEnded
@@ -382,7 +388,10 @@ func (k *kinesisReader) efoSubscribeAndProcess(
 				for _, record := range shardEvent.Records {
 					if recordBatcher.AddRecord(record) {
 						// Batch full — flush to pipeline
-						if err := k.flushBatchedMessage(ctx, recordBatcher, pendingMsg, *commitCtx); err != nil {
+						if err := k.flushBatchedMessage(ctx, info, shardID, recordBatcher, pendingMsg, state, commitCtx, commitCtxClose); err != nil {
+							if errors.Is(err, errLeaseLost) {
+								return continuationSeq, false, nil
+							}
 							k.log.Errorf("Failed to flush message: %v", err)
 							continue
 						}
@@ -391,10 +400,9 @@ func (k *kinesisReader) efoSubscribeAndProcess(
 
 				// Send any pending flushed message to the pipeline
 				if pendingMsg.msg != nil {
-					select {
-					case k.msgChan <- *pendingMsg:
-						*pendingMsg = asyncMessage{}
-					case <-ctx.Done():
+					if !k.sendToPipeline(ctx, info, shardID, recordBatcher, pendingMsg, state, commitCtx, commitCtxClose) {
+						// Either shutting down or the lease was lost; both end
+						// this subscription, and ctx.Err() distinguishes them.
 						return continuationSeq, false, ctx.Err()
 					}
 				}
@@ -421,7 +429,10 @@ func (k *kinesisReader) efoSubscribeAndProcess(
 		case <-nextTimedBatchChan:
 			// Timed batch trigger — flush even without new events
 			nextTimedBatchChan = nil
-			if err := k.flushBatchedMessage(ctx, recordBatcher, pendingMsg, *commitCtx); err != nil {
+			if err := k.flushBatchedMessage(ctx, info, shardID, recordBatcher, pendingMsg, state, commitCtx, commitCtxClose); err != nil {
+				if errors.Is(err, errLeaseLost) {
+					return continuationSeq, false, nil
+				}
 				k.log.Errorf("Failed to flush timed batch: %v", err)
 			}
 
@@ -431,17 +442,8 @@ func (k *kinesisReader) efoSubscribeAndProcess(
 				return continuationSeq, false, ctx.Err()
 			}
 
-			(*commitCtxClose)()
-			*commitCtx, *commitCtxClose = context.WithTimeout(ctx, k.commitPeriod)
-
-			if *state == awsKinesisConsumerConsuming {
-				stillOwned, cpErr := k.checkpointer.Checkpoint(ctx, info.id, shardID, recordBatcher.GetSequence(), false)
-				if cpErr != nil {
-					k.log.Errorf("Failed to store checkpoint for Kinesis stream '%v' shard '%v': %v", info.id, shardID, cpErr)
-				} else if !stillOwned {
-					*state = awsKinesisConsumerYielding
-					return continuationSeq, false, nil
-				}
+			if lost := k.renewLease(ctx, info, shardID, recordBatcher, state, commitCtx, commitCtxClose); lost {
+				return continuationSeq, false, nil
 			}
 
 		case <-ctx.Done():
@@ -461,39 +463,139 @@ streamEnded:
 	return continuationSeq, shardFinished, nil
 }
 
-// flushBatchedMessage flushes the batcher into pendingMsg and sends it to the
-// pipeline via msgChan. Blocks until the pipeline accepts the message
-// (backpressure) or the context is cancelled.
-func (k *kinesisReader) flushBatchedMessage(
+// renewLease performs the periodic checkpoint that doubles as this client's
+// lease renewal, and resets the commit context for the next period. It reports
+// whether the lease was lost, in which case the caller must stop consuming and
+// let the consumer yield the shard.
+//
+// The balancer treats a lease older than 2x lease_period as unclaimed, so this
+// must keep being called even while the consumer is blocked waiting for the
+// pipeline — see sendToPipeline.
+func (k *kinesisReader) renewLease(
 	ctx context.Context,
+	info streamInfo,
+	shardID string,
+	recordBatcher *awsKinesisRecordBatcher,
+	state *awsKinesisConsumerState,
+	commitCtx *context.Context,
+	commitCtxClose *context.CancelFunc,
+) (leaseLost bool) {
+	(*commitCtxClose)()
+	*commitCtx, *commitCtxClose = context.WithTimeout(ctx, k.commitPeriod)
+
+	if *state != awsKinesisConsumerConsuming {
+		return false
+	}
+
+	stillOwned, err := k.checkpoint(ctx, info.id, shardID, recordBatcher.GetSequence())
+	if err != nil {
+		k.log.Errorf("Failed to store checkpoint for Kinesis stream '%v' shard '%v': %v", info.id, shardID, err)
+		return false
+	}
+	if !stillOwned {
+		*state = awsKinesisConsumerYielding
+		return true
+	}
+	return false
+}
+
+// checkpoint stores the periodic (non-final) checkpoint for a shard, reporting
+// whether this client still owns the lease. It is a field-backed indirection so
+// that tests can drive lease renewal without a DynamoDB client.
+func (k *kinesisReader) checkpoint(ctx context.Context, streamID, shardID, sequence string) (bool, error) {
+	if k.checkpointFn != nil {
+		return k.checkpointFn(ctx, streamID, shardID, sequence)
+	}
+	return k.checkpointer.Checkpoint(ctx, streamID, shardID, sequence, false)
+}
+
+// sendToPipeline hands a message to the pipeline, blocking until it is accepted
+// (this is the backpressure that stops us reading from Kinesis) while continuing
+// to renew the shard lease in the background.
+//
+// Renewing while blocked is essential: the lease renewal is a periodic
+// checkpoint, and a consumer that stops renewing for 2x lease_period is treated
+// as dead by the balancer, which then starts a second consumer for the same
+// shard. The original consumer stays blocked here holding a decoded batch, so
+// every such generation leaks memory until the pod is OOM killed.
+//
+// Returns false if the lease was lost or the context was cancelled, in which
+// case pendingMsg is left intact for the caller to deal with. Inspect state to
+// tell the two apart: a lost lease sets awsKinesisConsumerYielding.
+func (k *kinesisReader) sendToPipeline(
+	ctx context.Context,
+	info streamInfo,
+	shardID string,
 	recordBatcher *awsKinesisRecordBatcher,
 	pendingMsg *asyncMessage,
-	commitCtx context.Context,
-) error {
-	// First send any previously flushed message that hasn't been sent yet
-	if pendingMsg.msg != nil {
+	state *awsKinesisConsumerState,
+	commitCtx *context.Context,
+	commitCtxClose *context.CancelFunc,
+) (sent bool) {
+	for {
 		select {
 		case k.msgChan <- *pendingMsg:
 			*pendingMsg = asyncMessage{}
+			return true
+
+		case <-(*commitCtx).Done():
+			if ctx.Err() != nil {
+				return false
+			}
+			if lost := k.renewLease(ctx, info, shardID, recordBatcher, state, commitCtx, commitCtxClose); lost {
+				return false
+			}
+
 		case <-ctx.Done():
-			return ctx.Err()
+			return false
+		}
+	}
+}
+
+// flushBatchedMessage flushes the batcher into pendingMsg and sends it to the
+// pipeline via msgChan. Blocks until the pipeline accepts the message
+// (backpressure) or the context is cancelled, renewing the shard lease while it
+// waits.
+func (k *kinesisReader) flushBatchedMessage(
+	ctx context.Context,
+	info streamInfo,
+	shardID string,
+	recordBatcher *awsKinesisRecordBatcher,
+	pendingMsg *asyncMessage,
+	state *awsKinesisConsumerState,
+	commitCtx *context.Context,
+	commitCtxClose *context.CancelFunc,
+) error {
+	// First send any previously flushed message that hasn't been sent yet
+	if pendingMsg.msg != nil {
+		if !k.sendToPipeline(ctx, info, shardID, recordBatcher, pendingMsg, state, commitCtx, commitCtxClose) {
+			return sendInterruptedErr(ctx, *state)
 		}
 	}
 
 	// Now flush the batcher
 	var err error
-	if *pendingMsg, err = recordBatcher.FlushMessage(commitCtx); err != nil {
+	if *pendingMsg, err = recordBatcher.FlushMessage(*commitCtx); err != nil {
 		return fmt.Errorf("failed to flush message due to checkpoint error: %w", err)
 	}
 
 	if pendingMsg.msg != nil {
-		select {
-		case k.msgChan <- *pendingMsg:
-			*pendingMsg = asyncMessage{}
-		case <-ctx.Done():
-			return ctx.Err()
+		if !k.sendToPipeline(ctx, info, shardID, recordBatcher, pendingMsg, state, commitCtx, commitCtxClose) {
+			return sendInterruptedErr(ctx, *state)
 		}
 	}
 
+	return nil
+}
+
+// sendInterruptedErr explains why sendToPipeline gave up. A cancelled context
+// wins over a lost lease, since shutdown is the more significant event.
+func sendInterruptedErr(ctx context.Context, state awsKinesisConsumerState) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if state == awsKinesisConsumerYielding {
+		return errLeaseLost
+	}
 	return nil
 }

--- a/internal/impl/aws/input_kinesis_efo_lease_test.go
+++ b/internal/impl/aws/input_kinesis_efo_lease_test.go
@@ -1,0 +1,244 @@
+package aws
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+// newLeaseTestReader builds a kinesisReader wired for lease tests: an unbuffered
+// msgChan like production, a short commit period, and a stubbed checkpoint call
+// so no DynamoDB client is needed.
+func newLeaseTestReader(commitPeriod time.Duration, checkpointFn func(ctx context.Context, streamID, shardID, sequence string) (bool, error)) *kinesisReader {
+	mgr := service.MockResources()
+	k := &kinesisReader{
+		log:           mgr.Logger(),
+		mgr:           mgr,
+		batcher:       service.BatchPolicy{Count: 1},
+		conf:          kiConfig{CheckpointLimit: 1024},
+		commitPeriod:  commitPeriod,
+		msgChan:       make(chan asyncMessage),
+		runningShards: map[string]struct{}{},
+		checkpointFn:  checkpointFn,
+	}
+	k.ctx, k.done = context.WithCancel(context.Background())
+	return k
+}
+
+func newLeaseTestBatcher(t *testing.T, k *kinesisReader) *awsKinesisRecordBatcher {
+	t.Helper()
+	batcher, err := k.newAWSKinesisRecordBatcher(streamInfo{id: "test-stream"}, "shard-0", "seq-0")
+	require.NoError(t, err)
+	return batcher
+}
+
+// TestSendToPipelineRenewsLeaseWhileBlocked is the regression test for the OOM
+// loop: while a consumer waits for a busy pipeline it must keep renewing its
+// lease, otherwise the balancer treats the shard as unowned and starts a second
+// consumer for it.
+func TestSendToPipelineRenewsLeaseWhileBlocked(t *testing.T) {
+	const commitPeriod = 20 * time.Millisecond
+
+	var checkpoints atomic.Int32
+	k := newLeaseTestReader(commitPeriod, func(context.Context, string, string, string) (bool, error) {
+		checkpoints.Add(1)
+		return true, nil // lease still ours
+	})
+	defer k.done()
+
+	batcher := newLeaseTestBatcher(t, k)
+	info := streamInfo{id: "test-stream"}
+	state := awsKinesisConsumerConsuming
+	commitCtx, commitCtxClose := context.WithTimeout(k.ctx, commitPeriod)
+	defer commitCtxClose()
+
+	pendingMsg := asyncMessage{msg: service.MessageBatch{service.NewMessage([]byte("hello"))}}
+
+	sendDone := make(chan bool, 1)
+	go func() {
+		sendDone <- k.sendToPipeline(k.ctx, info, "shard-0", batcher, &pendingMsg, &state, &commitCtx, &commitCtxClose)
+	}()
+
+	// Hold the pipeline busy for several commit periods without reading.
+	time.Sleep(6 * commitPeriod)
+
+	renewalsWhileBlocked := checkpoints.Load()
+	assert.GreaterOrEqual(t, renewalsWhileBlocked, int32(3),
+		"lease must be renewed repeatedly while blocked on the pipeline; got %d renewals", renewalsWhileBlocked)
+
+	// The send is still outstanding — backpressure is preserved.
+	select {
+	case <-sendDone:
+		t.Fatal("sendToPipeline returned before the pipeline accepted the message")
+	default:
+	}
+
+	// Now drain, and the send should complete.
+	select {
+	case got := <-k.msgChan:
+		assert.Len(t, got.msg, 1)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the message to reach the pipeline")
+	}
+
+	select {
+	case sent := <-sendDone:
+		assert.True(t, sent, "send should report success once the pipeline accepts")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for sendToPipeline to return")
+	}
+
+	assert.Equal(t, asyncMessage{}, pendingMsg, "pendingMsg should be cleared once sent")
+}
+
+// TestSendToPipelineStopsWhenLeaseLost checks that losing the lease while
+// blocked ends the send rather than waiting forever, and marks the consumer as
+// yielding so the shard is handed over cleanly.
+func TestSendToPipelineStopsWhenLeaseLost(t *testing.T) {
+	const commitPeriod = 20 * time.Millisecond
+
+	k := newLeaseTestReader(commitPeriod, func(context.Context, string, string, string) (bool, error) {
+		return false, nil // someone else owns the lease now
+	})
+	defer k.done()
+
+	batcher := newLeaseTestBatcher(t, k)
+	info := streamInfo{id: "test-stream"}
+	state := awsKinesisConsumerConsuming
+	commitCtx, commitCtxClose := context.WithTimeout(k.ctx, commitPeriod)
+	defer commitCtxClose()
+
+	pendingMsg := asyncMessage{msg: service.MessageBatch{service.NewMessage([]byte("hello"))}}
+
+	sendDone := make(chan bool, 1)
+	go func() {
+		sendDone <- k.sendToPipeline(k.ctx, info, "shard-0", batcher, &pendingMsg, &state, &commitCtx, &commitCtxClose)
+	}()
+
+	// Never read from msgChan: only the lost lease can end the send.
+	select {
+	case sent := <-sendDone:
+		assert.False(t, sent, "send should report failure when the lease is lost")
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendToPipeline did not give up after losing the lease")
+	}
+
+	assert.Equal(t, awsKinesisConsumerYielding, state, "consumer should be marked as yielding")
+	assert.NotNil(t, pendingMsg.msg, "pendingMsg should be left intact for the caller")
+}
+
+// TestSendToPipelineStopsOnShutdown checks the shutdown path still works.
+func TestSendToPipelineStopsOnShutdown(t *testing.T) {
+	const commitPeriod = time.Hour // never fires; shutdown is the only exit
+
+	k := newLeaseTestReader(commitPeriod, func(context.Context, string, string, string) (bool, error) {
+		return true, nil
+	})
+
+	batcher := newLeaseTestBatcher(t, k)
+	info := streamInfo{id: "test-stream"}
+	state := awsKinesisConsumerConsuming
+	commitCtx, commitCtxClose := context.WithTimeout(k.ctx, commitPeriod)
+	defer commitCtxClose()
+
+	pendingMsg := asyncMessage{msg: service.MessageBatch{service.NewMessage([]byte("hello"))}}
+
+	sendDone := make(chan bool, 1)
+	go func() {
+		sendDone <- k.sendToPipeline(k.ctx, info, "shard-0", batcher, &pendingMsg, &state, &commitCtx, &commitCtxClose)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	k.done() // shut down
+
+	select {
+	case sent := <-sendDone:
+		assert.False(t, sent, "send should report failure on shutdown")
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendToPipeline did not return on shutdown")
+	}
+}
+
+// TestRunningShardRegistry covers the bookkeeping the balancer relies on.
+func TestRunningShardRegistry(t *testing.T) {
+	k := newLeaseTestReader(time.Second, nil)
+	defer k.done()
+
+	assert.False(t, k.isShardRunning("stream-a", "shard-0"))
+
+	require.True(t, k.claimRunningShard("stream-a", "shard-0"), "first claim should succeed")
+	assert.True(t, k.isShardRunning("stream-a", "shard-0"))
+
+	assert.False(t, k.claimRunningShard("stream-a", "shard-0"), "second claim for the same shard should fail")
+
+	// Shards are namespaced per stream, and per shard within a stream.
+	assert.True(t, k.claimRunningShard("stream-b", "shard-0"), "same shard ID on another stream is independent")
+	assert.True(t, k.claimRunningShard("stream-a", "shard-1"), "another shard on the same stream is independent")
+
+	k.releaseRunningShard("stream-a", "shard-0")
+	assert.False(t, k.isShardRunning("stream-a", "shard-0"))
+	assert.True(t, k.claimRunningShard("stream-a", "shard-0"), "claim should succeed again after release")
+
+	// The other entries are untouched by that release.
+	assert.True(t, k.isShardRunning("stream-b", "shard-0"))
+	assert.True(t, k.isShardRunning("stream-a", "shard-1"))
+}
+
+// TestRunningShardRegistryConcurrent checks the registry admits exactly one
+// consumer per shard when the balancer races with itself.
+func TestRunningShardRegistryConcurrent(t *testing.T) {
+	k := newLeaseTestReader(time.Second, nil)
+	defer k.done()
+
+	const attempts = 50
+	var granted atomic.Int32
+	var wg sync.WaitGroup
+	for range attempts {
+		wg.Go(func() {
+			if k.claimRunningShard("stream-a", "shard-0") {
+				granted.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), granted.Load(), "exactly one concurrent claim should be granted")
+}
+
+// TestStartConsumerSkipsAlreadyRunningShard is the regression test for the
+// self-stealing balancer: a shard whose lease looks stale but which this client
+// is already consuming must not get a second consumer.
+func TestStartConsumerSkipsAlreadyRunningShard(t *testing.T) {
+	k := newLeaseTestReader(time.Second, nil)
+	defer k.done()
+
+	info := streamInfo{id: "test-stream"}
+	require.True(t, k.claimRunningShard(info.id, "shard-0"), "precondition: shard registered as running")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// startConsumer owns the wait group increment, so this must not block.
+	err := k.startConsumer(&wg, info, "shard-0", "seq-0")
+	require.NoError(t, err, "skipping an already-running shard is not an error")
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("startConsumer did not release the wait group when skipping the shard")
+	}
+
+	assert.True(t, k.isShardRunning(info.id, "shard-0"), "the original consumer's registration must survive")
+}

--- a/internal/impl/aws/input_kinesis_efo_lease_test.go
+++ b/internal/impl/aws/input_kinesis_efo_lease_test.go
@@ -131,7 +131,58 @@ func TestSendToPipelineStopsWhenLeaseLost(t *testing.T) {
 	}
 
 	assert.Equal(t, awsKinesisConsumerYielding, state, "consumer should be marked as yielding")
-	assert.NotNil(t, pendingMsg.msg, "pendingMsg should be left intact for the caller")
+
+	// The batch is dropped rather than retained. Holding it would leave the
+	// consumer's exit drain blocked on the same full pipeline that cost us the
+	// lease, so the goroutine would never exit and its deferred cleanup would
+	// never yield the checkpoint or deregister the shard. Dropping is safe
+	// because the yielded checkpoint uses the acked sequence, which sits before
+	// anything unsent.
+	assert.Nil(t, pendingMsg.msg, "unsent batch should be dropped when the lease is lost")
+}
+
+// TestConsumerExitDrainDoesNotBlockAfterLeaseLoss is the reason the batch is
+// dropped above: it reproduces the exit path a consumer takes after losing its
+// lease, with the pipeline still full, and checks it can finish.
+func TestConsumerExitDrainDoesNotBlockAfterLeaseLoss(t *testing.T) {
+	const commitPeriod = 20 * time.Millisecond
+
+	k := newLeaseTestReader(commitPeriod, func(context.Context, string, string, string) (bool, error) {
+		return false, nil // lease gone
+	})
+	defer k.done()
+
+	batcher := newLeaseTestBatcher(t, k)
+	info := streamInfo{id: "test-stream"}
+	state := awsKinesisConsumerConsuming
+	commitCtx, commitCtxClose := context.WithTimeout(k.ctx, commitPeriod)
+	defer commitCtxClose()
+
+	pendingMsg := asyncMessage{msg: service.MessageBatch{service.NewMessage([]byte("hello"))}}
+
+	// Lose the lease while blocked on a pipeline nobody is draining.
+	require.False(t, k.sendToPipeline(k.ctx, info, "shard-0", batcher, &pendingMsg, &state, &commitCtx, &commitCtxClose))
+	require.Equal(t, awsKinesisConsumerYielding, state)
+
+	// This mirrors the tail drain in runEFOConsumer. With the batch dropped it
+	// is a no-op; if the batch were retained it would block until shutdown and
+	// the consumer's deferred cleanup would never run.
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		if pendingMsg.msg != nil {
+			select {
+			case k.msgChan <- pendingMsg:
+			case <-k.ctx.Done():
+			}
+		}
+	}()
+
+	select {
+	case <-drained:
+	case <-time.After(time.Second):
+		t.Fatal("consumer exit drain blocked after lease loss; the unsent batch was not dropped")
+	}
 }
 
 // TestSendToPipelineStopsOnShutdown checks the shutdown path still works.


### PR DESCRIPTION
## Problem

An `aws_kinesis` input using `enhanced_fan_out` accumulates duplicate shard consumers when the pipeline applies sustained backpressure. Memory grows with every surplus consumer until the process is killed, and because each restart resumes from an older checkpoint the cycle repeats.

We hit this in production on a 64-shard stream: consumer goroutines grew from 120 to **287 for 64 shards** in about four minutes, with 96% of the heap held by decoded `SubscribeToShard` events in the AWS SDK's event-stream reader (5–9 MB per subscription).

Three things combine:

1. **A blocked consumer cannot renew its lease.** The periodic checkpoint that doubles as lease renewal lives in the `case <-(*commitCtx).Done():` branch of `efoSubscribeAndProcess`'s outer `select`. `flushBatchedMessage` blocks on `k.msgChan <- *pendingMsg` with only `ctx.Done()` as an alternative, so while the pipeline is full that branch is unreachable and the lease ages past `2 * lease_period`.

2. **The balancer then claims the shard from itself.** `runBalancedShards` marks any claim older than `leasePeriod*2` as unclaimed regardless of owner, and `Claim` uses `ConditionExpression: "ClientID = :old_client_id"`, which succeeds when the client ID is its own. A second consumer starts for a shard already being consumed.

3. **The original consumer never exits.** Kinesis terminates the older `SubscribeToShard` subscription, but that goroutine is still blocked sending to the pipeline, so it never reads the closed stream and never notices. It keeps its decoded batch alive indefinitely.

The polling consumer does not have this problem: it keeps `<-commitCtx.Done()` and `nextFlushChan <- pendingMsg` as sibling cases of one `select`, so a blocked send can never starve lease renewal. The EFO rewrite in #819 moved the send into a helper whose only other case is context cancellation, which is where that property was lost.

## Fix

**Renew the lease while waiting on the pipeline.** `renewLease` is extracted from the commit branch, and every pipeline send now goes through `sendToPipeline`, which selects on the send, the commit timer, and `ctx` — restoring the invariant the polling path already has. A lease genuinely lost while blocked now ends the subscription and yields the shard (`errLeaseLost`) instead of blocking indefinitely.

**Never start a second consumer for a shard we already run.** `kinesisReader` tracks the shards it has live consumers for; `startConsumer` refuses to start a duplicate and the balancer skips such shards before attempting a claim. Consumers deregister in their existing deferred cleanup, so a genuinely dead consumer's shard is still reclaimable.

**Drop the unsent batch when the lease is lost.** Retaining it left the consumer's exit drain blocked on the same full pipeline that cost the lease: the outer loop stops once the state is yielding, and the tail drain in `runEFOConsumer` then waits on `msgChan` until the whole input shuts down, so the deferred cleanup never yields the checkpoint or deregisters the shard. This is safe for at-least-once delivery because `Yield` checkpoints with `recordBatcher.GetSequence()`, which returns `ackedSequence` and only advances when a batch is acked downstream — the yielded position sits before anything unsent, so the next owner reprocesses those records. Both lease-loss exits are covered: the one inside `sendToPipeline` and the one in the subscribe loop's commit branch, which can also lose the lease holding a flushed-but-unsent batch.

This also fixes a third blocking send I found while working through it — the inline `k.msgChan <- *pendingMsg` in the event-handling case, which had the same defect as the two inside `flushBatchedMessage`.

Behaviour when the pipeline is keeping up is unchanged, and the polling path is untouched.

## Testing

`internal/impl/aws/input_kinesis_efo_lease_test.go` covers lease renewal while blocked on the pipeline, giving up when the lease is genuinely lost, the shutdown path, the running-shard registry including its concurrent case, and the balancer guard.

Each test was verified to fail against the previous behaviour: reverting the renewal reports `got 0 renewals`, reverting the balancer guard starts a second consumer, and reverting the lease-loss drop blocks the exit drain until timeout.

- `go test ./internal/impl/aws/...` passes, including with `-race`
- `golangci-lint run -c .golangci.yml ./internal/impl/aws/...` reports 0 issues
- `gofmt -s` clean, `go vet ./...` clean

To make renewal testable without a DynamoDB client, the periodic checkpoint call goes through a `checkpointFn` field that is nil in production. Happy to swap this for an interface on the checkpointer if you'd prefer — it seemed the smaller change.

## Validation

Deployed the fix on the same 64-shard EFO stream that previously OOMed, at higher load than the run that crashed:

| | Before | After |
|---|---|---|
| Consumer goroutines for 64 shards | 120 → 287, climbing | **64, steady** |
| Container restarts | 7 (OOMKilled) | **0** |
| Peak memory | 6.5 GiB → killed | ~2.5 GiB, released after the run |
| Throughput | collapsed to ~0 | ~1,300 events/s sustained |

One consumer per owned shard, with memory that tracks shard count rather than elapsed time.

One operational note for anyone else running EFO at high shard counts: because all shards now renew on schedule rather than only the unblocked ones, steady-state writes to the DynamoDB lease table go up. Ours went from ~3 to ~13 writes/second on a 64-shard stream — that is one write per shard per `commit_period`, as intended, but it is worth checking the table's provisioned capacity before deploying.