### PR TITLE
update(go): Bump from v1.26.6 to v1.27.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.11.3
+        version: v2.13.2
 
   build-docsite:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 
 - `kafka_franz` output field `broker_write_max_bytes` misconfigured (introduced in version 1.21.0) @jem-davies
 
+### Changed 
+
+ - Updated to Go version 1.27.1 @gregfurman
+
 ## 1.21.0 - 2026-08-21
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/bigquery v1.72.0
 	cloud.google.com/go/bigtable v1.42.0
 	cloud.google.com/go/pubsub v1.50.1
+	cloud.google.com/go/spanner v1.87.0
 	cloud.google.com/go/storage v1.56.0
 	connectrpc.com/connect v1.18.1
 	cuelang.org/go v0.7.1
@@ -30,12 +31,14 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/PaesslerAG/gval v1.2.3
 	github.com/PaesslerAG/jsonpath v0.1.1
+	github.com/andybalholm/brotli v1.2.3
 	github.com/apache/pulsar-client-go v0.21.0
 	github.com/aws/aws-lambda-go v1.46.0
 	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4
 	github.com/aws/aws-sdk-go-v2 v1.47.0
 	github.com/aws/aws-sdk-go-v2/config v1.33.4
 	github.com/aws/aws-sdk-go-v2/credentials v1.20.4
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.12.17
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.6.17
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.4.23
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.41
@@ -46,10 +49,14 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.5
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.88.5
+	github.com/aws/aws-sdk-go-v2/service/rds v1.94.1
+	github.com/aws/aws-sdk-go-v2/service/redshift v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.113.0
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/sns v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.29.7
 	github.com/aws/aws-sdk-go-v2/service/sts v1.50.0
+	github.com/aws/smithy-go v1.28.1
 	github.com/beanstalkd/go-beanstalk v0.2.0
 	github.com/benhoyt/goawk v1.25.0
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
@@ -78,6 +85,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
 	github.com/googleapis/go-sql-spanner v1.7.4
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
@@ -92,6 +100,7 @@ require (
 	github.com/itchyny/timefmt-go v0.1.6
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/jhump/protoreflect v1.15.6
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/klauspost/compress v1.20.0
@@ -108,6 +117,7 @@ require (
 	github.com/nats-io/nats.go v1.49.0
 	github.com/nats-io/nkeys v0.4.15
 	github.com/nats-io/stan.go v0.10.4
+	github.com/neo4j/neo4j-go-driver/v5 v5.24.0
 	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/oklog/ulid/v2 v2.1.1
@@ -130,11 +140,14 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/rickb777/period v1.0.7
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/s2-streamstore/s2-sdk-go v0.13.3
 	github.com/segmentio/ksuid v1.0.4
 	github.com/sijms/go-ora/v2 v2.8.22
 	github.com/sirupsen/logrus v1.9.4
+	github.com/slack-go/slack v0.17.3
 	github.com/smira/go-statsd v1.3.4
 	github.com/snowflakedb/gosnowflake/v2 v2.2.0
+	github.com/snowplow/snowplow-golang-analytics-sdk v0.4.1
 	github.com/sourcegraph/conc v0.3.0
 	github.com/stretchr/testify v1.12.1
 	github.com/tetratelabs/wazero v1.6.0
@@ -143,6 +156,7 @@ require (
 	github.com/twmb/franz-go v1.20.7
 	github.com/twmb/franz-go/pkg/kadm v1.16.0
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0
+	github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0
 	github.com/urfave/cli/v2 v2.27.7
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/xdg-go/scram v1.1.2
@@ -177,98 +191,6 @@ require (
 )
 
 require (
-	cloud.google.com/go/pubsub/v2 v2.0.0 // indirect
-	github.com/Azure/go-ntlmssp v0.1.0 // indirect
-	github.com/BurntSushi/toml v1.6.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
-	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
-	github.com/RoaringBitmap/roaring/v2 v2.8.0 // indirect
-	github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e // indirect
-	github.com/apache/arrow-go/v18 v18.8.0 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.4.5 // indirect
-	github.com/aws/aws-sdk-go-v2/service/signin v1.10.0 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/daulet/tokenizers v1.27.0 // indirect
-	github.com/duckdb/duckdb-go-bindings v0.10505.0 // indirect
-	github.com/duckdb/duckdb-go-bindings/lib/darwin-amd64 v0.10505.0 // indirect
-	github.com/duckdb/duckdb-go-bindings/lib/darwin-arm64 v0.10505.0 // indirect
-	github.com/duckdb/duckdb-go-bindings/lib/linux-amd64 v0.10505.0 // indirect
-	github.com/duckdb/duckdb-go-bindings/lib/linux-arm64 v0.10505.0 // indirect
-	github.com/duckdb/duckdb-go-bindings/lib/windows-amd64 v0.10505.0 // indirect
-	github.com/elastic/elastic-transport-go/v8 v8.7.0 // indirect
-	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
-	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
-	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-errors/errors v1.5.1 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
-	github.com/go-openapi/jsonpointer v0.21.0 // indirect
-	github.com/go-openapi/jsonreference v0.20.2 // indirect
-	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/go-zeromq/goczmq/v4 v4.2.2 // indirect
-	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
-	github.com/gomlx/exceptions v0.0.3 // indirect
-	github.com/gomlx/go-huggingface v0.3.5 // indirect
-	github.com/gomlx/go-xla v0.2.2 // indirect
-	github.com/gomlx/gomlx v0.27.3 // indirect
-	github.com/gomlx/onnx-gomlx v0.4.2 // indirect
-	github.com/google/btree v1.1.3 // indirect
-	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
-	github.com/hamba/avro/v2 v2.31.0 // indirect
-	github.com/huandu/xstrings v1.5.0 // indirect
-	github.com/iskorotkov/avro/v2 v2.33.1 // indirect
-	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/knights-analytics/ortgenai v0.3.1 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/sys/user v0.4.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/mschoch/smat v0.2.0 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/parquet-go/bitpack v1.0.0 // indirect
-	github.com/parquet-go/jsonlite v1.5.0 // indirect
-	github.com/spf13/cast v1.7.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/spiffe/go-spiffe/v2 v2.7.0 // indirect
-	github.com/theparanoids/crypki v1.20.9 // indirect
-	github.com/twpayne/go-geom v1.6.1 // indirect
-	github.com/yalue/onnxruntime_go v1.30.1 // indirect
-	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/exp v0.0.0-20260908205506-85c1c2202aba // indirect
-	golang.org/x/image v0.43.0 // indirect
-	golang.org/x/telemetry v0.0.0-20260908163034-4bcc4b2ee518 // indirect
-	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-	k8s.io/api v0.34.2 // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
-	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
-	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
-	rsc.io/binaryregexp v0.2.0 // indirect
-	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
-)
-
-require (
-	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
-	github.com/s2-streamstore/s2-sdk-go v0.13.3
-	github.com/tidwall/btree v1.8.1 // indirect
-)
-
-require (
 	cel.dev/expr v0.25.2 // indirect
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.18.2 // indirect
@@ -277,7 +199,7 @@ require (
 	cloud.google.com/go/iam v1.5.3 // indirect
 	cloud.google.com/go/longrunning v0.8.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
-	cloud.google.com/go/spanner v1.87.0
+	cloud.google.com/go/pubsub/v2 v2.0.0 // indirect
 	cloud.google.com/go/trace v1.11.7 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
@@ -286,21 +208,28 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/Azure/go-ntlmssp v0.1.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.8.0 // indirect
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/ClickHouse/ch-go v0.71.0 // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
-	github.com/andybalholm/brotli v1.2.3
+	github.com/RoaringBitmap/roaring/v2 v2.8.0 // indirect
+	github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e // indirect
+	github.com/apache/arrow-go/v18 v18.8.0 // indirect
 	github.com/apache/arrow/go/v15 v15.0.2 // indirect
 	github.com/ardielle/ardielle-go v1.5.2 // indirect
 	github.com/armon/go-metrics v0.3.4 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.20 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.12.17
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.20.0 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.4.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.3 // indirect
@@ -310,12 +239,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.8.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.14.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.20.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/rds v1.94.1
-	github.com/aws/aws-sdk-go-v2/service/redshift v1.54.1
-	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.40.1
+	github.com/aws/aws-sdk-go-v2/service/signin v1.10.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.38.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.43.0 // indirect
-	github.com/aws/smithy-go v1.28.1
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.12.0 // indirect
@@ -326,6 +252,7 @@ require (
 	github.com/btnguyen2k/consu/reddo v0.1.9 // indirect
 	github.com/btnguyen2k/consu/semita v0.1.5 // indirect
 	github.com/bufbuild/protocompile v0.8.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.1 // indirect
@@ -338,6 +265,7 @@ require (
 	github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/daulet/tokenizers v1.27.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
@@ -345,29 +273,55 @@ require (
 	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/duckdb/duckdb-go-bindings v0.10505.0 // indirect
+	github.com/duckdb/duckdb-go-bindings/lib/darwin-amd64 v0.10505.0 // indirect
+	github.com/duckdb/duckdb-go-bindings/lib/darwin-arm64 v0.10505.0 // indirect
+	github.com/duckdb/duckdb-go-bindings/lib/linux-amd64 v0.10505.0 // indirect
+	github.com/duckdb/duckdb-go-bindings/lib/linux-arm64 v0.10505.0 // indirect
+	github.com/duckdb/duckdb-go-bindings/lib/windows-amd64 v0.10505.0 // indirect
 	github.com/dvsekhvalnov/jose2go v1.11.0 // indirect
 	github.com/eapache/go-resiliency v1.7.0 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
+	github.com/elastic/elastic-transport-go/v8 v8.7.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.15 // indirect
+	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-openapi/jsonpointer v0.21.0 // indirect
+	github.com/go-openapi/jsonreference v0.20.2 // indirect
+	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
+	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/go-zeromq/goczmq/v4 v4.2.2 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
+	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
+	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
+	github.com/gomlx/exceptions v0.0.3 // indirect
+	github.com/gomlx/go-huggingface v0.3.5 // indirect
+	github.com/gomlx/go-xla v0.2.2 // indirect
+	github.com/gomlx/gomlx v0.27.3 // indirect
+	github.com/gomlx/onnx-gomlx v0.4.2 // indirect
+	github.com/google/btree v1.1.3 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
+	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
@@ -375,22 +329,29 @@ require (
 	github.com/govalues/decimal v0.1.32 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
+	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
+	github.com/hamba/avro/v2 v2.31.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/iskorotkov/avro/v2 v2.33.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
 	github.com/jcmturner/gofork v1.7.6 // indirect
-	github.com/jcmturner/gokrb5/v8 v8.4.4
+	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect
+	github.com/knights-analytics/ortgenai v0.3.1 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
@@ -398,18 +359,29 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de // indirect
+	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nats-io/nats-server/v2 v2.12.6 // indirect
 	github.com/nats-io/nats-streaming-server v0.24.6 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
-	github.com/neo4j/neo4j-go-driver/v5 v5.24.0
+	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runc v1.2.8 // indirect
+	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
 	github.com/oschwald/maxminddb-golang v1.11.0 // indirect
+	github.com/parquet-go/bitpack v1.0.0 // indirect
+	github.com/parquet-go/jsonlite v1.5.0 // indirect
 	github.com/paulmach/orb v0.12.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -421,11 +393,14 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
-	github.com/slack-go/slack v0.17.3
-	github.com/snowplow/snowplow-golang-analytics-sdk v0.4.0
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/spf13/cast v1.7.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.7.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
-	github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0
+	github.com/theparanoids/crypki v1.20.9 // indirect
+	github.com/tidwall/btree v1.8.1 // indirect
+	github.com/twpayne/go-geom v1.6.1 // indirect
 	github.com/viant/afs v1.30.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -434,20 +409,29 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
+	github.com/yalue/onnxruntime_go v1.30.1 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.etcd.io/bbolt v1.3.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.5 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.44.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.46.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
+	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
+	golang.org/x/exp v0.0.0-20260908205506-85c1c2202aba // indirect
+	golang.org/x/image v0.43.0 // indirect
 	golang.org/x/mod v0.41.0 // indirect
 	golang.org/x/sys v0.48.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260908163034-4bcc4b2ee518 // indirect
 	golang.org/x/term v0.46.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.50.0 // indirect
@@ -455,18 +439,28 @@ require (
 	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/jcmturner/aescts.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/dnsutils.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/gokrb5.v6 v6.1.1 // indirect
 	gopkg.in/jcmturner/rpc.v1 v1.1.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/api v0.34.2 // indirect
+	k8s.io/klog/v2 v2.140.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
+	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	modernc.org/libc v1.74.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
+	rsc.io/binaryregexp v0.2.0 // indirect
+	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-go 1.26.6
+go 1.27.1
 
 // TODO(gregfurman): Fixes CVE GO-2026-5048 in archived github.com/hamba/avro/v2, required by
 // github.com/warpstreamlabs/bento/public/components/pulsar. Once fixed upstream, this can be dropped.

--- a/go.sum
+++ b/go.sum
@@ -1808,8 +1808,8 @@ github.com/smira/go-statsd v1.3.4 h1:kBYWcLSGT+qC6JVbvfz48kX7mQys32fjDOPrfmsSx2c
 github.com/smira/go-statsd v1.3.4/go.mod h1:RjdsESPgDODtg1VpVVf9MJrEW2Hw0wtRNbmB1CAhu6A=
 github.com/snowflakedb/gosnowflake/v2 v2.2.0 h1:zm0fhoAknhZ+DZ9crMGbIrTxFZhS2yVlPbJ6EqjyWdE=
 github.com/snowflakedb/gosnowflake/v2 v2.2.0/go.mod h1:poUMAfesYFh8piXMqKVPW304tekACzv1cfskxMdpikY=
-github.com/snowplow/snowplow-golang-analytics-sdk v0.4.0 h1:NsHqJlv1gOAwUSkyj/vA/yrGvV9PGAutUAjfShaQ3DA=
-github.com/snowplow/snowplow-golang-analytics-sdk v0.4.0/go.mod h1:NupNFhNOUp42uUo+eQ5chfz/iprPia1LBq3ESBy9jiU=
+github.com/snowplow/snowplow-golang-analytics-sdk v0.4.1 h1:cdIa9zAf6lGGvNYt3P/EZe6fV+Q/ACgSmv3xXANSpF4=
+github.com/snowplow/snowplow-golang-analytics-sdk v0.4.1/go.mod h1:NupNFhNOUp42uUo+eQ5chfz/iprPia1LBq3ESBy9jiU=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/bloblang/mapping/executor.go
+++ b/internal/bloblang/mapping/executor.go
@@ -310,8 +310,7 @@ func (e *errStacks) Error() string {
 }
 
 func formatExecErr(err error, input, stmtInput []rune) error {
-	var u *failedAssignmentErr
-	if errors.As(err, &u) {
+	if u, ok := errors.AsType[*failedAssignmentErr](err); ok {
 		return u
 	}
 
@@ -320,8 +319,7 @@ func formatExecErr(err error, input, stmtInput []rune) error {
 		line, _ = LineAndColOf(input, stmtInput)
 	}
 
-	var e *errStacks
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*errStacks](err); ok {
 		err = e
 	}
 

--- a/internal/bloblang/query/errors.go
+++ b/internal/bloblang/query/errors.go
@@ -50,8 +50,7 @@ func ErrFrom(err error, from Function) error {
 	if _, isTypeMismatchErr := err.(*TypeMismatch); isTypeMismatchErr {
 		return err
 	}
-	var fErr *errFrom
-	if errors.As(err, &fErr) {
+	if _, ok := errors.AsType[*errFrom](err); ok {
 		return err
 	}
 	return &errFrom{from: from, err: err}

--- a/internal/bundle/package.go
+++ b/internal/bundle/package.go
@@ -120,8 +120,7 @@ func wrapComponentErr(mgr NewManagement, typeStr string, err error) error {
 		return nil
 	}
 
-	var existing *componentErr
-	if errors.As(err, &existing) {
+	if _, ok := errors.AsType[*componentErr](err); ok {
 		return err
 	}
 

--- a/internal/bundle/tracing/events.go
+++ b/internal/bundle/tracing/events.go
@@ -114,7 +114,7 @@ func getFlowID(part *message.Part) string {
 
 type control struct {
 	isEnabled  int32
-	eventLimit int64
+	eventLimit atomic.Int64
 }
 
 func (c *control) SetEnabled(e bool) {
@@ -126,7 +126,7 @@ func (c *control) SetEnabled(e bool) {
 }
 
 func (c *control) SetEventLimit(n int64) {
-	atomic.StoreInt64(&c.eventLimit, n)
+	c.eventLimit.Store(n)
 }
 
 func (c *control) IsEnabled() bool {
@@ -134,7 +134,7 @@ func (c *control) IsEnabled() bool {
 }
 
 func (c *control) EventLimit() int64 {
-	return atomic.LoadInt64(&c.eventLimit)
+	return c.eventLimit.Load()
 }
 
 // Summary is a high level description of all traced events.
@@ -230,7 +230,7 @@ func (s *Summary) wProcessorEvents(label string) (e *events, errCounter *uint64)
 type events struct {
 	mut  sync.Mutex
 	m    []NodeEvent
-	mLen int64
+	mLen atomic.Int64
 
 	ctrl *control
 }
@@ -240,7 +240,7 @@ func (e *events) IsEnabled() bool {
 		return false
 	}
 	if limit := e.ctrl.EventLimit(); limit > 0 {
-		return atomic.LoadInt64(&e.mLen) < limit
+		return e.mLen.Load() < limit
 	}
 	return true
 }
@@ -249,7 +249,7 @@ func (e *events) Add(event NodeEvent) {
 	e.mut.Lock()
 	defer e.mut.Unlock()
 
-	atomic.AddInt64(&e.mLen, 1)
+	e.mLen.Add(1)
 	e.m = append(e.m, event)
 }
 
@@ -269,6 +269,6 @@ func (e *events) Flush() []NodeEvent {
 
 	tmpEvents := e.m
 	e.m = nil
-	atomic.StoreInt64(&e.mLen, 0)
+	e.mLen.Store(0)
 	return tmpEvents
 }

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -99,8 +99,7 @@ func lintMDSnippets(path string, spec docs.FieldSpecs, lConf docs.LintConfig) (p
 
 		pConf, err := spec.ParsedConfigFromAny(cNode)
 		if err != nil {
-			var l docs.Lint
-			if errors.As(err, &l) {
+			if l, ok := errors.AsType[docs.Lint](err); ok {
 				l.Line += snippetLine - 1
 				pathLints = append(pathLints, pathLint{
 					source: path,
@@ -115,8 +114,7 @@ func lintMDSnippets(path string, spec docs.FieldSpecs, lConf docs.LintConfig) (p
 		}
 
 		if _, err := config.FromParsed(lConf.DocsProvider, pConf, nil); err != nil {
-			var l docs.Lint
-			if errors.As(err, &l) {
+			if l, ok := errors.AsType[docs.Lint](err); ok {
 				l.Line += snippetLine - 1
 				pathLints = append(pathLints, pathLint{
 					source: path,

--- a/internal/component/input/async_preserver.go
+++ b/internal/component/input/async_preserver.go
@@ -23,7 +23,7 @@ import (
 type AsyncPreserver struct {
 	retryList *autoretry.List[message.Batch]
 
-	inputClosed int32
+	inputClosed atomic.Int32
 	r           Async
 }
 
@@ -88,7 +88,7 @@ func (p *AsyncPreserver) Connect(ctx context.Context) error {
 	// we act like we're still open. Read will be called and we can either
 	// return the pending messages or wait for them.
 	if errors.Is(err, component.ErrTypeClosed) && !p.retryList.Exhausted() {
-		atomic.StoreInt32(&p.inputClosed, 1)
+		p.inputClosed.Store(1)
 		err = nil
 	}
 	return err
@@ -96,7 +96,7 @@ func (p *AsyncPreserver) Connect(ctx context.Context) error {
 
 // ReadBatch attempts to read a new message from the source.
 func (p *AsyncPreserver) ReadBatch(ctx context.Context) (message.Batch, AsyncAckFn, error) {
-	batch, rAckFn, err := p.retryList.Shift(ctx, atomic.LoadInt32(&p.inputClosed) == 0)
+	batch, rAckFn, err := p.retryList.Shift(ctx, p.inputClosed.Load() == 0)
 	if err != nil {
 		if errors.Is(err, autoretry.ErrExhausted) {
 			return nil, nil, component.ErrTypeClosed
@@ -104,7 +104,7 @@ func (p *AsyncPreserver) ReadBatch(ctx context.Context) (message.Batch, AsyncAck
 		if errors.Is(err, component.ErrTypeClosed) {
 			// Mark our input as being closed and trigger an immediate re-read
 			// in order to clear any pending retries.
-			atomic.StoreInt32(&p.inputClosed, 1)
+			p.inputClosed.Store(1)
 			return p.ReadBatch(ctx)
 		}
 		// Otherwise we have an unknown error from our reader that we should

--- a/internal/component/input/async_reader.go
+++ b/internal/component/input/async_reader.go
@@ -127,8 +127,7 @@ func (r *AsyncReader) loop() {
 
 				var nextBoff time.Duration
 
-				var e *component.ErrBackOff
-				if errors.As(err, &e) {
+				if e, ok := errors.AsType[*component.ErrBackOff](err); ok {
 					nextBoff = e.Wait
 				} else {
 					nextBoff = r.connBackoff.NextBackOff()

--- a/internal/component/output/async_writer.go
+++ b/internal/component/output/async_writer.go
@@ -127,8 +127,7 @@ func (w *AsyncWriter) loop() {
 
 				var nextBoff time.Duration
 
-				var ebo *component.ErrBackOff
-				if errors.As(err, &ebo) {
+				if ebo, ok := errors.AsType[*component.ErrBackOff](err); ok {
 					nextBoff = ebo.Wait
 				} else {
 					nextBoff = connBackoff.NextBackOff()

--- a/internal/component/output/async_writer_test.go
+++ b/internal/component/output/async_writer_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 type mockAsyncWriter struct {
-	msgsTotal uint64
+	msgsTotal atomic.Uint64
 	msgsRcvd  sync.Map
 	connChan  chan error
 	writeChan chan error
@@ -34,7 +34,7 @@ func (w *mockAsyncWriter) Connect(ctx context.Context) error {
 }
 
 func (w *mockAsyncWriter) WriteBatch(ctx context.Context, msg message.Batch) error {
-	w.msgsRcvd.Store(atomic.AddUint64(&w.msgsTotal, 1), msg)
+	w.msgsRcvd.Store(w.msgsTotal.Add(1), msg)
 	return <-w.writeChan
 }
 func (w *mockAsyncWriter) Close(context.Context) error { return nil }

--- a/internal/component/output/wrap_with_pipeline.go
+++ b/internal/component/output/wrap_with_pipeline.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"context"
+	"slices"
 
 	"github.com/warpstreamlabs/bento/internal/component"
 	iprocessor "github.com/warpstreamlabs/bento/internal/component/processor"
@@ -36,8 +37,8 @@ func WrapWithPipeline(out Streamed, pipeConstructor iprocessor.PipelineConstruct
 // WrapWithPipelines wraps an output with a variadic number of pipelines.
 func WrapWithPipelines(out Streamed, pipeConstructors ...iprocessor.PipelineConstructorFunc) (Streamed, error) {
 	var err error
-	for i := len(pipeConstructors) - 1; i >= 0; i-- {
-		if out, err = WrapWithPipeline(out, pipeConstructors[i]); err != nil {
+	for _, pipeConstructor := range slices.Backward(pipeConstructors) {
+		if out, err = WrapWithPipeline(out, pipeConstructor); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/config/lint.go
+++ b/internal/config/lint.go
@@ -98,8 +98,7 @@ func ReadFileEnvSwap(store ifs.FS, path string, lookupEnvFn func(name string) (s
 	}
 
 	if configBytes, err = ReplaceEnvVariables(configBytes, lookupEnvFn); err != nil {
-		var errEnvMissing *ErrMissingEnvVars
-		if errors.As(err, &errEnvMissing) {
+		if errEnvMissing, ok := errors.AsType[*ErrMissingEnvVars](err); ok {
 			configBytes = errEnvMissing.BestAttempt
 			lints = append(lints, docs.NewLintError(1, docs.LintMissingEnvVar, err))
 			err = nil
@@ -121,8 +120,7 @@ func ReadBentoConfigEnvVarEnvSwap(config string, lookupEnvFn func(name string) (
 	}
 
 	if configBytes, err = ReplaceEnvVariables(configBytes, lookupEnvFn); err != nil {
-		var errEnvMissing *ErrMissingEnvVars
-		if errors.As(err, &errEnvMissing) {
+		if errEnvMissing, ok := errors.AsType[*ErrMissingEnvVars](err); ok {
 			configBytes = errEnvMissing.BestAttempt
 			lints = append(lints, docs.NewLintError(1, docs.LintMissingEnvVar, err))
 			err = nil

--- a/internal/docs/field.go
+++ b/internal/docs/field.go
@@ -796,8 +796,7 @@ type Lint struct {
 
 // NewLintError returns an error lint.
 func NewLintError(line int, t LintType, err error) Lint {
-	var inner Lint
-	if errors.As(err, &inner) {
+	if inner, ok := errors.AsType[Lint](err); ok {
 		return inner
 	}
 	return Lint{Line: line, Column: 1, Level: LintError, Type: t, What: err.Error()}

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -38,9 +38,9 @@ func clientConfig(t testing.TB, confStr string, args ...any) OldConfig {
 }
 
 func TestHTTPClientRetries(t *testing.T) {
-	var reqCount uint32
+	var reqCount atomic.Uint32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddUint32(&reqCount, 1)
+		reqCount.Add(1)
 		http.Error(w, "test error", http.StatusForbidden)
 	}))
 	defer ts.Close()
@@ -57,7 +57,7 @@ retries: 3
 
 	_, err = h.Send(context.Background(), service.MessageBatch{service.NewMessage([]byte("test"))})
 	assert.Error(t, err)
-	assert.Equal(t, uint32(4), atomic.LoadUint32(&reqCount))
+	assert.Equal(t, uint32(4), reqCount.Load())
 }
 
 func TestHTTPClientBadRequest(t *testing.T) {
@@ -168,11 +168,11 @@ drop_on: [ 400 ]
 }
 
 func TestHTTPClientSuccessfulOn(t *testing.T) {
-	var reqs int32
+	var reqs atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"foo":"bar"}`))
-		atomic.AddInt32(&reqs, 1)
+		reqs.Add(1)
 	}))
 	defer ts.Close()
 
@@ -191,7 +191,7 @@ successful_on: [ 400 ]
 	mBytes, err := resMsg[0].AsBytes()
 	require.NoError(t, err)
 	assert.Equal(t, `{"foo":"bar"}`, string(mBytes))
-	assert.Equal(t, int32(1), atomic.LoadInt32(&reqs))
+	assert.Equal(t, int32(1), reqs.Load())
 }
 
 func TestHTTPClientSendInterpolate(t *testing.T) {

--- a/internal/impl/aws/cache_dynamodb.go
+++ b/internal/impl/aws/cache_dynamodb.go
@@ -383,8 +383,7 @@ func (d *dynamodbCache) add(ctx context.Context, key string, value []byte, ttl *
 	input.ConditionExpression = expr.Condition()
 
 	if _, err = d.client.PutItem(ctx, input); err != nil {
-		var derr *types.ConditionalCheckFailedException
-		if errors.As(err, &derr) {
+		if _, ok := errors.AsType[*types.ConditionalCheckFailedException](err); ok {
 			return service.ErrKeyAlreadyExists
 		}
 		return err

--- a/internal/impl/aws/cache_dynamodb_integration_test.go
+++ b/internal/impl/aws/cache_dynamodb_integration_test.go
@@ -37,8 +37,7 @@ func createTable(ctx context.Context, t testing.TB, dynamoPort, id string) error
 		TableName: &table,
 	})
 	if err != nil {
-		var derr *types.ResourceNotFoundException
-		if !errors.As(err, &derr) {
+		if _, ok := errors.AsType[*types.ResourceNotFoundException](err); !ok {
 			return err
 		}
 	}

--- a/internal/impl/aws/cache_s3.go
+++ b/internal/impl/aws/cache_s3.go
@@ -134,8 +134,7 @@ func (s *s3Cache) Get(ctx context.Context, key string) (body []byte, err error) 
 			Bucket: &s.bucket,
 			Key:    &key,
 		}); err != nil {
-			var aerr *types.NoSuchKey
-			if errors.As(err, &aerr) {
+			if _, ok := errors.AsType[*types.NoSuchKey](err); ok {
 				err = service.ErrKeyNotFound
 				return
 			}
@@ -170,8 +169,7 @@ func (s *s3Cache) Exists(ctx context.Context, key string) (exists bool, err erro
 			Key:    &key,
 		})
 		if err != nil {
-			var aerr *types.NoSuchKey
-			if errors.As(err, &aerr) {
+			if _, ok := errors.AsType[*types.NoSuchKey](err); ok {
 				return false, nil
 			}
 		} else {

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -579,8 +579,7 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 						pullTimer.Reset(boff.NextBackOff())
 						nextPullChan = pullTimer.C
 
-						var aerr *types.ExpiredIteratorException
-						if errors.As(err, &aerr) {
+						if _, ok := errors.AsType[*types.ExpiredIteratorException](err); ok {
 							k.log.Warn("Shard iterator expired, attempting to refresh")
 							newIter, err := k.getIter(info, shardID, recordBatcher.GetSequence())
 							if err != nil {

--- a/internal/impl/aws/input_kinesis_checkpointer.go
+++ b/internal/impl/aws/input_kinesis_checkpointer.go
@@ -142,8 +142,7 @@ func (k *awsKinesisCheckpointer) getCheckpoint(ctx context.Context, streamID, sh
 		},
 	})
 	if err != nil {
-		var aerr *types.ResourceNotFoundException
-		if errors.As(err, &aerr) {
+		if _, ok := errors.AsType[*types.ResourceNotFoundException](err); ok {
 			return nil, nil
 		}
 		return nil, err
@@ -314,8 +313,7 @@ func (k *awsKinesisCheckpointer) Claim(ctx context.Context, streamID, shardID, f
 		},
 	})
 	if err != nil {
-		var aerr *types.ConditionalCheckFailedException
-		if errors.As(err, &aerr) {
+		if _, ok := errors.AsType[*types.ConditionalCheckFailedException](err); ok {
 			return "", ErrLeaseNotAcquired
 		}
 		return "", err
@@ -403,8 +401,7 @@ func (k *awsKinesisCheckpointer) Checkpoint(ctx context.Context, streamID, shard
 		TableName: aws.String(k.conf.Table),
 		Item:      item,
 	}); err != nil {
-		var aerr *types.ConditionalCheckFailedException
-		if errors.As(err, &aerr) {
+		if _, ok := errors.AsType[*types.ConditionalCheckFailedException](err); ok {
 			return false, nil
 		}
 		return false, err

--- a/internal/impl/aws/input_kinesis_efo.go
+++ b/internal/impl/aws/input_kinesis_efo.go
@@ -73,8 +73,7 @@ func (m *kinesisEFOManager) ensureConsumerRegistered(ctx context.Context) (strin
 
 	output, err := m.svc.RegisterStreamConsumer(ctx, registerInput)
 	if err != nil {
-		var resourceInUse *types.ResourceInUseException
-		if errors.As(err, &resourceInUse) {
+		if _, ok := errors.AsType[*types.ResourceInUseException](err); ok {
 			m.log.Debugf("Consumer %s already exists, describing to get ARN", m.consumerName)
 			return m.describeAndWaitForActive(ctx)
 		}

--- a/internal/impl/aws/metrics_cloudwatch.go
+++ b/internal/impl/aws/metrics_cloudwatch.go
@@ -327,12 +327,10 @@ func (c *cwMetrics) NewCounterCtor(name string, labelKeys ...string) service.Met
 	}
 	return func(labelValues ...string) service.MetricsExporterCounter {
 		return (&cloudWatchCounterVec{
-			cloudWatchStatVec: cloudWatchStatVec{
-				root:       c,
-				name:       name,
-				unit:       types.StandardUnitCount,
-				labelNames: labelKeys,
-			},
+			root:       c,
+			name:       name,
+			unit:       types.StandardUnitCount,
+			labelNames: labelKeys,
 		}).With(labelValues...)
 	}
 }
@@ -350,12 +348,10 @@ func (c *cwMetrics) NewTimerCtor(name string, labelKeys ...string) service.Metri
 	}
 	return func(labelValues ...string) service.MetricsExporterTimer {
 		return (&cloudWatchTimerVec{
-			cloudWatchStatVec: cloudWatchStatVec{
-				root:       c,
-				name:       name,
-				unit:       types.StandardUnitMicroseconds,
-				labelNames: labelKeys,
-			},
+			root:       c,
+			name:       name,
+			unit:       types.StandardUnitMicroseconds,
+			labelNames: labelKeys,
 		}).With(labelValues...)
 	}
 }
@@ -373,12 +369,10 @@ func (c *cwMetrics) NewGaugeCtor(name string, labelKeys ...string) service.Metri
 	}
 	return func(labelValues ...string) service.MetricsExporterGauge {
 		return (&cloudWatchGaugeVec{
-			cloudWatchStatVec: cloudWatchStatVec{
-				root:       c,
-				name:       name,
-				unit:       types.StandardUnitNone,
-				labelNames: labelKeys,
-			},
+			root:       c,
+			name:       name,
+			unit:       types.StandardUnitNone,
+			labelNames: labelKeys,
 		}).With(labelValues...)
 	}
 }

--- a/internal/impl/aws/output_dynamodb_integration_test.go
+++ b/internal/impl/aws/output_dynamodb_integration_test.go
@@ -187,8 +187,7 @@ func createMusicTable(ctx context.Context, t testing.TB, dynamoPort string) erro
 		TableName: &tableName,
 	})
 	if err != nil {
-		var derr *types.ResourceNotFoundException
-		if !errors.As(err, &derr) {
+		if _, ok := errors.AsType[*types.ResourceNotFoundException](err); !ok {
 			return err
 		}
 	}

--- a/internal/impl/azure/input_table_storage.go
+++ b/internal/impl/azure/input_table_storage.go
@@ -103,7 +103,7 @@ func init() {
 type azureTableStorage struct {
 	conf  tsiConfig
 	pager *runtime.Pager[aztables.ListEntitiesResponse]
-	row   int64
+	row   atomic.Int64
 	log   *service.Logger
 }
 
@@ -159,7 +159,7 @@ func (a *azureTableStorage) ReadBatch(ctx context.Context) (batch service.Messag
 		for _, entity := range resp.Entities {
 			m := service.NewMessage(entity)
 			m.MetaSetMut("table_storage_name", a.conf.TableName)
-			m.MetaSetMut("row_num", atomic.AddInt64(&a.row, 1))
+			m.MetaSetMut("row_num", a.row.Add(1))
 			batch = append(batch, m)
 		}
 		return batch, func(_ context.Context, res error) error {

--- a/internal/impl/cockroachdb/input_changefeed.go
+++ b/internal/impl/cockroachdb/input_changefeed.go
@@ -257,7 +257,7 @@ func (c *crdbChangefeedInput) Read(ctx context.Context) (*service.Message, servi
 		return nil, nil, service.ErrNotConnected
 	}
 
-	result := crdbChangefeedResult{}
+	var result crdbChangefeedResult
 	select {
 	case <-ctx.Done():
 		return nil, nil, ctx.Err()

--- a/internal/impl/couchbase/cache_test.go
+++ b/internal/impl/couchbase/cache_test.go
@@ -77,11 +77,9 @@ func createBucket(ctx context.Context, port, bucket string) error {
 	}
 
 	err = cluster.Buckets().CreateBucket(gocb.CreateBucketSettings{
-		BucketSettings: gocb.BucketSettings{
-			Name:       bucket,
-			RAMQuotaMB: 100, // smallest value and allow max 10 running bucket with cluster-ramsize 1024 from setup script
-			BucketType: gocb.CouchbaseBucketType,
-		},
+		Name:       bucket,
+		RAMQuotaMB: 100, // smallest value and allow max 10 running bucket with cluster-ramsize 1024 from setup script
+		BucketType: gocb.CouchbaseBucketType,
 	}, nil)
 	if err != nil {
 		return err

--- a/internal/impl/discord/input.go
+++ b/internal/impl/discord/input.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/bwmarrin/discordgo"
@@ -158,10 +159,10 @@ func (r *reader) Connect(ctx context.Context) error {
 				if len(msgs) == 0 {
 					return afterID
 				}
-				for i := len(msgs) - 1; i >= 0; i-- {
-					afterID = msgs[i].ID
+				for _, msg := range slices.Backward(msgs) {
+					afterID = msg.ID
 					select {
-					case msgChan <- msgs[i]:
+					case msgChan <- msg:
 					case <-r.shutSig.SoftStopChan():
 						return ""
 					}

--- a/internal/impl/io/input_http_client_test.go
+++ b/internal/impl/io/input_http_client_test.go
@@ -45,7 +45,7 @@ func TestHTTPClientGET(t *testing.T) {
 		"foo5",
 	}
 
-	var reqCount uint32
+	var reqCount atomic.Uint32
 	index := 0
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -57,7 +57,7 @@ func TestHTTPClientGET(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, reqBytes)
 
-		atomic.AddUint32(&reqCount, 1)
+		reqCount.Add(1)
 		_, _ = w.Write([]byte(inputs[index%len(inputs)]))
 		index++
 	}))
@@ -96,7 +96,7 @@ http_client:
 	h.TriggerStopConsuming()
 	require.NoError(t, h.WaitForClose(tCtx))
 
-	if exp, act := uint32(len(inputs)), atomic.LoadUint32(&reqCount); exp != act && exp+1 != act {
+	if exp, act := uint32(len(inputs)), reqCount.Load(); exp != act && exp+1 != act {
 		t.Errorf("Wrong count of HTTP attempts: %v != %v", act, exp)
 	}
 }
@@ -276,7 +276,7 @@ func TestHTTPClientPOST(t *testing.T) {
 	tCtx, done := context.WithTimeout(context.Background(), time.Second*5)
 	defer done()
 
-	var reqCount uint32
+	var reqCount atomic.Uint32
 	inputs := []string{
 		"foo1",
 		"foo2",
@@ -301,7 +301,7 @@ func TestHTTPClientPOST(t *testing.T) {
 			t.Errorf("Wrong post body: %v != %v", act, exp)
 		}
 
-		atomic.AddUint32(&reqCount, 1)
+		reqCount.Add(1)
 		_, _ = w.Write([]byte(inputs[index%len(inputs)]))
 		index++
 	}))
@@ -342,7 +342,7 @@ http_client:
 	h.TriggerStopConsuming()
 	require.NoError(t, h.WaitForClose(tCtx))
 
-	if exp, act := uint32(len(inputs)), atomic.LoadUint32(&reqCount); exp != act && exp+1 != act {
+	if exp, act := uint32(len(inputs)), reqCount.Load(); exp != act && exp+1 != act {
 		t.Errorf("Wrong count of HTTP attempts: %v != %v", act, exp)
 	}
 }
@@ -351,12 +351,12 @@ func TestHTTPClientGETMultipart(t *testing.T) {
 	tCtx, done := context.WithTimeout(context.Background(), time.Second*5)
 	defer done()
 
-	var reqCount uint32
+	var reqCount atomic.Uint32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if exp, act := "GET", r.Method; exp != act {
 			t.Errorf("Wrong method: %v != %v", act, exp)
 		}
-		atomic.AddUint32(&reqCount, 1)
+		reqCount.Add(1)
 
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)
@@ -420,7 +420,7 @@ http_client:
 	h.TriggerStopConsuming()
 	require.NoError(t, h.WaitForClose(tCtx))
 
-	if exp, act := uint32(1), atomic.LoadUint32(&reqCount); exp != act && exp+1 != act {
+	if exp, act := uint32(1), reqCount.Load(); exp != act && exp+1 != act {
 		t.Errorf("Wrong count of HTTP attempts: %v != %v", act, exp)
 	}
 }

--- a/internal/impl/io/output_dynamic_fan_out.go
+++ b/internal/impl/io/output_dynamic_fan_out.go
@@ -156,12 +156,12 @@ func (d *dynamicFanOutOutputBroker) loop() {
 	apiWG := sync.WaitGroup{}
 
 	ackInterruptChan := make(chan struct{})
-	var ackPending int64
+	var ackPending atomic.Int64
 
 	defer func() {
 		// Wait for pending acks to be resolved, or forceful termination
 	ackWaitLoop:
-		for atomic.LoadInt64(&ackPending) > 0 {
+		for ackPending.Load() > 0 {
 			select {
 			case <-ackInterruptChan:
 			case <-time.After(time.Millisecond * 100):
@@ -253,7 +253,7 @@ func (d *dynamicFanOutOutputBroker) loop() {
 			d.outputsMut.RLock()
 		}
 
-		_ = atomic.AddInt64(&ackPending, 1)
+		_ = ackPending.Add(1)
 		pendingResponses := int64(len(d.outputs))
 
 	outputsLoop:
@@ -263,7 +263,7 @@ func (d *dynamicFanOutOutputBroker) loop() {
 				if atomic.AddInt64(&pendingResponses, -1) == 0 || err != nil {
 					atomic.StoreInt64(&pendingResponses, 0)
 					ackErr := ts.Ack(ctx, err)
-					_ = atomic.AddInt64(&ackPending, -1)
+					_ = ackPending.Add(-1)
 					select {
 					case ackInterruptChan <- struct{}{}:
 					default:

--- a/internal/impl/io/output_http_client_test.go
+++ b/internal/impl/io/output_http_client_test.go
@@ -195,9 +195,9 @@ func TestHTTPClientRetries(t *testing.T) {
 	ctx, done := context.WithTimeout(context.Background(), time.Second*30)
 	defer done()
 
-	var reqCount uint32
+	var reqCount atomic.Uint32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddUint32(&reqCount, 1)
+		reqCount.Add(1)
 		http.Error(w, "test error", http.StatusForbidden)
 	}))
 	defer ts.Close()
@@ -213,7 +213,7 @@ http_client:
 	require.NoError(t, err)
 
 	require.Error(t, writeBatchToStreamed(ctx, t, message.QuickBatch([][]byte{[]byte("test")}), h))
-	if exp, act := uint32(4), atomic.LoadUint32(&reqCount); exp != act {
+	if exp, act := uint32(4), reqCount.Load(); exp != act {
 		t.Errorf("Wrong count of HTTP attempts: %v != %v", exp, act)
 	}
 

--- a/internal/impl/io/processor_http_test.go
+++ b/internal/impl/io/processor_http_test.go
@@ -28,9 +28,9 @@ func parseYAMLProcConf(t testing.TB, formatStr string, args ...any) (conf proces
 }
 
 func TestHTTPClientRetries(t *testing.T) {
-	var reqCount uint32
+	var reqCount atomic.Uint32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddUint32(&reqCount, 1)
+		reqCount.Add(1)
 		http.Error(w, "test error", http.StatusForbidden)
 	}))
 	defer ts.Close()
@@ -65,7 +65,7 @@ http:
 		t.Errorf("Wrong response code metadata: %v != %v", act, exp)
 	}
 
-	if exp, act := uint32(4), atomic.LoadUint32(&reqCount); exp != act {
+	if exp, act := uint32(4), reqCount.Load(); exp != act {
 		t.Errorf("Wrong count of HTTP attempts: %v != %v", exp, act)
 	}
 }

--- a/internal/impl/kafka/input_sarama_kafka_parts.go
+++ b/internal/impl/kafka/input_sarama_kafka_parts.go
@@ -132,7 +132,7 @@ func (k *kafkaReader) offsetPartitionPutRequest(consumerGroup string) *sarama.Of
 	return req
 }
 
-func (k *kafkaReader) connectExplicitTopics(ctx context.Context, config *sarama.Config) (err error) {
+func (k *kafkaReader) connectExplicitTopics(_ context.Context, config *sarama.Config) (err error) {
 	var coordinator *sarama.Broker
 	var consumer sarama.Consumer
 	var client sarama.Client

--- a/internal/impl/pure/output_broker_fan_out.go
+++ b/internal/impl/pure/output_broker_fan_out.go
@@ -57,12 +57,12 @@ func (o *fanOutOutputBroker) ConnectionStatus() (s component.ConnectionStatuses)
 
 func (o *fanOutOutputBroker) loop() {
 	ackInterruptChan := make(chan struct{})
-	var ackPending int64
+	var ackPending atomic.Int64
 
 	defer func() {
 		// Wait for pending acks to be resolved, or forceful termination
 	ackWaitLoop:
-		for atomic.LoadInt64(&ackPending) > 0 {
+		for ackPending.Load() > 0 {
 			select {
 			case <-ackInterruptChan:
 			case <-time.After(time.Millisecond * 100):
@@ -90,7 +90,7 @@ func (o *fanOutOutputBroker) loop() {
 			return
 		}
 
-		_ = atomic.AddInt64(&ackPending, 1)
+		_ = ackPending.Add(1)
 		pendingResponses := int64(len(o.outputTSChans))
 		for target := range o.outputTSChans {
 			msgCopy, i := ts.Payload.ShallowCopy(), target
@@ -99,7 +99,7 @@ func (o *fanOutOutputBroker) loop() {
 				if atomic.AddInt64(&pendingResponses, -1) == 0 || err != nil {
 					atomic.StoreInt64(&pendingResponses, 0)
 					ackErr := ts.Ack(ctx, err)
-					_ = atomic.AddInt64(&ackPending, -1)
+					_ = ackPending.Add(-1)
 					select {
 					case ackInterruptChan <- struct{}{}:
 					default:

--- a/internal/impl/pure/output_broker_fan_out_sequential.go
+++ b/internal/impl/pure/output_broker_fan_out_sequential.go
@@ -58,11 +58,11 @@ func (o *fanOutSequentialOutputBroker) ConnectionStatus() (s component.Connectio
 
 func (o *fanOutSequentialOutputBroker) loop() {
 	ackInterruptChan := make(chan struct{})
-	var ackPending int64
+	var ackPending atomic.Int64
 
 	defer func() {
 		// Wait for pending acks to be resolved, or forceful termination
-		for atomic.LoadInt64(&ackPending) > 0 {
+		for ackPending.Load() > 0 {
 			select {
 			case <-ackInterruptChan:
 			case <-time.After(time.Millisecond * 100):
@@ -89,7 +89,7 @@ func (o *fanOutSequentialOutputBroker) loop() {
 			return
 		}
 
-		_ = atomic.AddInt64(&ackPending, 1)
+		_ = ackPending.Add(1)
 
 		i := 0
 		var ackFn func(ctx context.Context, err error) error
@@ -97,7 +97,7 @@ func (o *fanOutSequentialOutputBroker) loop() {
 			i++
 			if err != nil || len(o.outputTSChans) <= i {
 				ackErr := ts.Ack(ctx, err)
-				_ = atomic.AddInt64(&ackPending, -1)
+				_ = ackPending.Add(-1)
 				select {
 				case ackInterruptChan <- struct{}{}:
 				default:

--- a/internal/impl/pure/output_reject_errored.go
+++ b/internal/impl/pure/output_reject_errored.go
@@ -237,8 +237,7 @@ func (t *rejectErroredBroker) loop() {
 				return tran.Ack(ctx, batchErr)
 			}
 
-			var tmpBatchErr *batch.Error
-			if errors.As(err, &tmpBatchErr) {
+			if tmpBatchErr, ok := errors.AsType[*batch.Error](err); ok {
 				tmpBatchErr.WalkPartsBySource(sortGroup, sortedBatch, func(i int, p *message.Part, err error) bool {
 					if err != nil {
 						batchErr.Failed(i, err)

--- a/internal/impl/pure/output_retry.go
+++ b/internal/impl/pure/output_retry.go
@@ -131,12 +131,12 @@ func (r *indefiniteRetry) loop() {
 	defer cnDone()
 
 	errInterruptChan := make(chan struct{})
-	var errLooped int64
+	var errLooped atomic.Int64
 
 	for !r.shutSig.IsSoftStopSignalled() {
 		// Do not consume another message while pending messages are being
 		// reattempted.
-		for atomic.LoadInt64(&errLooped) > 0 {
+		for errLooped.Load() > 0 {
 			select {
 			case <-errInterruptChan:
 			case <-time.After(time.Millisecond * 100):
@@ -173,7 +173,7 @@ func (r *indefiniteRetry) loop() {
 			defer func() {
 				wg.Done()
 				if inErrLoop {
-					atomic.AddInt64(&errLooped, -1)
+					errLooped.Add(-1)
 
 					// We're exiting our error loop, so (attempt to) interrupt the
 					// consumer.
@@ -195,7 +195,7 @@ func (r *indefiniteRetry) loop() {
 				if res != nil {
 					if !inErrLoop {
 						inErrLoop = true
-						atomic.AddInt64(&errLooped, 1)
+						errLooped.Add(1)
 					}
 
 					if backOff == nil {

--- a/internal/impl/pure/output_switch.go
+++ b/internal/impl/pure/output_switch.go
@@ -350,8 +350,7 @@ func (o *switchOutput) dispatchToTargets(
 		select {
 		case o.outputTSChans[i] <- message.NewTransactionFunc(parts, func(ctx context.Context, err error) error {
 			if err != nil {
-				var bErr *batch.Error
-				if errors.As(err, &bErr) {
+				if bErr, ok := errors.AsType[*batch.Error](err); ok {
 					bErr.WalkPartsBySource(group, sourceMessage, func(i int, p *message.Part, e error) bool {
 						if e != nil {
 							setErrForPart(p, e)
@@ -378,12 +377,12 @@ func (o *switchOutput) dispatchToTargets(
 
 func (o *switchOutput) loop() {
 	ackInterruptChan := make(chan struct{})
-	var ackPending int64
+	var ackPending atomic.Int64
 
 	defer func() {
 		// Wait for pending acks to be resolved, or forceful termination
 	ackWaitLoop:
-		for atomic.LoadInt64(&ackPending) > 0 {
+		for ackPending.Load() > 0 {
 			select {
 			case <-ackInterruptChan:
 			case <-time.After(time.Millisecond * 100):
@@ -454,10 +453,10 @@ func (o *switchOutput) loop() {
 			continue
 		}
 
-		_ = atomic.AddInt64(&ackPending, 1)
+		_ = ackPending.Add(1)
 		o.dispatchToTargets(group, trackedMsg, outputTargets, func(ctx context.Context, err error) error {
 			ackErr := ts.Ack(ctx, err)
-			_ = atomic.AddInt64(&ackPending, -1)
+			_ = ackPending.Add(-1)
 			select {
 			case ackInterruptChan <- struct{}{}:
 			default:

--- a/internal/impl/pure/processor_parallel_test.go
+++ b/internal/impl/pure/processor_parallel_test.go
@@ -125,14 +125,14 @@ parallel:
 }
 
 func TestParallelCapped(t *testing.T) {
-	var reqs int64
+	var reqs atomic.Int64
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if req := atomic.AddInt64(&reqs, 1); req > 5 {
+		if req := reqs.Add(1); req > 5 {
 			t.Errorf("Beyond parallelism cap: %v", req)
 		}
 		<-time.After(time.Millisecond * 10)
 		_, _ = w.Write([]byte("foobar"))
-		atomic.AddInt64(&reqs, -1)
+		reqs.Add(-1)
 	}))
 	defer ts.Close()
 

--- a/internal/impl/pure/processor_rate_limit_test.go
+++ b/internal/impl/pure/processor_rate_limit_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 func TestRateLimitBasic(t *testing.T) {
-	var hits int32
+	var hits atomic.Int32
 	rlFn := func(context.Context) (time.Duration, error) {
-		atomic.AddInt32(&hits, 1)
+		hits.Add(1)
 		return 0, nil
 	}
 
@@ -58,7 +58,7 @@ rate_limit:
 		t.Errorf("Wrong result messages: %s != %s", act, exp)
 	}
 
-	if exp, act := int32(3), atomic.LoadInt32(&hits); exp != act {
+	if exp, act := int32(3), hits.Load(); exp != act {
 		t.Errorf("Wrong count of rate limit hits: %v != %v", act, exp)
 	}
 }

--- a/internal/impl/sql/conn_fields.go
+++ b/internal/impl/sql/conn_fields.go
@@ -403,6 +403,11 @@ func sqlOpenWithReworks(ctx context.Context, logger *service.Logger, driver, dsn
 	return db, nil
 }
 
+type pgErr interface {
+	error
+	SQLState() string
+}
+
 // isAuthError detects authentication failures so the connection can be
 // re-established with fresh credentials. Only postgres and mysql are handled
 // because they are the only drivers that support IAM token rotation;
@@ -417,7 +422,7 @@ func isAuthError(driver string, err error) bool {
 		// pq.Error has a SQLState() method that returns the PostgreSQL error code.
 		// SQLSTATE class 28 = Invalid Authorization Specification
 		// (e.g. 28P01 for PAM/password auth failure).
-		if stateErr, ok := errors.AsType[interface{ SQLState() string }](err); ok {
+		if stateErr, ok := errors.AsType[pgErr](err); ok {
 			return strings.HasPrefix(stateErr.SQLState(), "28")
 		}
 	case "mysql":

--- a/internal/impl/sql/conn_fields.go
+++ b/internal/impl/sql/conn_fields.go
@@ -417,8 +417,7 @@ func isAuthError(driver string, err error) bool {
 		// pq.Error has a SQLState() method that returns the PostgreSQL error code.
 		// SQLSTATE class 28 = Invalid Authorization Specification
 		// (e.g. 28P01 for PAM/password auth failure).
-		var stateErr interface{ SQLState() string }
-		if errors.As(err, &stateErr) {
+		if stateErr, ok := errors.AsType[interface{ SQLState() string }](err); ok {
 			return strings.HasPrefix(stateErr.SQLState(), "28")
 		}
 	case "mysql":

--- a/internal/old/util/throttle/type.go
+++ b/internal/old/util/throttle/type.go
@@ -12,7 +12,7 @@ import (
 // fails to reach its destination.
 type Type struct {
 	// consecutiveRetries is the live count of consecutive retries.
-	consecutiveRetries int64
+	consecutiveRetries atomic.Int64
 
 	// throttlePeriod is the current throttle period, by default this is set to
 	// the baseThrottlePeriod.
@@ -98,7 +98,7 @@ func (t *Type) Retry() bool {
 // retry may be attempted (returning true) or that the close channel has closed
 // (returning false), or that the context was cancelled (false).
 func (t *Type) RetryWithContext(ctx context.Context) bool {
-	if rets := atomic.AddInt64(&t.consecutiveRetries, 1); rets <= t.unthrottledRetries {
+	if rets := t.consecutiveRetries.Add(1); rets <= t.unthrottledRetries {
 		return true
 	}
 	select {
@@ -120,7 +120,7 @@ func (t *Type) ExponentialRetry() bool {
 // ExponentialRetryWithContext is the same as RetryWithContext except also sets
 // the throttle period to exponentially increase after each consecutive retry.
 func (t *Type) ExponentialRetryWithContext(ctx context.Context) bool {
-	if atomic.LoadInt64(&t.consecutiveRetries) > t.unthrottledRetries {
+	if t.consecutiveRetries.Load() > t.unthrottledRetries {
 		if throtPrd := atomic.LoadInt64(&t.throttlePeriod); throtPrd < t.maxExponentialPeriod {
 			throtPrd *= 2
 			if throtPrd > t.maxExponentialPeriod {
@@ -135,7 +135,7 @@ func (t *Type) ExponentialRetryWithContext(ctx context.Context) bool {
 // Reset clears the count of consecutive retries and resets the exponential
 // backoff.
 func (t *Type) Reset() {
-	atomic.StoreInt64(&t.consecutiveRetries, 0)
+	t.consecutiveRetries.Store(0)
 	atomic.StoreInt64(&t.throttlePeriod, t.baseThrottlePeriod)
 }
 

--- a/internal/serverless/lambda/lambda.go
+++ b/internal/serverless/lambda/lambda.go
@@ -43,8 +43,7 @@ func Run() {
 		if err != nil {
 			// TODO: Make this configurable somehow maybe, along with linting
 			// errors.
-			var errEnvMissing *config.ErrMissingEnvVars
-			if errors.As(err, &errEnvMissing) {
+			if errEnvMissing, ok := errors.AsType[*config.ErrMissingEnvVars](err); ok {
 				confBytes = errEnvMissing.BestAttempt
 			} else {
 				fmt.Fprintf(os.Stderr, "Configuration file read error: %v\n", err)

--- a/internal/stream/manager/type.go
+++ b/internal/stream/manager/type.go
@@ -17,7 +17,7 @@ import (
 
 // StreamStatus tracks a stream along with information regarding its internals.
 type StreamStatus struct {
-	stoppedAfter int64
+	stoppedAfter atomic.Int64
 	config       stream.Config
 	strm         *stream.Type
 	metrics      *metrics.Local
@@ -39,7 +39,7 @@ func (s *StreamStatus) setStream(strm *stream.Type) {
 // IsRunning returns a boolean indicating whether the stream is currently
 // running.
 func (s *StreamStatus) IsRunning() bool {
-	return atomic.LoadInt64(&s.stoppedAfter) == 0
+	return s.stoppedAfter.Load() == 0
 }
 
 // IsReady returns a boolean indicating whether the stream is connected at both
@@ -50,7 +50,7 @@ func (s *StreamStatus) IsReady() bool {
 
 // Uptime returns a time.Duration indicating the current uptime of the stream.
 func (s *StreamStatus) Uptime() time.Duration {
-	if stoppedAfter := atomic.LoadInt64(&s.stoppedAfter); stoppedAfter > 0 {
+	if stoppedAfter := s.stoppedAfter.Load(); stoppedAfter > 0 {
 		return time.Duration(stoppedAfter)
 	}
 	return time.Since(s.createdAt)
@@ -68,7 +68,7 @@ func (s *StreamStatus) Metrics() *metrics.Local {
 
 // setClosed sets the flag indicating that the stream is closed.
 func (s *StreamStatus) setClosed() {
-	atomic.SwapInt64(&s.stoppedAfter, int64(time.Since(s.createdAt)))
+	s.stoppedAfter.Swap(int64(time.Since(s.createdAt)))
 }
 
 //------------------------------------------------------------------------------

--- a/internal/template/config.go
+++ b/internal/template/config.go
@@ -109,8 +109,7 @@ func (c Config) compile() (*compiled, error) {
 	}
 	mapping, err := bloblang.GlobalEnvironment().NewMapping(c.Mapping)
 	if err != nil {
-		var perr *parser.Error
-		if errors.As(err, &perr) {
+		if perr, ok := errors.AsType[*parser.Error](err); ok {
 			return nil, fmt.Errorf("parse mapping: %v", perr.ErrorAtPositionStructured("", []rune(c.Mapping)))
 		}
 		return nil, fmt.Errorf("parse mapping: %w", err)

--- a/internal/transaction/tracked.go
+++ b/internal/transaction/tracked.go
@@ -71,8 +71,7 @@ func (t *Tracked) getResFromGroup(walkable *batch.Error) error {
 
 func (t *Tracked) resFromError(err error) error {
 	if err != nil {
-		var walkable *batch.Error
-		if errors.As(err, &walkable) {
+		if walkable, ok := errors.AsType[*batch.Error](err); ok {
 			err = t.getResFromGroup(walkable)
 		}
 	}

--- a/public/service/chaos_test.go
+++ b/public/service/chaos_test.go
@@ -21,7 +21,7 @@ type chaosOutput struct {
 	t        *testing.T
 	expected string
 	eRate    float64
-	seen     int64
+	seen     atomic.Int64
 }
 
 func (c *chaosOutput) Connect(ctx context.Context) error {
@@ -33,7 +33,7 @@ func (c *chaosOutput) Write(ctx context.Context, m *service.Message) error {
 	require.NoError(c.t, err)
 	assert.Equal(c.t, c.expected, string(mBytes))
 
-	_ = atomic.AddInt64(&c.seen, 1)
+	_ = c.seen.Add(1)
 
 	// Whether or not we acknowledge is random
 	if f := rand.Float64(); f <= c.eRate {
@@ -43,7 +43,7 @@ func (c *chaosOutput) Write(ctx context.Context, m *service.Message) error {
 }
 
 func (c *chaosOutput) Close(ctx context.Context) error {
-	assert.Greater(c.t, atomic.LoadInt64(&c.seen), int64(0), c.expected)
+	assert.Greater(c.t, c.seen.Load(), int64(0), c.expected)
 	return nil
 }
 

--- a/public/service/errors.go
+++ b/public/service/errors.go
@@ -178,13 +178,11 @@ func publicToInternalErr(err error) error {
 		return nil
 	}
 
-	var e *ErrBackOff
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*ErrBackOff](err); ok {
 		return &component.ErrBackOff{Err: publicToInternalErr(e.Err), Wait: e.Wait}
 	}
 
-	var bErr *BatchError
-	if errors.As(err, &bErr) {
+	if bErr, ok := errors.AsType[*BatchError](err); ok {
 		return bErr.wrapped
 	}
 

--- a/public/service/input_auto_retry.go
+++ b/public/service/input_auto_retry.go
@@ -43,7 +43,7 @@ func AutoRetryNacks(i Input) Input {
 type autoRetryInput struct {
 	retryList   *autoretry.List[*Message]
 	child       Input
-	inputClosed int32
+	inputClosed atomic.Int32
 }
 
 func (i *autoRetryInput) Connect(ctx context.Context) error {
@@ -52,14 +52,14 @@ func (i *autoRetryInput) Connect(ctx context.Context) error {
 	// we act like we're still open. Read will be called and we can either
 	// return the pending messages or wait for them.
 	if errors.Is(err, ErrEndOfInput) && !i.retryList.Exhausted() {
-		atomic.StoreInt32(&i.inputClosed, 1)
+		i.inputClosed.Store(1)
 		err = nil
 	}
 	return err
 }
 
 func (i *autoRetryInput) Read(ctx context.Context) (*Message, AckFunc, error) {
-	msg, rAckFn, err := i.retryList.Shift(ctx, atomic.LoadInt32(&i.inputClosed) == 0)
+	msg, rAckFn, err := i.retryList.Shift(ctx, i.inputClosed.Load() == 0)
 	if err != nil {
 		if errors.Is(err, autoretry.ErrExhausted) {
 			return nil, nil, ErrEndOfInput
@@ -67,7 +67,7 @@ func (i *autoRetryInput) Read(ctx context.Context) (*Message, AckFunc, error) {
 		if errors.Is(err, ErrEndOfInput) {
 			// Mark our input as being closed and trigger an immediate re-read
 			// in order to clear any pending retries.
-			atomic.StoreInt32(&i.inputClosed, 1)
+			i.inputClosed.Store(1)
 			return i.Read(ctx)
 		}
 		// Otherwise we have an unknown error from our reader that we should

--- a/public/service/input_auto_retry_batched.go
+++ b/public/service/input_auto_retry_batched.go
@@ -98,7 +98,7 @@ func AutoRetryNacksBatched(i BatchInput) BatchInput {
 type autoRetryInputBatched struct {
 	retryList   *autoretry.List[MessageBatch]
 	child       BatchInput
-	inputClosed int32
+	inputClosed atomic.Int32
 }
 
 func (i *autoRetryInputBatched) Connect(ctx context.Context) error {
@@ -107,14 +107,14 @@ func (i *autoRetryInputBatched) Connect(ctx context.Context) error {
 	// we act like we're still open. Read will be called and we can either
 	// return the pending messages or wait for them.
 	if errors.Is(err, ErrEndOfInput) && !i.retryList.Exhausted() {
-		atomic.StoreInt32(&i.inputClosed, 1)
+		i.inputClosed.Store(1)
 		err = nil
 	}
 	return err
 }
 
 func (i *autoRetryInputBatched) ReadBatch(ctx context.Context) (MessageBatch, AckFunc, error) {
-	batch, rAckFn, err := i.retryList.Shift(ctx, atomic.LoadInt32(&i.inputClosed) == 0)
+	batch, rAckFn, err := i.retryList.Shift(ctx, i.inputClosed.Load() == 0)
 	if err != nil {
 		if errors.Is(err, autoretry.ErrExhausted) {
 			return nil, nil, ErrEndOfInput
@@ -122,7 +122,7 @@ func (i *autoRetryInputBatched) ReadBatch(ctx context.Context) (MessageBatch, Ac
 		if errors.Is(err, ErrEndOfInput) {
 			// Mark our input as being closed and trigger an immediate re-read
 			// in order to clear any pending retries.
-			atomic.StoreInt32(&i.inputClosed, 1)
+			i.inputClosed.Store(1)
 			return i.ReadBatch(ctx)
 		}
 		// Otherwise we have an unknown error from our reader that we should

--- a/public/service/lints.go
+++ b/public/service/lints.go
@@ -195,8 +195,7 @@ func lintsToErr(lints []docs.Lint) (lintWarns []Lint, err error) {
 }
 
 func convertDocsLintErr(err error) error {
-	var l docs.Lint
-	if errors.As(err, &l) {
+	if l, ok := errors.AsType[docs.Lint](err); ok {
 		return convertDocsLint(l)
 	}
 	return err

--- a/public/service/metrics.go
+++ b/public/service/metrics.go
@@ -194,12 +194,12 @@ func newAirGapMetrics(m MetricsExporter) metrics.Type {
 type airGapGauge struct {
 	// TODO: This is a hack and we don't really use incr/decr internally in our
 	// metrics. Can we ditch it?
-	v         int64
+	v         atomic.Int64
 	airGapped MetricsExporterGauge
 }
 
 func (a *airGapGauge) Incr(by int64) {
-	value := atomic.AddInt64(&a.v, by)
+	value := a.v.Add(by)
 	a.airGapped.Set(value)
 }
 
@@ -208,7 +208,7 @@ func (a *airGapGauge) IncrFloat64(count float64) {
 }
 
 func (a *airGapGauge) SetFloat64(value float64) {
-	atomic.StoreInt64(&a.v, int64(value))
+	a.v.Store(int64(value))
 	if fer, ok := a.airGapped.(interface {
 		SetFloat64(float64)
 	}); ok {
@@ -219,7 +219,7 @@ func (a *airGapGauge) SetFloat64(value float64) {
 }
 
 func (a *airGapGauge) Decr(by int64) {
-	value := atomic.AddInt64(&a.v, -by)
+	value := a.v.Add(-by)
 	a.airGapped.Set(value)
 }
 
@@ -228,7 +228,7 @@ func (a *airGapGauge) DecrFloat64(count float64) {
 }
 
 func (a *airGapGauge) Set(value int64) {
-	atomic.StoreInt64(&a.v, value)
+	a.v.Store(value)
 	a.airGapped.Set(value)
 }
 

--- a/public/service/stream_builder.go
+++ b/public/service/stream_builder.go
@@ -1132,8 +1132,7 @@ func (s *StreamBuilder) getYAMLNode(b []byte) (*yaml.Node, error) {
 	if b, err = config.ReplaceEnvVariables(b, s.envVarLookupFn); err != nil {
 		// TODO: Allow users to specify whether they care about env variables
 		// missing, in which case we error or not based on that.
-		var errEnvMissing *config.ErrMissingEnvVars
-		if errors.As(err, &errEnvMissing) {
+		if errEnvMissing, ok := errors.AsType[*config.ErrMissingEnvVars](err); ok {
 			b = errEnvMissing.BestAttempt
 		} else {
 			return nil, err

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6 AS build
+FROM golang:1.27.1 AS build
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/resources/docker/Dockerfile.cgo
+++ b/resources/docker/Dockerfile.cgo
@@ -1,4 +1,4 @@
-FROM golang:1.26.6 AS build
+FROM golang:1.27.1 AS build
 
 ENV CGO_ENABLED=1
 ENV GOOS=linux


### PR DESCRIPTION
## Context

Now that a patch version for 1.27 has been released, let's update to the latest stable Go version at 1.27.1.

FYI you can run the following on your local to update:

```sh
go env -w GOTOOLCHAIN=go1.27.1+auto
```